### PR TITLE
fix: normalize GitHub PR diff URL so files/commits views work

### DIFF
--- a/content.js
+++ b/content.js
@@ -147,13 +147,26 @@ function isGitLabMRPage() {
  * @returns {string} Patch URL
  */
 function getPatchUrl() {
-  let url = window.location.href;
-  
-  // GitHub uses .diff, GitLab uses .patch
-  const extension = platformDetector && platformDetector.isOnGitHubPRPage() ? '.diff' : '.patch';
+  // GitHub: normalize to canonical PR diff URL so suffix views like /files or /commits still work
+  if (platformDetector && platformDetector.isOnGitHubPRPage()) {
+    const githubDiffUrl = platformDetector.getGitHubPRDiffUrl && platformDetector.getGitHubPRDiffUrl();
+    if (githubDiffUrl) {
+      return githubDiffUrl;
+    }
+    // Fallback: legacy behavior for safety
+    let legacyUrl = window.location.href.replace(/[#?].*$/, '');
+    if (!legacyUrl.endsWith('.diff')) {
+      legacyUrl += '.diff';
+    }
+    return legacyUrl;
+  }
+
+  // GitLab and others: keep existing .patch behavior
+  let url = window.location.href.replace(/[#?].*$/, '');
+  const extension = '.patch';
   
   if (!url.endsWith(extension)) {
-    url = url.replace(/[#?].*$/, '') + extension;
+    url += extension;
   }
   return url;
 }

--- a/services/github-detector.js
+++ b/services/github-detector.js
@@ -376,6 +376,36 @@ export class GitHubDetector {
     
     return hasChanged;
   }
+
+  /**
+   * Get the canonical GitHub PR URL (without suffix segments like /files or /commits)
+   * @returns {string} Canonical PR URL or current URL without query/hash as a fallback
+   */
+  getCanonicalPRUrl() {
+    const { origin, pathname } = window.location;
+    const prInfo = parseGitHubPRFromPath(pathname);
+
+    if (prInfo) {
+      const { owner, repo, prNumber } = prInfo;
+      return `${origin}/${owner}/${repo}/pull/${prNumber}`;
+    }
+
+    // Fallback: strip query/hash but otherwise return current URL
+    return window.location.href.replace(/[#?].*$/, '');
+  }
+
+  /**
+   * Get the canonical GitHub PR diff URL (always .../pull/{number}.diff)
+   * @returns {string} Canonical PR diff URL
+   */
+  getCanonicalPRDiffUrl() {
+    const baseUrl = this.getCanonicalPRUrl();
+    // Ensure we don't end up with .patch.diff, etc.
+    const normalized = baseUrl
+      .replace(/[#?].*$/, '')
+      .replace(/\.(diff|patch)$/, '');
+    return `${normalized}.diff`;
+  }
 }
 
 // Create and export a singleton instance

--- a/services/platform-detector.js
+++ b/services/platform-detector.js
@@ -275,6 +275,17 @@ export class PlatformDetector {
   }
 
   /**
+   * Get canonical GitHub PR diff URL (normalizes suffixes like /files or /commits)
+   * @returns {string|null} Canonical PR diff URL if on a GitHub PR page, otherwise null
+   */
+  getGitHubPRDiffUrl() {
+    if (!this.isGitHubPRPage() && !this.isOnGitHubPRPage()) {
+      return null;
+    }
+    return githubDetector.getCanonicalPRDiffUrl();
+  }
+
+  /**
    * Get current platform
    * @returns {string|null} Current platform ('gitlab', 'github', or 'azure-devops')
    */


### PR DESCRIPTION
## Summary

Normalize GitHub PR URLs before fetching the `.diff` so that the extension works correctly on all PR sub‑pages (main, Files changed, Commits, etc).

## What changed

- Added `getCanonicalPRUrl()` and `getCanonicalPRDiffUrl()` helpers in `github-detector.js` using the existing PR URL parser.
- Exposed `platformDetector.getGitHubPRDiffUrl()` to return a normalized `.../pull/{number}.diff` URL when on a GitHub PR page.
- Updated `getPatchUrl()` in `content.js` to use the canonical GitHub diff URL for GitHub, while keeping the existing `.patch` behavior for GitLab.

## Why

Previously, on GitHub PR sub‑pages like `/pull/46/files` or `/pull/46/commits`, we would try to fetch URLs like `/pull/46/files.diff`, which 404 and surface as `Failed to fetch GitHub diff`. Normalizing to `/pull/46.diff` fixes this while still supporting GitLab’s `.patch` endpoints.

## Testing

- On GitHub:
  - Opened a PR main page and triggered a review → diff fetched successfully.
  - Opened the same PR’s Files changed tab and refreshed → diff still fetched successfully.
  - Opened the same PR’s Commits tab and refreshed → diff still fetched successfully.
- On GitLab:
  - Verified MR review still uses `.patch` and continues to work as before.