### PR TITLE
Added overflow handling to the .chat-message container

### DIFF
--- a/components/integrated-review.css
+++ b/components/integrated-review.css
@@ -258,6 +258,8 @@
   border-radius: 18px;
   word-wrap: break-word;
   line-height: 1.4;
+  overflow-x: auto;
+  box-sizing: border-box;
 }
 
 .chat-message.user-message {


### PR DESCRIPTION
Add expandable container for message responses . this is important for larger width tables 
<img width="689" height="437" alt="image" src="https://github.com/user-attachments/assets/413906ab-9c59-4068-921e-6e37fa5349dd" />
