### PR TITLE
fix(detector): restore correct project extraction for visualstudio.com URLs

### DIFF
--- a/services/azure-devops-detector.js
+++ b/services/azure-devops-detector.js
@@ -260,25 +260,41 @@ export class AzureDevOpsDetector {
   }
 
   /**
-   * Extract project name from URL
-   * Project is always the first segment after the org: /{org}/{project}/... or /{org}/{project}/{team}/_git/...
-   * Returns null only when path is /{org}/_git/{repo} (no project segment).
-   * @returns {string|null} Project name, or null when URL is /{org}/_git/{repo}
+   * Extract project name from URL.
+   *
+   * URL shapes by host type:
+   *   visualstudio.com  → org is subdomain; path = /{project}/_git/{repo}/...   → pathParts[0] is project
+   *   dev.azure.com     → org is pathParts[0]; path = /{org}/{project}/_git/...  → pathParts[1] is project
+   *   on-prem/custom    → collection is pathParts[0]; path = /{coll}/_git/{repo} or /{coll}/{project}/_git/...
+   *                       → pathParts[1] is project (null when it equals '_git')
+   *
+   * @returns {string|null} Project name, or null when it cannot be determined from the URL
    */
   extractProject() {
     const pathname = window.location.pathname;
+    const hostname = window.location.hostname;
     const pathParts = pathname.split('/').filter(Boolean);
 
-    // Must have at least org and something before or at _git
-    if (pathParts.length < 2) return null;
-
-    // First segment is org/collection; second is project when present
-    // URL shapes: /{org}/_git/{repo} or /{org}/{project}/_git/{repo} or /{org}/{project}/{team}/_git/{repo}
-    const segmentAfterOrg = pathParts[1];
-    if (segmentAfterOrg === '_git') {
+    // visualstudio.com: org is the subdomain, so the path starts with the project
+    if (hostname.includes('visualstudio.com')) {
+      // Path: /{project}/_git/{repo}/...
+      if (pathParts.length >= 1 && pathParts[0] !== '_git') {
+        return pathParts[0];
+      }
       return null;
     }
-    return segmentAfterOrg;
+
+    // dev.azure.com: path is /{org}/{project}/_git/{repo}/...
+    if (hostname.includes('dev.azure.com')) {
+      if (pathParts.length < 2) return null;
+      const segmentAfterOrg = pathParts[1];
+      return segmentAfterOrg === '_git' ? null : segmentAfterOrg;
+    }
+
+    // On-prem / custom domain: path is /{collection}/_git/{repo} or /{collection}/{project}/_git/{repo}
+    if (pathParts.length < 2) return null;
+    const segmentAfterOrg = pathParts[1];
+    return segmentAfterOrg === '_git' ? null : segmentAfterOrg;
   }
 
   /**


### PR DESCRIPTION
## Summary

- **Closes #165**
- Fixes extension breaking on all `*.visualstudio.com` URLs (e.g. `https://thinkreview.visualstudio.com/{project}/_git/{repo}/pullrequest/{id}`)
- Root cause: commit `973bea8` refactored `extractProject()` to assume the path always starts with the org (`/{org}/{project}/_git/...`), but on `visualstudio.com` the **org is the subdomain** — so the path is `/{project}/_git/{repo}`. `pathParts[1]` was always `_git`, causing `null` to be returned and the API to fail with `400 - A project name is required`.

## Root Cause

| Host | Path structure | What `pathParts[0]` is |
|---|---|---|
| `{org}.visualstudio.com` | `/{project}/_git/{repo}` | **project** |
| `dev.azure.com` | `/{org}/{project}/_git/{repo}` | org |
| on-prem/custom | `/{collection}/_git/{repo}` or `/{collection}/{project}/_git/{repo}` | collection |

The previous code treated `pathParts[0]` as the org in all cases and returned `null` when `pathParts[1] === '_git'` — which is always the case on `visualstudio.com`.

## Fix

Made `extractProject()` hostname-aware, matching the existing logic in `extractOrganization()`:
- **`visualstudio.com`** → `pathParts[0]` is the project
- **`dev.azure.com`** → `pathParts[1]` is the project (`pathParts[0]` is the org)
- **on-prem/custom** → unchanged behavior

## Test plan

- [ ] Visit a `*.visualstudio.com` PR URL — extension should load and review correctly
- [ ] Visit a `dev.azure.com` PR URL — no regression
- [ ] Visit an on-prem Azure DevOps PR URL — no regression

Made with [Cursor](https://cursor.com)