### PR TITLE
relax the detection rules to rely on the url rather than the dom elem…

### DIFF
--- a/services/azure-devops-detector.js
+++ b/services/azure-devops-detector.js
@@ -43,28 +43,18 @@ export class AzureDevOpsDetector {
     }
     
     // Check if URL contains pull request path patterns
+    // This is sufficient and more reliable than DOM checks
+    // URL patterns are consistent and available immediately in SPAs
     const isPRPath = url.includes('/pullrequest/') || 
-                    url.includes('/pullRequest/') ||
-                    url.includes('/_git/') && url.includes('/pullrequest/');
-    
-    // Check for Azure DevOps specific elements
-    const hasAzureElements = !!(
-      document.querySelector('[data-testid="pull-request-header"]') ||
-      document.querySelector('.repos-pr-header') ||
-      document.querySelector('.pr-header') ||
-      document.querySelector('[aria-label*="pull request"]') ||
-      document.querySelector('.pr-details-header') ||
-      document.querySelector('.pull-request-header')
-    );
+                    url.includes('/pullRequest/');
     
     dbgLog('Azure DevOps PR detection:', {
       isAzureDevOpsDomain,
       isPRPath,
-      hasAzureElements,
       url: url.substring(0, 100) + '...'
     });
     
-    return isAzureDevOpsDomain && (isPRPath || hasAzureElements);
+    return isAzureDevOpsDomain && isPRPath;
   }
 
   /**


### PR DESCRIPTION
relax azure devops PR pages detection rules to rely on the url rather than the dom elements which might not be consistent

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches Azure DevOps PR detection to URL-based checks only, removing DOM element heuristics and simplifying logging/return logic.
> 
> - **Services**
>   - **`services/azure-devops-detector.js`**:
>     - PR page detection now uses only URL patterns (`/pullrequest/` or `/pullRequest/`).
>     - Removed DOM-based heuristics and related debug fields.
>     - Simplified return condition and debug logging for detection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b838aa5dbb75f83017047127e23fe2f65e3ffe5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->