### PR TITLE
feat/new redirect feedback link to submit extension feedback

### DIFF
--- a/components/integrated-review.js
+++ b/components/integrated-review.js
@@ -58,7 +58,7 @@ async function initReviewPromptComponent() {
     reviewPrompt = new module.ReviewPrompt({
       threshold: 5, // Show prompt after 5 daily reviews
       chromeStoreUrl: 'https://chromewebstore.google.com/detail/thinkreview-ai-code-revie/bpgkhgbchmlmpjjpmlaiejhnnbkdjdjn/reviews',
-      feedbackUrl: 'https://thinkreview.dev/feedback'
+      feedbackUrl: 'https://thinkreview.dev/extension-feedback.html'
     });
     reviewPrompt.init('review-prompt-container');
     window.reviewPrompt = reviewPrompt; // Make accessible globally


### PR DESCRIPTION

We’re introducing a new approach to include query parameters, such as users’ email addresses, when submitting feedback about the extension. Our intention is to make the submission process as effortless as possible for the end user. 