### PR TITLE
Fet/Add bitbucket data center support

### DIFF
--- a/background.js
+++ b/background.js
@@ -669,9 +669,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       const isDataCenter = typeof url === 'string' && url.includes('/rest/api/1.0/');
       let token, email;
       if (isDataCenter) {
-        const creds = await chrome.storage.local.get(['bitbucketDataCenterToken', 'bitbucketDataCenterUsername']);
+        const creds = await chrome.storage.local.get(['bitbucketDataCenterToken']);
         token = creds.bitbucketDataCenterToken;
-        email = creds.bitbucketDataCenterUsername;
+        email = null; // Bearer auth — no username needed
       } else {
         const creds = await chrome.storage.local.get(['bitbucketToken', 'bitbucketEmail']);
         token = creds.bitbucketToken;

--- a/background.js
+++ b/background.js
@@ -665,8 +665,19 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === 'FETCH_BITBUCKET_PATCH') {
     const { url } = message;
     (async () => {
-      const { bitbucketToken, bitbucketEmail } = await chrome.storage.local.get(['bitbucketToken', 'bitbucketEmail']);
-      const result = await fetchPatchContent(url, { token: bitbucketToken, email: bitbucketEmail });
+      // Use Data Center credentials when the URL points to a self-hosted REST API endpoint
+      const isDataCenter = typeof url === 'string' && url.includes('/rest/api/1.0/');
+      let token, email;
+      if (isDataCenter) {
+        const creds = await chrome.storage.local.get(['bitbucketDataCenterToken', 'bitbucketDataCenterUsername']);
+        token = creds.bitbucketDataCenterToken;
+        email = creds.bitbucketDataCenterUsername;
+      } else {
+        const creds = await chrome.storage.local.get(['bitbucketToken', 'bitbucketEmail']);
+        token = creds.bitbucketToken;
+        email = creds.bitbucketEmail;
+      }
+      const result = await fetchPatchContent(url, { token, email });
       sendResponse(result);
     })();
     return true; // Keep channel open
@@ -1203,7 +1214,12 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
 // Listen for domain changes
 chrome.storage.onChanged.addListener((changes, namespace) => {
-  if (namespace === 'local' && (changes.gitlabDomains || changes.azureDevOpsDomains || changes.bitbucketAllowed)) {
+  if (namespace === 'local' && (
+    changes.gitlabDomains ||
+    changes.azureDevOpsDomains ||
+    changes.bitbucketAllowed ||
+    changes.bitbucketDataCenterDomains
+  )) {
     dbgLog('Domains changed, updating content scripts');
     updateContentScripts();
   }
@@ -1212,10 +1228,11 @@ chrome.storage.onChanged.addListener((changes, namespace) => {
 async function updateContentScripts() {
   try {
     // Get current domains from storage
-    const result = await chrome.storage.local.get(['gitlabDomains', 'azureDevOpsDomains', 'bitbucketAllowed', 'githubEnterpriseDomains']);
+    const result = await chrome.storage.local.get(['gitlabDomains', 'azureDevOpsDomains', 'bitbucketAllowed', 'githubEnterpriseDomains', 'bitbucketDataCenterDomains']);
     const gitlabDomains = result.gitlabDomains || DEFAULT_DOMAINS;
     const customAzureDevOpsDomains = result.azureDevOpsDomains || [];
     const githubEnterpriseDomains = result.githubEnterpriseDomains || [];
+    const bitbucketDataCenterDomains = result.bitbucketDataCenterDomains || [];
 
     // Built-in Azure DevOps domains (always included)
     const builtInAzureDevOpsDomains = [
@@ -1229,7 +1246,7 @@ async function updateContentScripts() {
       ...githubEnterpriseDomains
     ];
 
-    // Add Bitbucket when user has allowed it and we have permission
+    // Add Bitbucket Cloud when user has allowed it and we have permission
     const bitbucketDomains = [];
     if (result.bitbucketAllowed === true) {
       const hasBitbucket = await chrome.permissions.contains({ origins: ['https://bitbucket.org/*'] });
@@ -1238,9 +1255,16 @@ async function updateContentScripts() {
       }
     }
 
-    const allDomains = [...gitlabDomains, ...builtInAzureDevOpsDomains, ...customAzureDevOpsDomains, ...githubDomains, ...bitbucketDomains];
+    const allDomains = [
+      ...gitlabDomains,
+      ...builtInAzureDevOpsDomains,
+      ...customAzureDevOpsDomains,
+      ...githubDomains,
+      ...bitbucketDomains,
+      ...bitbucketDataCenterDomains
+    ];
     const azureMatchAllDomains = new Set([...builtInAzureDevOpsDomains, ...customAzureDevOpsDomains]);
-    const bitbucketMatchAllDomains = new Set(bitbucketDomains);
+    const bitbucketMatchAllDomains = new Set([...bitbucketDomains, ...bitbucketDataCenterDomains]);
     const githubMatchAllHosts = new Set(
       githubDomains
         .filter(d => typeof d === 'string')
@@ -1322,7 +1346,7 @@ async function updateContentScripts() {
       } else {
         // Simple domain provided (e.g., gitlab.com, github.com, devops.companyname.com)
         originPattern = `https://${domain}/*`;
-        if (azureMatchAllDomains.has(domain) || domain === 'github.com' || domain.endsWith('.github.com') || domain === 'bitbucket.org') {
+        if (azureMatchAllDomains.has(domain) || domain === 'github.com' || domain.endsWith('.github.com') || domain === 'bitbucket.org' || bitbucketMatchAllDomains.has(domain)) {
           matchPattern = `https://${domain}/*`;
         } else {
           // GitLab: match merge request pages only

--- a/components/bitbucket-token-error.js
+++ b/components/bitbucket-token-error.js
@@ -7,8 +7,9 @@ const BITBUCKET_DOCS_URL = 'https://thinkreview.dev/docs/bitbucket-integration';
 /**
  * Shows Bitbucket token configuration error with helpful UI
  * @param {Function} stopEnhancedLoader - Function to stop the enhanced loader if running
+ * @param {string|null} extraInfo - Optional server error message to surface to the user
  */
-export function showBitbucketTokenError(stopEnhancedLoader = null) {
+export function showBitbucketTokenError(stopEnhancedLoader = null, extraInfo = null) {
   if (typeof stopEnhancedLoader === 'function') {
     stopEnhancedLoader();
   }
@@ -30,6 +31,7 @@ export function showBitbucketTokenError(stopEnhancedLoader = null) {
     }
   }
 
+  updateTokenErrorDetails(tokenError, extraInfo);
   tokenError.classList.remove('gl-hidden');
 }
 
@@ -72,6 +74,21 @@ function createTokenErrorElement() {
   description.style.textShadow = '0 1px 2px rgba(0, 0, 0, 0.2)';
   description.textContent = 'Generate a Bitbucket API token for ThinkReview. It takes about 60 seconds.';
   messageContainer.appendChild(description);
+
+  const extraDetails = document.createElement('p');
+  extraDetails.className = 'bitbucket-token-extra';
+  extraDetails.style.display = 'none';
+  extraDetails.style.textAlign = 'left';
+  extraDetails.style.marginBottom = '16px';
+  extraDetails.style.fontSize = '12px';
+  extraDetails.style.color = '#ffb347';
+  extraDetails.style.lineHeight = '1.5';
+  extraDetails.style.background = 'rgba(255, 179, 71, 0.08)';
+  extraDetails.style.border = '1px solid rgba(255, 179, 71, 0.35)';
+  extraDetails.style.borderRadius = '6px';
+  extraDetails.style.padding = '10px 12px';
+  extraDetails.style.wordBreak = 'break-word';
+  messageContainer.appendChild(extraDetails);
 
   tokenError.appendChild(messageContainer);
 
@@ -123,6 +140,26 @@ function createTokenErrorElement() {
 
   tokenError.appendChild(actionContainer);
   return tokenError;
+}
+
+/**
+ * Updates the optional extra details section with the server's error message.
+ * @param {HTMLElement} container - The token error container element
+ * @param {string|null} extraInfo - Raw server message (may be plain text or JSON/HTML)
+ */
+function updateTokenErrorDetails(container, extraInfo) {
+  const extraElement = container.querySelector('.bitbucket-token-extra');
+  if (!extraElement) return;
+
+  if (extraInfo && extraInfo.trim().length > 0) {
+    const trimmed = extraInfo.trim();
+    const displayText = trimmed.length > 400 ? `${trimmed.slice(0, 397)}…` : trimmed;
+    extraElement.textContent = `Server message: ${displayText}`;
+    extraElement.style.display = 'block';
+  } else {
+    extraElement.textContent = '';
+    extraElement.style.display = 'none';
+  }
 }
 
 export function hideBitbucketTokenError() {

--- a/content.js
+++ b/content.js
@@ -86,8 +86,11 @@ async function initializePlatformDetection() {
     platformDetector.init();
 
     // Load custom Azure DevOps domains so on-prem URLs are detected
-    const storage = await chrome.storage.local.get(['azureDevOpsDomains']);
+    const storage = await chrome.storage.local.get(['azureDevOpsDomains', 'bitbucketDataCenterDomains']);
     platformDetector.setAzureDevOpsCustomDomains(storage.azureDevOpsDomains || []);
+
+    // Load custom Bitbucket Data Center domains
+    platformDetector.setBitbucketCustomDomains(storage.bitbucketDataCenterDomains || []);
     
     // Dynamically import Azure DevOps API module for error handling
     const apiModule = await import(chrome.runtime.getURL('services/azure-devops-api.js'));

--- a/content.js
+++ b/content.js
@@ -1264,7 +1264,7 @@ async function fetchAndDisplayCodeReview(forceRegenerate = false, isAutoTriggere
         if (authRequired) {
           try {
             const bitbucketTokenErrorModule = await import(chrome.runtime.getURL('components/bitbucket-token-error.js'));
-            bitbucketTokenErrorModule.showBitbucketTokenError(stopEnhancedLoader);
+            bitbucketTokenErrorModule.showBitbucketTokenError(stopEnhancedLoader, bgResponse?.serverMessage || null);
           } catch (e) {
             dbgWarn('Failed to show Bitbucket token error UI:', e);
             throw new Error('Generate a Bitbucket API token for ThinkReview (takes about 60 seconds): https://thinkreview.dev/docs/bitbucket-integration');

--- a/popup.html
+++ b/popup.html
@@ -259,7 +259,7 @@
             </div>
           </button>
 
-          <!-- Bitbucket -->
+          <!-- Bitbucket Cloud -->
           <button class="platform-card" id="card-bitbucket" data-platform="bitbucket" data-scroll-target="">
             <div class="platform-card-icon platform-card-icon--bitbucket">
               <svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor">
@@ -269,6 +269,19 @@
             <div class="platform-card-info">
               <span class="platform-card-name">Bitbucket Cloud</span>
               <span class="platform-badge platform-badge-setup" id="badge-bitbucket">⚙ Setup needed</span>
+            </div>
+          </button>
+
+          <!-- Bitbucket Data Center (self-hosted) -->
+          <button class="platform-card" id="card-bitbucket-dc" data-platform="bitbucket-dc" data-scroll-target="">
+            <div class="platform-card-icon platform-card-icon--bitbucket">
+              <svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M.778 1.213a.768.768 0 00-.768.892l3.263 19.81c.084.5.515.868 1.022.873H19.95a.772.772 0 00.77-.646l3.27-20.03a.768.768 0 00-.768-.891L.778 1.213zM14.52 15.53H9.522L8.17 8.466h7.561l-1.211 7.064z"/>
+              </svg>
+            </div>
+            <div class="platform-card-info">
+              <span class="platform-card-name">Bitbucket Data Center</span>
+              <span class="platform-badge platform-badge-setup" id="badge-bitbucket-dc">⚙ Setup needed</span>
             </div>
           </button>
         </div>
@@ -718,7 +731,70 @@
             Step by Step Bitbucket Setup Guide
           </a>
         </div>
+
       </div><!-- /platform-view-bitbucket -->
+
+
+      <!-- ---- BITBUCKET DATA CENTER (SELF-HOSTED) ---- -->
+      <div id="platform-view-bitbucket-dc" class="platform-view" style="display:none;">
+        <button class="platform-back-btn" data-back>
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
+          All Platforms
+        </button>
+        <div class="platform-view-header">
+          <div class="platform-view-icon platform-view-icon--bitbucket">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M.778 1.213a.768.768 0 00-.768.892l3.263 19.81c.084.5.515.868 1.022.873H19.95a.772.772 0 00.77-.646l3.27-20.03a.768.768 0 00-.768-.891L.778 1.213zM14.52 15.53H9.522L8.17 8.466h7.561l-1.211 7.064z"/></svg>
+          </div>
+          <h3>Bitbucket Data Center</h3>
+        </div>
+
+        <div class="platform-subsection platform-subsection--required">
+          <div class="subsection-required-badge">Setup required</div>
+          <p class="settings-description">Connect ThinkReview to your self-hosted Bitbucket Data Center instance.</p>
+          <div class="wizard-steps wizard-steps--compact">
+            <div class="wizard-step wizard-step--compact" style="--step-delay:0s">
+              <div class="wizard-step-num">1</div>
+              <span>In Bitbucket, go to your <strong>profile → Manage account → HTTP access tokens</strong> and create one with <em>Repository read</em> and <em>Pull request read</em> permissions</span>
+            </div>
+            <div class="wizard-step wizard-step--compact" style="--step-delay:0.15s">
+              <div class="wizard-step-num">2</div>
+              <span>Enter your Bitbucket <strong>username</strong> and the token below, then click <strong>Save</strong></span>
+            </div>
+            <div class="wizard-step wizard-step--compact" style="--step-delay:0.3s">
+              <div class="wizard-step-num">3</div>
+              <span>Enter your instance domain (e.g. <code>bitbucket.mycompany.com</code>) and click <strong>Add</strong> — approve the browser permission prompt</span>
+            </div>
+            <div class="wizard-step wizard-step--compact" style="--step-delay:0.45s">
+              <div class="wizard-step-num">4</div>
+              <span>Navigate to any pull request on your instance — ThinkReview activates automatically</span>
+            </div>
+          </div>
+
+          <div class="token-input-section" style="margin-top:12px;">
+            <input type="text" id="bitbucket-dc-username-input" placeholder="Bitbucket username" class="token-input" autocomplete="off">
+            <input type="password" id="bitbucket-dc-token-input" class="token-input" placeholder="Password or HTTP access token" aria-label="Bitbucket Data Center token">
+            <button id="save-bitbucket-dc-token-btn" class="save-token-btn">Save</button>
+          </div>
+          <div id="bitbucket-dc-token-status" class="token-status"></div>
+          <p class="help-text">Use your Bitbucket username with an HTTP access token (recommended) or your account password.</p>
+
+          <div class="domain-input-section" style="margin-top:14px;">
+            <input type="text" id="bitbucket-dc-domain-input" placeholder="e.g., bitbucket.mycompany.com" class="domain-input">
+            <button id="add-bitbucket-dc-domain-btn" class="add-domain-btn" disabled>Add</button>
+          </div>
+          <div id="bitbucket-dc-domain-list" class="domain-list"></div>
+        </div>
+
+        <div class="platform-docs-actions">
+          <a id="setup-guide-bitbucket-dc" href="https://thinkreview.dev/docs/bitbucket-data-center" target="_blank" rel="noopener noreferrer" class="platform-docs-btn platform-docs-btn--guide">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path>
+              <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path>
+            </svg>
+            Bitbucket Data Center Setup Guide
+          </a>
+        </div>
+      </div><!-- /platform-view-bitbucket-dc -->
 
     </div><!-- /authenticated-content -->
 

--- a/popup.html
+++ b/popup.html
@@ -758,7 +758,7 @@
             </div>
             <div class="wizard-step wizard-step--compact" style="--step-delay:0.15s">
               <div class="wizard-step-num">2</div>
-              <span>Enter your Bitbucket <strong>username</strong> and the token below, then click <strong>Save</strong></span>
+              <span>Paste the token below and click <strong>Save</strong> — no username needed, the token authenticates on its own</span>
             </div>
             <div class="wizard-step wizard-step--compact" style="--step-delay:0.3s">
               <div class="wizard-step-num">3</div>
@@ -771,12 +771,11 @@
           </div>
 
           <div class="token-input-section" style="margin-top:12px;">
-            <input type="text" id="bitbucket-dc-username-input" placeholder="Bitbucket username" class="token-input" autocomplete="off">
-            <input type="password" id="bitbucket-dc-token-input" class="token-input" placeholder="Password or HTTP access token" aria-label="Bitbucket Data Center token">
+            <input type="password" id="bitbucket-dc-token-input" class="token-input" placeholder="HTTP access token" aria-label="Bitbucket Data Center HTTP access token">
             <button id="save-bitbucket-dc-token-btn" class="save-token-btn">Save</button>
           </div>
           <div id="bitbucket-dc-token-status" class="token-status"></div>
-          <p class="help-text">Use your Bitbucket username with an HTTP access token (recommended) or your account password.</p>
+          <p class="help-text">Uses Bearer token authentication — works even when Basic Authentication is disabled on the instance.</p>
 
           <div class="domain-input-section" style="margin-top:14px;">
             <input type="text" id="bitbucket-dc-domain-input" placeholder="e.g., bitbucket.mycompany.com" class="domain-input">

--- a/popup.js
+++ b/popup.js
@@ -895,29 +895,45 @@ async function loadDomains() {
 
 function renderDomainList(domains) {
   const domainList = document.getElementById('domain-list');
-  
+
+  domainList.replaceChildren();
+
   if (domains.length === 0) {
-    domainList.innerHTML = '<div class="no-domains">No custom domains added</div>';
+    const empty = document.createElement('div');
+    empty.className = 'no-domains';
+    empty.textContent = 'No custom domains added';
+    domainList.appendChild(empty);
     return;
   }
-  
-  domainList.innerHTML = domains.map(domain => {
+
+  domains.forEach(domain => {
     const isDefault = DEFAULT_DOMAINS.includes(domain);
     const displayDomain = formatDomainForDisplay(domain);
-    return `
-      <div class="domain-item ${isDefault ? 'default' : ''}">
-        <span class="domain-name">${displayDomain}</span>
-        <div>
-          ${isDefault ? '<span class="default-label">DEFAULT</span>' : ''}
-          ${!isDefault ? `<button class="remove-domain-btn" data-domain="${domain}">Remove</button>` : ''}
-        </div>
-      </div>
-    `;
-  }).join('');
-  
-  // Add event listeners to remove buttons
-  domainList.querySelectorAll('.remove-domain-btn').forEach(button => {
-    button.addEventListener('click', () => removeDomain(button.dataset.domain));
+
+    const item = document.createElement('div');
+    item.className = 'domain-item' + (isDefault ? ' default' : '');
+
+    const nameSpan = document.createElement('span');
+    nameSpan.className = 'domain-name';
+    nameSpan.textContent = displayDomain;
+
+    const actionsDiv = document.createElement('div');
+    if (isDefault) {
+      const defaultLabel = document.createElement('span');
+      defaultLabel.className = 'default-label';
+      defaultLabel.textContent = 'DEFAULT';
+      actionsDiv.appendChild(defaultLabel);
+    } else {
+      const removeBtn = document.createElement('button');
+      removeBtn.className = 'remove-domain-btn';
+      removeBtn.textContent = 'Remove';
+      removeBtn.addEventListener('click', () => removeDomain(domain));
+      actionsDiv.appendChild(removeBtn);
+    }
+
+    item.appendChild(nameSpan);
+    item.appendChild(actionsDiv);
+    domainList.appendChild(item);
   });
 }
 
@@ -1066,27 +1082,44 @@ function renderGitHubEnterpriseDomainList(domains) {
   const domainList = document.getElementById('github-enterprise-domain-list');
   if (!domainList) return;
 
+  domainList.replaceChildren();
+
   if (!domains || domains.length === 0) {
-    domainList.innerHTML = '<div class="no-domains">No custom domains added</div>';
+    const empty = document.createElement('div');
+    empty.className = 'no-domains';
+    empty.textContent = 'No custom domains added';
+    domainList.appendChild(empty);
     return;
   }
 
-  domainList.innerHTML = domains.map(domain => {
+  domains.forEach(domain => {
     const isDefault = GITHUB_ENTERPRISE_DEFAULT_DOMAINS.includes(domain);
     const displayDomain = formatDomainForDisplay(domain);
-    return `
-      <div class="domain-item ${isDefault ? 'default' : ''}">
-        <span class="domain-name">${displayDomain}</span>
-        <div>
-          ${isDefault ? '<span class="default-label">DEFAULT</span>' : ''}
-          ${!isDefault ? `<button class="remove-domain-btn" data-domain="${domain.replace(/"/g, '&quot;')}">Remove</button>` : ''}
-        </div>
-      </div>
-    `;
-  }).join('');
 
-  domainList.querySelectorAll('.remove-domain-btn').forEach(button => {
-    button.addEventListener('click', () => removeGitHubEnterpriseDomain(button.dataset.domain));
+    const item = document.createElement('div');
+    item.className = 'domain-item' + (isDefault ? ' default' : '');
+
+    const nameSpan = document.createElement('span');
+    nameSpan.className = 'domain-name';
+    nameSpan.textContent = displayDomain;
+
+    const actionsDiv = document.createElement('div');
+    if (isDefault) {
+      const defaultLabel = document.createElement('span');
+      defaultLabel.className = 'default-label';
+      defaultLabel.textContent = 'DEFAULT';
+      actionsDiv.appendChild(defaultLabel);
+    } else {
+      const removeBtn = document.createElement('button');
+      removeBtn.className = 'remove-domain-btn';
+      removeBtn.textContent = 'Remove';
+      removeBtn.addEventListener('click', () => removeGitHubEnterpriseDomain(domain));
+      actionsDiv.appendChild(removeBtn);
+    }
+
+    item.appendChild(nameSpan);
+    item.appendChild(actionsDiv);
+    domainList.appendChild(item);
   });
 }
 
@@ -1296,27 +1329,44 @@ function renderAzureDevOpsDomainList(customDomains) {
     ...(customDomains.filter(d => !AZURE_DEFAULT_DOMAINS.includes(d)))
   ];
 
+  domainList.replaceChildren();
+
   if (displayList.length === 0) {
-    domainList.innerHTML = '<div class="no-domains">No custom domains added</div>';
+    const empty = document.createElement('div');
+    empty.className = 'no-domains';
+    empty.textContent = 'No custom domains added';
+    domainList.appendChild(empty);
     return;
   }
 
-  domainList.innerHTML = displayList.map(domain => {
+  displayList.forEach(domain => {
     const isDefault = AZURE_DEFAULT_DOMAINS.includes(domain);
     const displayDomain = formatDomainForDisplay(domain);
-    return `
-      <div class="domain-item ${isDefault ? 'default' : ''}">
-        <span class="domain-name">${displayDomain}</span>
-        <div>
-          ${isDefault ? '<span class="default-label">DEFAULT</span>' : ''}
-          ${!isDefault ? `<button class="remove-domain-btn" data-domain="${domain.replace(/"/g, '&quot;')}">Remove</button>` : ''}
-        </div>
-      </div>
-    `;
-  }).join('');
 
-  domainList.querySelectorAll('.remove-domain-btn').forEach(button => {
-    button.addEventListener('click', () => removeAzureDevOpsDomain(button.dataset.domain));
+    const item = document.createElement('div');
+    item.className = 'domain-item' + (isDefault ? ' default' : '');
+
+    const nameSpan = document.createElement('span');
+    nameSpan.className = 'domain-name';
+    nameSpan.textContent = displayDomain;
+
+    const actionsDiv = document.createElement('div');
+    if (isDefault) {
+      const defaultLabel = document.createElement('span');
+      defaultLabel.className = 'default-label';
+      defaultLabel.textContent = 'DEFAULT';
+      actionsDiv.appendChild(defaultLabel);
+    } else {
+      const removeBtn = document.createElement('button');
+      removeBtn.className = 'remove-domain-btn';
+      removeBtn.textContent = 'Remove';
+      removeBtn.addEventListener('click', () => removeAzureDevOpsDomain(domain));
+      actionsDiv.appendChild(removeBtn);
+    }
+
+    item.appendChild(nameSpan);
+    item.appendChild(actionsDiv);
+    domainList.appendChild(item);
   });
 }
 
@@ -1657,25 +1707,36 @@ function renderBitbucketDataCenterDomainList(domains) {
   const domainList = document.getElementById('bitbucket-dc-domain-list');
   if (!domainList) return;
 
+  domainList.replaceChildren();
+
   if (!domains || domains.length === 0) {
-    domainList.innerHTML = '<div class="no-domains">No custom domains added</div>';
+    const empty = document.createElement('div');
+    empty.className = 'no-domains';
+    empty.textContent = 'No custom domains added';
+    domainList.appendChild(empty);
     return;
   }
 
-  domainList.innerHTML = domains.map(domain => {
+  domains.forEach(domain => {
     const displayDomain = formatDomainForDisplay(domain);
-    return `
-      <div class="domain-item">
-        <span class="domain-name">${displayDomain}</span>
-        <div>
-          <button class="remove-domain-btn" data-domain="${domain.replace(/"/g, '&quot;')}">Remove</button>
-        </div>
-      </div>
-    `;
-  }).join('');
 
-  domainList.querySelectorAll('.remove-domain-btn').forEach(button => {
-    button.addEventListener('click', () => removeBitbucketDataCenterDomain(button.dataset.domain));
+    const item = document.createElement('div');
+    item.className = 'domain-item';
+
+    const nameSpan = document.createElement('span');
+    nameSpan.className = 'domain-name';
+    nameSpan.textContent = displayDomain;
+
+    const actionsDiv = document.createElement('div');
+    const removeBtn = document.createElement('button');
+    removeBtn.className = 'remove-domain-btn';
+    removeBtn.textContent = 'Remove';
+    removeBtn.addEventListener('click', () => removeBitbucketDataCenterDomain(domain));
+    actionsDiv.appendChild(removeBtn);
+
+    item.appendChild(nameSpan);
+    item.appendChild(actionsDiv);
+    domainList.appendChild(item);
   });
 }
 

--- a/popup.js
+++ b/popup.js
@@ -731,6 +731,9 @@ document.addEventListener('DOMContentLoaded', async () => {
   
   // Initialize Bitbucket settings (also called above after Azure)
   initializeBitbucketSettings();
+
+  // Initialize Bitbucket Data Center (self-hosted) settings
+  initializeBitbucketDataCenterSettings();
   
   // Initialize AI Provider settings
   initializeAIProviderSettings();
@@ -1610,6 +1613,271 @@ async function saveBitbucketToken() {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Bitbucket Data Center (self-hosted) domain and credential management
+// ---------------------------------------------------------------------------
+
+const BITBUCKET_DC_TOKEN_MASK = '••••••••••••••••••••••••••••••••••••••••••••••••••';
+
+function initializeBitbucketDataCenterSettings() {
+  loadBitbucketDataCenterDomains();
+  loadBitbucketDataCenterToken();
+  setupBitbucketDataCenterEventListeners();
+}
+
+function setupBitbucketDataCenterEventListeners() {
+  const addButton = document.getElementById('add-bitbucket-dc-domain-btn');
+  const domainInput = document.getElementById('bitbucket-dc-domain-input');
+  const saveTokenBtn = document.getElementById('save-bitbucket-dc-token-btn');
+  const tokenInput = document.getElementById('bitbucket-dc-token-input');
+  const usernameInput = document.getElementById('bitbucket-dc-username-input');
+
+  if (addButton && domainInput) {
+    addButton.addEventListener('click', addBitbucketDataCenterDomain);
+    domainInput.addEventListener('keypress', (e) => { if (e.key === 'Enter') addBitbucketDataCenterDomain(); });
+    domainInput.addEventListener('input', () => {
+      addButton.disabled = !validateDomainInput(domainInput.value.trim());
+    });
+  }
+
+  if (saveTokenBtn) saveTokenBtn.addEventListener('click', saveBitbucketDataCenterToken);
+  if (tokenInput) tokenInput.addEventListener('keypress', (e) => { if (e.key === 'Enter') saveBitbucketDataCenterToken(); });
+  if (usernameInput) usernameInput.addEventListener('keypress', (e) => { if (e.key === 'Enter') saveBitbucketDataCenterToken(); });
+}
+
+async function loadBitbucketDataCenterDomains() {
+  try {
+    const result = await chrome.storage.local.get(['bitbucketDataCenterDomains']);
+    renderBitbucketDataCenterDomainList(result.bitbucketDataCenterDomains || []);
+  } catch (error) {
+    dbgWarn('Error loading Bitbucket Data Center domains:', error);
+    renderBitbucketDataCenterDomainList([]);
+  }
+}
+
+function renderBitbucketDataCenterDomainList(domains) {
+  const domainList = document.getElementById('bitbucket-dc-domain-list');
+  if (!domainList) return;
+
+  if (!domains || domains.length === 0) {
+    domainList.innerHTML = '<div class="no-domains">No custom domains added</div>';
+    return;
+  }
+
+  domainList.innerHTML = domains.map(domain => {
+    const displayDomain = formatDomainForDisplay(domain);
+    return `
+      <div class="domain-item">
+        <span class="domain-name">${displayDomain}</span>
+        <div>
+          <button class="remove-domain-btn" data-domain="${domain.replace(/"/g, '&quot;')}">Remove</button>
+        </div>
+      </div>
+    `;
+  }).join('');
+
+  domainList.querySelectorAll('.remove-domain-btn').forEach(button => {
+    button.addEventListener('click', () => removeBitbucketDataCenterDomain(button.dataset.domain));
+  });
+}
+
+let isAddingBitbucketDCDomain = false;
+
+async function addBitbucketDataCenterDomain() {
+  if (isAddingBitbucketDCDomain) return;
+
+  const domainInput = document.getElementById('bitbucket-dc-domain-input');
+  const addButton = document.getElementById('add-bitbucket-dc-domain-btn');
+  const inputValue = domainInput?.value?.trim()?.toLowerCase() ?? '';
+
+  if (!validateDomainInput(inputValue)) {
+    alert('Please enter a valid domain (e.g., bitbucket.mycompany.com, https://bitbucket.mycompany.com)');
+    return;
+  }
+
+  const domain = normalizeDomain(inputValue);
+
+  try {
+    isAddingBitbucketDCDomain = true;
+    const originalButtonText = addButton?.textContent ?? 'Add';
+    if (addButton) {
+      addButton.textContent = 'Adding...';
+      addButton.disabled = true;
+    }
+
+    const result = await chrome.storage.local.get(['bitbucketDataCenterDomains']);
+    const domains = result.bitbucketDataCenterDomains || [];
+
+    if (domains.includes(domain)) {
+      alert('Domain already exists');
+      if (addButton) {
+        addButton.textContent = originalButtonText;
+        addButton.disabled = false;
+      }
+      return;
+    }
+
+    let originPattern;
+    if (domain.startsWith('http://') || domain.startsWith('https://')) {
+      const url = new URL(domain);
+      originPattern = `${url.protocol}//${url.host}/*`;
+    } else {
+      originPattern = `https://${domain}/*`;
+    }
+
+    dbgLog(`Adding Bitbucket Data Center domain with pattern: ${originPattern}`);
+
+    const granted = await chrome.permissions.request({ origins: [originPattern] });
+    if (!granted) {
+      alert('Permission not granted. The extension needs permission to access this domain.');
+      if (addButton) {
+        addButton.textContent = originalButtonText;
+        addButton.disabled = false;
+      }
+      return;
+    }
+
+    const updatedDomains = [...domains, domain];
+    await chrome.storage.local.set({ bitbucketDataCenterDomains: updatedDomains });
+
+    isUserLoggedIn().then(isLoggedIn => {
+      if (isLoggedIn && window.CloudService) {
+        window.CloudService.trackCustomDomains(domain, 'add')
+          .catch(err => dbgWarn('Error tracking Bitbucket DC domain in cloud (non-critical):', err));
+      }
+    }).catch(err => dbgWarn('Error checking login for DC domain tracking:', err));
+
+    chrome.runtime.sendMessage({ type: 'UPDATE_CONTENT_SCRIPTS' });
+
+    if (domainInput) domainInput.value = '';
+    if (addButton) {
+      addButton.textContent = originalButtonText;
+      addButton.disabled = true;
+    }
+
+    renderBitbucketDataCenterDomainList(updatedDomains);
+    showMessage('Domain added. Reload your Bitbucket Data Center pages to use AI reviews.', 'success');
+  } catch (error) {
+    dbgWarn('Error adding Bitbucket Data Center domain:', error);
+    alert(`Error adding domain: ${error.message}. Please try again.`);
+    if (addButton) {
+      addButton.textContent = 'Add';
+      addButton.disabled = false;
+    }
+  } finally {
+    isAddingBitbucketDCDomain = false;
+  }
+}
+
+async function removeBitbucketDataCenterDomain(domain) {
+  if (!confirm(`Remove domain "${domain}"?`)) return;
+
+  try {
+    const result = await chrome.storage.local.get(['bitbucketDataCenterDomains']);
+    const domains = result.bitbucketDataCenterDomains || [];
+    const updatedDomains = domains.filter(d => d !== domain);
+    await chrome.storage.local.set({ bitbucketDataCenterDomains: updatedDomains });
+
+    isUserLoggedIn().then(isLoggedIn => {
+      if (isLoggedIn && window.CloudService) {
+        window.CloudService.trackCustomDomains(domain, 'remove')
+          .catch(err => dbgWarn('Error tracking Bitbucket DC domain removal in cloud (non-critical):', err));
+      }
+    }).catch(err => dbgWarn('Error checking login for DC domain tracking:', err));
+
+    chrome.runtime.sendMessage({ type: 'UPDATE_CONTENT_SCRIPTS' });
+    renderBitbucketDataCenterDomainList(updatedDomains);
+    showMessage('Domain removed successfully!', 'success');
+  } catch (error) {
+    dbgWarn('Error removing Bitbucket Data Center domain:', error);
+    alert('Error removing domain. Please try again.');
+  }
+}
+
+async function loadBitbucketDataCenterToken() {
+  try {
+    const result = await chrome.storage.local.get(['bitbucketDataCenterToken', 'bitbucketDataCenterUsername']);
+    const token = result.bitbucketDataCenterToken;
+    const username = result.bitbucketDataCenterUsername;
+    const statusEl = document.getElementById('bitbucket-dc-token-status');
+    const tokenInput = document.getElementById('bitbucket-dc-token-input');
+    const usernameInput = document.getElementById('bitbucket-dc-username-input');
+
+    if (token && String(token).trim()) {
+      if (statusEl) {
+        statusEl.textContent = 'Credentials saved';
+        statusEl.className = 'token-status success';
+      }
+      if (tokenInput) {
+        tokenInput.value = BITBUCKET_DC_TOKEN_MASK;
+        tokenInput.type = 'password';
+      }
+    } else {
+      if (statusEl) {
+        statusEl.textContent = '';
+        statusEl.className = 'token-status';
+      }
+    }
+    if (usernameInput) {
+      usernameInput.value = (username != null && username !== undefined) ? String(username) : '';
+    }
+  } catch (error) {
+    dbgWarn('Error loading Bitbucket Data Center token:', error);
+  }
+}
+
+async function saveBitbucketDataCenterToken() {
+  const tokenInput = document.getElementById('bitbucket-dc-token-input');
+  const usernameInput = document.getElementById('bitbucket-dc-username-input');
+  const saveBtn = document.getElementById('save-bitbucket-dc-token-btn');
+  const statusEl = document.getElementById('bitbucket-dc-token-status');
+
+  const tokenRaw = tokenInput?.value?.trim() ?? '';
+  const username = usernameInput?.value?.trim() ?? '';
+
+  const stored = await chrome.storage.local.get(['bitbucketDataCenterToken', 'bitbucketDataCenterUsername']);
+  const existingToken = stored.bitbucketDataCenterToken && String(stored.bitbucketDataCenterToken).trim() ? stored.bitbucketDataCenterToken.trim() : '';
+  const token = (tokenRaw === BITBUCKET_DC_TOKEN_MASK && existingToken) ? existingToken : tokenRaw;
+
+  if (!token) {
+    if (statusEl) {
+      statusEl.textContent = 'Enter a token or password to save';
+      statusEl.className = 'token-status error';
+    }
+    return;
+  }
+
+  try {
+    if (saveBtn) saveBtn.textContent = 'Saving...';
+    await chrome.storage.local.set({
+      bitbucketDataCenterToken: token,
+      bitbucketDataCenterUsername: username || ''
+    });
+    if (statusEl) {
+      statusEl.textContent = 'Credentials saved';
+      statusEl.className = 'token-status success';
+    }
+    if (tokenInput) {
+      tokenInput.value = BITBUCKET_DC_TOKEN_MASK;
+      tokenInput.type = 'password';
+    }
+    if (saveBtn) {
+      saveBtn.textContent = 'Save';
+      saveBtn.disabled = false;
+    }
+  } catch (error) {
+    dbgWarn('Error saving Bitbucket Data Center token:', error);
+    if (statusEl) {
+      statusEl.textContent = 'Failed to save';
+      statusEl.className = 'token-status error';
+    }
+    if (saveBtn) {
+      saveBtn.textContent = 'Save';
+      saveBtn.disabled = false;
+    }
+  }
+}
+
 function showMessage(text, type = 'info') {
   // Create a temporary message element
   const message = document.createElement('div');
@@ -2276,17 +2544,18 @@ document.head.appendChild(style);
 // PLATFORM NAVIGATION
 // =====================================================================
 
-const PLATFORM_IDS = ['github', 'gitlab', 'azure', 'bitbucket'];
+const PLATFORM_IDS = ['github', 'gitlab', 'azure', 'bitbucket', 'bitbucket-dc'];
 
 // Card definitions: id → { platform view to open, optional scroll target id }
 const PLATFORM_CARDS = [
-  { cardId: 'card-github-com',          platform: 'github',    scrollTarget: null },
-  { cardId: 'card-github-enterprise',   platform: 'github',    scrollTarget: 'github-enterprise-subsection' },
-  { cardId: 'card-gitlab-com',          platform: 'gitlab',    scrollTarget: null },
-  { cardId: 'card-gitlab-self-managed', platform: 'gitlab',    scrollTarget: 'gitlab-self-managed-subsection' },
-  { cardId: 'card-azure-cloud',         platform: 'azure',     scrollTarget: null },
-  { cardId: 'card-azure-server',        platform: 'azure',     scrollTarget: 'azure-server-subsection' },
-  { cardId: 'card-bitbucket',           platform: 'bitbucket', scrollTarget: null },
+  { cardId: 'card-github-com',          platform: 'github',        scrollTarget: null },
+  { cardId: 'card-github-enterprise',   platform: 'github',        scrollTarget: 'github-enterprise-subsection' },
+  { cardId: 'card-gitlab-com',          platform: 'gitlab',        scrollTarget: null },
+  { cardId: 'card-gitlab-self-managed', platform: 'gitlab',        scrollTarget: 'gitlab-self-managed-subsection' },
+  { cardId: 'card-azure-cloud',         platform: 'azure',         scrollTarget: null },
+  { cardId: 'card-azure-server',        platform: 'azure',         scrollTarget: 'azure-server-subsection' },
+  { cardId: 'card-bitbucket',           platform: 'bitbucket',     scrollTarget: null },
+  { cardId: 'card-bitbucket-dc',        platform: 'bitbucket-dc',  scrollTarget: null },
 ];
 
 function initializePlatformNavigation() {
@@ -2354,12 +2623,14 @@ async function computePlatformStatuses() {
   try {
     const result = await chrome.storage.local.get([
       'azureToken',
-      'customDomains',           // GitLab custom domains
-      'azureCustomDomains',      // Azure on-prem domains
+      'customDomains',                  // GitLab custom domains
+      'azureCustomDomains',             // Azure on-prem domains
       'githubEnterpriseDomains',
       'bitbucketToken',
       'bitbucketEmail',
       'bitbucketEnabled',
+      'bitbucketDataCenterDomains',
+      'bitbucketDataCenterToken',
     ]);
 
     // Cloud variants: always ready, no setup required
@@ -2382,10 +2653,16 @@ async function computePlatformStatuses() {
     const azureServerReady = Array.isArray(azureDomains) && azureDomains.length > 0;
     setBadge('azure-server', azureServerReady ? 'ready' : 'setup');
 
-    // Bitbucket: requires explicit permission grant + token
+    // Bitbucket Cloud: requires explicit permission grant + token
     const bitbucketConfigured = result.bitbucketEnabled &&
       (result.bitbucketToken || result.bitbucketEmail);
     setBadge('bitbucket', bitbucketConfigured ? 'ready' : 'setup');
+
+    // Bitbucket Data Center: ready when at least one domain is saved with a token
+    const dcDomains = result.bitbucketDataCenterDomains;
+    const dcReady = Array.isArray(dcDomains) && dcDomains.length > 0 &&
+      result.bitbucketDataCenterToken && String(result.bitbucketDataCenterToken).trim();
+    setBadge('bitbucket-dc', dcReady ? 'ready' : 'setup');
   } catch (err) {
     dbgWarn('Error computing platform statuses:', err);
   }

--- a/popup.js
+++ b/popup.js
@@ -1630,7 +1630,6 @@ function setupBitbucketDataCenterEventListeners() {
   const domainInput = document.getElementById('bitbucket-dc-domain-input');
   const saveTokenBtn = document.getElementById('save-bitbucket-dc-token-btn');
   const tokenInput = document.getElementById('bitbucket-dc-token-input');
-  const usernameInput = document.getElementById('bitbucket-dc-username-input');
 
   if (addButton && domainInput) {
     addButton.addEventListener('click', addBitbucketDataCenterDomain);
@@ -1642,7 +1641,6 @@ function setupBitbucketDataCenterEventListeners() {
 
   if (saveTokenBtn) saveTokenBtn.addEventListener('click', saveBitbucketDataCenterToken);
   if (tokenInput) tokenInput.addEventListener('keypress', (e) => { if (e.key === 'Enter') saveBitbucketDataCenterToken(); });
-  if (usernameInput) usernameInput.addEventListener('keypress', (e) => { if (e.key === 'Enter') saveBitbucketDataCenterToken(); });
 }
 
 async function loadBitbucketDataCenterDomains() {
@@ -1796,16 +1794,14 @@ async function removeBitbucketDataCenterDomain(domain) {
 
 async function loadBitbucketDataCenterToken() {
   try {
-    const result = await chrome.storage.local.get(['bitbucketDataCenterToken', 'bitbucketDataCenterUsername']);
+    const result = await chrome.storage.local.get(['bitbucketDataCenterToken']);
     const token = result.bitbucketDataCenterToken;
-    const username = result.bitbucketDataCenterUsername;
     const statusEl = document.getElementById('bitbucket-dc-token-status');
     const tokenInput = document.getElementById('bitbucket-dc-token-input');
-    const usernameInput = document.getElementById('bitbucket-dc-username-input');
 
     if (token && String(token).trim()) {
       if (statusEl) {
-        statusEl.textContent = 'Credentials saved';
+        statusEl.textContent = 'Token saved';
         statusEl.className = 'token-status success';
       }
       if (tokenInput) {
@@ -1818,9 +1814,6 @@ async function loadBitbucketDataCenterToken() {
         statusEl.className = 'token-status';
       }
     }
-    if (usernameInput) {
-      usernameInput.value = (username != null && username !== undefined) ? String(username) : '';
-    }
   } catch (error) {
     dbgWarn('Error loading Bitbucket Data Center token:', error);
   }
@@ -1828,20 +1821,18 @@ async function loadBitbucketDataCenterToken() {
 
 async function saveBitbucketDataCenterToken() {
   const tokenInput = document.getElementById('bitbucket-dc-token-input');
-  const usernameInput = document.getElementById('bitbucket-dc-username-input');
   const saveBtn = document.getElementById('save-bitbucket-dc-token-btn');
   const statusEl = document.getElementById('bitbucket-dc-token-status');
 
   const tokenRaw = tokenInput?.value?.trim() ?? '';
-  const username = usernameInput?.value?.trim() ?? '';
 
-  const stored = await chrome.storage.local.get(['bitbucketDataCenterToken', 'bitbucketDataCenterUsername']);
+  const stored = await chrome.storage.local.get(['bitbucketDataCenterToken']);
   const existingToken = stored.bitbucketDataCenterToken && String(stored.bitbucketDataCenterToken).trim() ? stored.bitbucketDataCenterToken.trim() : '';
   const token = (tokenRaw === BITBUCKET_DC_TOKEN_MASK && existingToken) ? existingToken : tokenRaw;
 
   if (!token) {
     if (statusEl) {
-      statusEl.textContent = 'Enter a token or password to save';
+      statusEl.textContent = 'Enter an HTTP access token to save';
       statusEl.className = 'token-status error';
     }
     return;
@@ -1849,12 +1840,9 @@ async function saveBitbucketDataCenterToken() {
 
   try {
     if (saveBtn) saveBtn.textContent = 'Saving...';
-    await chrome.storage.local.set({
-      bitbucketDataCenterToken: token,
-      bitbucketDataCenterUsername: username || ''
-    });
+    await chrome.storage.local.set({ bitbucketDataCenterToken: token });
     if (statusEl) {
-      statusEl.textContent = 'Credentials saved';
+      statusEl.textContent = 'Token saved';
       statusEl.className = 'token-status success';
     }
     if (tokenInput) {

--- a/services/bitbucket-api.js
+++ b/services/bitbucket-api.js
@@ -9,6 +9,69 @@ function isDataCenterUrl(url) {
 }
 
 /**
+ * Convert Bitbucket Data Center diff JSON to unified diff (patch) format.
+ *
+ * DC diff JSON structure:
+ *   { diffs: [ { source, destination, binary, hunks: [ { sourceLine, sourceSpan,
+ *     destinationLine, destinationSpan, context, segments: [ { type, lines: [{ line }] } ] } ] } ] }
+ *
+ * Segment types: CONTEXT → ' ', ADDED → '+', REMOVED → '-'
+ *
+ * @param {Object} diffJson - Parsed JSON from /rest/api/1.0/…/pull-requests/{id}/diff
+ * @returns {string} Unified diff text
+ */
+function convertDataCenterDiffToUnifiedPatch(diffJson) {
+  const output = [];
+  const diffs = diffJson.diffs || diffJson.values || [];
+
+  for (const diff of diffs) {
+    const srcPath = diff.source?.toString ?? null;
+    const dstPath = diff.destination?.toString ?? null;
+    const aPath = srcPath || dstPath || 'unknown';
+    const bPath = dstPath || srcPath || 'unknown';
+
+    output.push(`diff --git a/${aPath} b/${bPath}`);
+
+    if (diff.binary) {
+      output.push(`Binary files a/${aPath} and b/${bPath} differ`);
+      continue;
+    }
+
+    // New / deleted file markers
+    if (!srcPath && dstPath) {
+      output.push('new file mode 100644');
+      output.push('--- /dev/null');
+      output.push(`+++ b/${dstPath}`);
+    } else if (srcPath && !dstPath) {
+      output.push('deleted file mode 100644');
+      output.push(`--- a/${srcPath}`);
+      output.push('+++ /dev/null');
+    } else {
+      output.push(`--- a/${aPath}`);
+      output.push(`+++ b/${bPath}`);
+    }
+
+    for (const hunk of (diff.hunks || [])) {
+      const srcStart  = hunk.sourceLine      ?? 1;
+      const srcSpan   = hunk.sourceSpan      ?? 0;
+      const dstStart  = hunk.destinationLine ?? 1;
+      const dstSpan   = hunk.destinationSpan ?? 0;
+      const ctx       = hunk.context ? ` ${hunk.context}` : '';
+      output.push(`@@ -${srcStart},${srcSpan} +${dstStart},${dstSpan} @@${ctx}`);
+
+      for (const segment of (hunk.segments || [])) {
+        const prefix = segment.type === 'ADDED' ? '+' : segment.type === 'REMOVED' ? '-' : ' ';
+        for (const ln of (segment.lines || [])) {
+          output.push(`${prefix}${ln.line ?? ''}`);
+        }
+      }
+    }
+  }
+
+  return output.join('\n') + (output.length ? '\n' : '');
+}
+
+/**
  * Build request headers for Bitbucket Cloud (Basic auth: email + app-password).
  * @param {string|null} token
  * @param {string|null} email
@@ -64,21 +127,44 @@ export async function fetchPatchContent(diffUrl, { token, email }) {
 
   try {
     if (isDataCenterUrl(diffUrl)) {
-      // Bitbucket Data Center: Bearer token auth (Basic auth is often disabled on DC instances)
+      // Bitbucket Data Center: Bearer token auth; API always returns JSON (not unified diff text)
       const headers = buildDataCenterAuthHeaders(trimmedToken, trimmedEmail);
       dbgLog('Fetching Bitbucket Data Center diff from:', diffUrl, trimmedToken ? '(Bearer auth)' : '(no token)');
-      const response = await fetch(diffUrl, { headers: { ...headers, 'Accept': 'text/plain,*/*' } });
-      if (!response.ok) {
-        const authRequired = response.status === 401 || response.status === 403;
-        let serverMessage = null;
-        try { serverMessage = (await response.text()).trim() || null; } catch (_) {}
-        const err = new Error(`Failed to fetch Bitbucket Data Center patch: ${response.status} ${response.statusText}`);
-        err.bitbucketAuthRequired = authRequired;
-        err.serverMessage = serverMessage;
-        throw err;
+
+      // Collect all file diffs, handling DC pagination (isLastPage / nextPageStart)
+      const allDiffs = [];
+      let fetchUrl = diffUrl;
+      let pageCount = 0;
+      const MAX_PAGES = 20;
+
+      while (fetchUrl && pageCount < MAX_PAGES) {
+        pageCount++;
+        const response = await fetch(fetchUrl, { headers: { ...headers, 'Accept': 'application/json' } });
+        if (!response.ok) {
+          const authRequired = response.status === 401 || response.status === 403;
+          let serverMessage = null;
+          try { serverMessage = (await response.text()).trim() || null; } catch (_) {}
+          const err = new Error(`Failed to fetch Bitbucket Data Center patch: ${response.status} ${response.statusText}`);
+          err.bitbucketAuthRequired = authRequired;
+          err.serverMessage = serverMessage;
+          throw err;
+        }
+
+        const diffJson = await response.json();
+        const pageDiffs = diffJson.diffs || diffJson.values || [];
+        allDiffs.push(...pageDiffs);
+
+        // Advance to next page if available
+        if (!diffJson.isLastPage && diffJson.nextPageStart != null) {
+          const separator = fetchUrl.includes('?') ? '&' : '?';
+          fetchUrl = `${diffUrl}${separator}start=${diffJson.nextPageStart}`;
+        } else {
+          fetchUrl = null;
+        }
       }
-      const patchContent = await response.text();
-      dbgLog('Successfully fetched Bitbucket Data Center diff, length:', patchContent.length);
+
+      const patchContent = convertDataCenterDiffToUnifiedPatch({ diffs: allDiffs });
+      dbgLog('Converted Bitbucket Data Center diff to unified patch, files:', allDiffs.length, 'length:', patchContent.length);
       return { success: true, content: patchContent };
     }
 

--- a/services/bitbucket-api.js
+++ b/services/bitbucket-api.js
@@ -9,7 +9,7 @@ function isDataCenterUrl(url) {
 }
 
 /**
- * Build request headers for Bitbucket API (Basic auth when email+token, Bearer when token only).
+ * Build request headers for Bitbucket Cloud (Basic auth: email + app-password).
  * @param {string|null} token
  * @param {string|null} email
  * @returns {{ 'Accept': string, 'Authorization'?: string }}
@@ -32,6 +32,21 @@ function buildAuthHeaders(token, email) {
 }
 
 /**
+ * Build request headers for Bitbucket Data Center (Bearer auth using HTTP access token).
+ * DC HTTP access tokens are standalone — username is not needed for the Authorization header.
+ * Basic auth is frequently disabled on DC instances; Bearer is the recommended approach.
+ * @param {string|null} token - HTTP access token or password
+ * @param {string|null} username - Stored for reference but not used in Bearer auth
+ * @returns {{ 'Accept': string, 'Authorization'?: string }}
+ */
+function buildDataCenterAuthHeaders(token, username) {
+  const headers = { 'Accept': 'application/json' };
+  if (!token) return headers;
+  headers['Authorization'] = `Bearer ${token}`;
+  return headers;
+}
+
+/**
  * Fetch Bitbucket PR patch/diff content (Cloud or Data Center).
  *
  * Cloud flow: parse diff URL -> GET PR API -> use links.diff.href -> GET diff (avoids 302).
@@ -46,12 +61,12 @@ function buildAuthHeaders(token, email) {
 export async function fetchPatchContent(diffUrl, { token, email }) {
   const trimmedToken = token && String(token).trim() ? token.trim() : null;
   const trimmedEmail = (email != null && email !== '' && String(email).trim()) ? String(email).trim() : null;
-  const headers = buildAuthHeaders(trimmedToken, trimmedEmail);
 
   try {
     if (isDataCenterUrl(diffUrl)) {
-      // Bitbucket Data Center: direct GET of the diff endpoint (no redirect needed)
-      dbgLog('Fetching Bitbucket Data Center diff from:', diffUrl, trimmedToken ? '(with auth)' : '(no token)');
+      // Bitbucket Data Center: Bearer token auth (Basic auth is often disabled on DC instances)
+      const headers = buildDataCenterAuthHeaders(trimmedToken, trimmedEmail);
+      dbgLog('Fetching Bitbucket Data Center diff from:', diffUrl, trimmedToken ? '(Bearer auth)' : '(no token)');
       const response = await fetch(diffUrl, { headers: { ...headers, 'Accept': 'text/plain,*/*' } });
       if (!response.ok) {
         const authRequired = response.status === 401 || response.status === 403;
@@ -67,7 +82,8 @@ export async function fetchPatchContent(diffUrl, { token, email }) {
       return { success: true, content: patchContent };
     }
 
-    // Bitbucket Cloud: parse diff URL -> PR API -> follow links.diff.href
+    // Bitbucket Cloud: Basic auth (email + app-password), parse diff URL -> PR API -> follow links.diff.href
+    const headers = buildAuthHeaders(trimmedToken, trimmedEmail);
     const parsed = parseBitbucketPrDiffUrl(diffUrl);
     let urlToFetch = diffUrl;
 

--- a/services/bitbucket-api.js
+++ b/services/bitbucket-api.js
@@ -1,7 +1,12 @@
 // bitbucket-api.js
-// Bitbucket API 2.0 service for fetching PR diff/patch. Used by background script (CSP-safe context).
+// Bitbucket API service for fetching PR diff/patch (Cloud and Data Center). Used by background script.
 import { dbgLog, dbgError } from '../utils/logger.js';
 import { parseBitbucketPrDiffUrl, getBitbucketPrApiUrl } from '../utils/bitbucket-api-urls.js';
+
+/** Returns true when diffUrl points to a Bitbucket Data Center REST API endpoint. */
+function isDataCenterUrl(url) {
+  return typeof url === 'string' && url.includes('/rest/api/1.0/');
+}
 
 /**
  * Build request headers for Bitbucket API (Basic auth when email+token, Bearer when token only).
@@ -27,11 +32,15 @@ function buildAuthHeaders(token, email) {
 }
 
 /**
- * Fetch Bitbucket PR patch/diff content.
- * Flow: parse diff URL -> GET PR API -> use links.diff.href -> GET diff body (avoids 302 from direct diff URL).
+ * Fetch Bitbucket PR patch/diff content (Cloud or Data Center).
  *
- * @param {string} diffUrl - Full diff URL e.g. .../repositories/workspace/repo/pullrequests/1/diff
- * @param {{ token: string|null, email: string|null }} credentials - From storage; token/email can be null or empty
+ * Cloud flow: parse diff URL -> GET PR API -> use links.diff.href -> GET diff (avoids 302).
+ * Data Center flow: direct GET of the /rest/api/1.0/...pull-requests/{id}/diff endpoint.
+ *
+ * @param {string} diffUrl - Diff URL (api.bitbucket.org for Cloud; {origin}/rest/api/1.0/... for DC)
+ * @param {{ token: string|null, email: string|null }} credentials
+ *   For Cloud: email = Atlassian account email, token = app password.
+ *   For Data Center: email = username, token = password or personal access token.
  * @returns {Promise<{ success: true, content: string }|{ success: false, error: string, bitbucketAuthRequired: boolean }>}
  */
 export async function fetchPatchContent(diffUrl, { token, email }) {
@@ -40,12 +49,28 @@ export async function fetchPatchContent(diffUrl, { token, email }) {
   const headers = buildAuthHeaders(trimmedToken, trimmedEmail);
 
   try {
+    if (isDataCenterUrl(diffUrl)) {
+      // Bitbucket Data Center: direct GET of the diff endpoint (no redirect needed)
+      dbgLog('Fetching Bitbucket Data Center diff from:', diffUrl, trimmedToken ? '(with auth)' : '(no token)');
+      const response = await fetch(diffUrl, { headers: { ...headers, 'Accept': 'text/plain,*/*' } });
+      if (!response.ok) {
+        const authRequired = response.status === 401 || response.status === 403;
+        const err = new Error(`Failed to fetch Bitbucket Data Center patch: ${response.status} ${response.statusText}`);
+        err.bitbucketAuthRequired = authRequired;
+        throw err;
+      }
+      const patchContent = await response.text();
+      dbgLog('Successfully fetched Bitbucket Data Center diff, length:', patchContent.length);
+      return { success: true, content: patchContent };
+    }
+
+    // Bitbucket Cloud: parse diff URL -> PR API -> follow links.diff.href
     const parsed = parseBitbucketPrDiffUrl(diffUrl);
     let urlToFetch = diffUrl;
 
     if (parsed) {
       const prApiUrl = getBitbucketPrApiUrl(parsed.workspace, parsed.repoSlug, parsed.prId);
-      dbgLog('Fetching Bitbucket PR:', prApiUrl);
+      dbgLog('Fetching Bitbucket Cloud PR:', prApiUrl);
       const prRes = await fetch(prApiUrl, { headers });
       if (!prRes.ok) {
         const authRequired = prRes.status === 401 || prRes.status === 403;
@@ -59,7 +84,7 @@ export async function fetchPatchContent(diffUrl, { token, email }) {
         throw new Error('Bitbucket PR response missing links.diff.href');
       }
       urlToFetch = diffHref;
-      dbgLog('Fetching Bitbucket diff from links.diff.href');
+      dbgLog('Fetching Bitbucket Cloud diff from links.diff.href');
     } else {
       dbgLog('Fetching Bitbucket diff from:', diffUrl, trimmedToken ? '(with auth)' : '(no token)');
     }

--- a/services/bitbucket-api.js
+++ b/services/bitbucket-api.js
@@ -55,8 +55,11 @@ export async function fetchPatchContent(diffUrl, { token, email }) {
       const response = await fetch(diffUrl, { headers: { ...headers, 'Accept': 'text/plain,*/*' } });
       if (!response.ok) {
         const authRequired = response.status === 401 || response.status === 403;
+        let serverMessage = null;
+        try { serverMessage = (await response.text()).trim() || null; } catch (_) {}
         const err = new Error(`Failed to fetch Bitbucket Data Center patch: ${response.status} ${response.statusText}`);
         err.bitbucketAuthRequired = authRequired;
+        err.serverMessage = serverMessage;
         throw err;
       }
       const patchContent = await response.text();
@@ -74,8 +77,11 @@ export async function fetchPatchContent(diffUrl, { token, email }) {
       const prRes = await fetch(prApiUrl, { headers });
       if (!prRes.ok) {
         const authRequired = prRes.status === 401 || prRes.status === 403;
+        let serverMessage = null;
+        try { serverMessage = (await prRes.text()).trim() || null; } catch (_) {}
         const err = new Error(`Failed to fetch Bitbucket PR: ${prRes.status} ${prRes.statusText}`);
         err.bitbucketAuthRequired = authRequired;
+        err.serverMessage = serverMessage;
         throw err;
       }
       const prJson = await prRes.json();
@@ -92,8 +98,11 @@ export async function fetchPatchContent(diffUrl, { token, email }) {
     const response = await fetch(urlToFetch, { headers: { ...headers, 'Accept': 'text/plain,*/*' } });
     if (!response.ok) {
       const authRequired = response.status === 401 || response.status === 403;
+      let serverMessage = null;
+      try { serverMessage = (await response.text()).trim() || null; } catch (_) {}
       const err = new Error(`Failed to fetch Bitbucket patch: ${response.status} ${response.statusText}`);
       err.bitbucketAuthRequired = authRequired;
+      err.serverMessage = serverMessage;
       throw err;
     }
     const patchContent = await response.text();
@@ -106,7 +115,8 @@ export async function fetchPatchContent(diffUrl, { token, email }) {
     return {
       success: false,
       error: error?.message || msg || 'Request failed',
-      bitbucketAuthRequired: authRequired
+      bitbucketAuthRequired: authRequired,
+      serverMessage: error?.serverMessage || null
     };
   }
 }

--- a/services/bitbucket-api.js
+++ b/services/bitbucket-api.js
@@ -1,224 +1,29 @@
 // bitbucket-api.js
-// Bitbucket API service for fetching PR diff/patch (Cloud and Data Center). Used by background script.
-import { dbgLog, dbgError } from '../utils/logger.js';
-import { parseBitbucketPrDiffUrl, getBitbucketPrApiUrl } from '../utils/bitbucket-api-urls.js';
+// Router: delegates to the correct Bitbucket implementation based on URL.
+//   Bitbucket Cloud      → services/bitbucket-cloud-api.js  (Basic auth, api.bitbucket.org)
+//   Bitbucket Data Center → services/bitbucket-dc-api.js    (Bearer auth, /rest/api/1.0/)
+// background.js imports only this file and calls fetchPatchContent() without needing
+// to know which platform it is dealing with.
+import { fetchCloudPatchContent } from './bitbucket-cloud-api.js';
+import { fetchDataCenterPatchContent } from './bitbucket-dc-api.js';
 
-/** Returns true when diffUrl points to a Bitbucket Data Center REST API endpoint. */
+/** Returns true when the URL points to a Bitbucket Data Center REST API endpoint. */
 function isDataCenterUrl(url) {
   return typeof url === 'string' && url.includes('/rest/api/1.0/');
 }
 
 /**
- * Convert Bitbucket Data Center diff JSON to unified diff (patch) format.
+ * Fetch Bitbucket PR diff as unified patch text (Cloud or Data Center).
  *
- * DC diff JSON structure:
- *   { diffs: [ { source, destination, binary, hunks: [ { sourceLine, sourceSpan,
- *     destinationLine, destinationSpan, context, segments: [ { type, lines: [{ line }] } ] } ] } ] }
- *
- * Segment types: CONTEXT → ' ', ADDED → '+', REMOVED → '-'
- *
- * @param {Object} diffJson - Parsed JSON from /rest/api/1.0/…/pull-requests/{id}/diff
- * @returns {string} Unified diff text
- */
-function convertDataCenterDiffToUnifiedPatch(diffJson) {
-  const output = [];
-  const diffs = diffJson.diffs || diffJson.values || [];
-
-  for (const diff of diffs) {
-    const srcPath = diff.source?.toString ?? null;
-    const dstPath = diff.destination?.toString ?? null;
-    const aPath = srcPath || dstPath || 'unknown';
-    const bPath = dstPath || srcPath || 'unknown';
-
-    output.push(`diff --git a/${aPath} b/${bPath}`);
-
-    if (diff.binary) {
-      output.push(`Binary files a/${aPath} and b/${bPath} differ`);
-      continue;
-    }
-
-    // New / deleted file markers
-    if (!srcPath && dstPath) {
-      output.push('new file mode 100644');
-      output.push('--- /dev/null');
-      output.push(`+++ b/${dstPath}`);
-    } else if (srcPath && !dstPath) {
-      output.push('deleted file mode 100644');
-      output.push(`--- a/${srcPath}`);
-      output.push('+++ /dev/null');
-    } else {
-      output.push(`--- a/${aPath}`);
-      output.push(`+++ b/${bPath}`);
-    }
-
-    for (const hunk of (diff.hunks || [])) {
-      const srcStart  = hunk.sourceLine      ?? 1;
-      const srcSpan   = hunk.sourceSpan      ?? 0;
-      const dstStart  = hunk.destinationLine ?? 1;
-      const dstSpan   = hunk.destinationSpan ?? 0;
-      const ctx       = hunk.context ? ` ${hunk.context}` : '';
-      output.push(`@@ -${srcStart},${srcSpan} +${dstStart},${dstSpan} @@${ctx}`);
-
-      for (const segment of (hunk.segments || [])) {
-        const prefix = segment.type === 'ADDED' ? '+' : segment.type === 'REMOVED' ? '-' : ' ';
-        for (const ln of (segment.lines || [])) {
-          output.push(`${prefix}${ln.line ?? ''}`);
-        }
-      }
-    }
-  }
-
-  return output.join('\n') + (output.length ? '\n' : '');
-}
-
-/**
- * Build request headers for Bitbucket Cloud (Basic auth: email + app-password).
- * @param {string|null} token
- * @param {string|null} email
- * @returns {{ 'Accept': string, 'Authorization'?: string }}
- */
-function buildAuthHeaders(token, email) {
-  const headers = { 'Accept': 'application/json' };
-  if (!token) return headers;
-  if (email) {
-    try {
-      const credentials = `${email}:${token}`;
-      const encoded = btoa(unescape(encodeURIComponent(credentials)));
-      headers['Authorization'] = `Basic ${encoded}`;
-    } catch (e) {
-      headers['Authorization'] = `Bearer ${token}`;
-    }
-  } else {
-    headers['Authorization'] = `Bearer ${token}`;
-  }
-  return headers;
-}
-
-/**
- * Build request headers for Bitbucket Data Center (Bearer auth using HTTP access token).
- * DC HTTP access tokens are standalone — username is not needed for the Authorization header.
- * Basic auth is frequently disabled on DC instances; Bearer is the recommended approach.
- * @param {string|null} token - HTTP access token or password
- * @param {string|null} username - Stored for reference but not used in Bearer auth
- * @returns {{ 'Accept': string, 'Authorization'?: string }}
- */
-function buildDataCenterAuthHeaders(token, username) {
-  const headers = { 'Accept': 'application/json' };
-  if (!token) return headers;
-  headers['Authorization'] = `Bearer ${token}`;
-  return headers;
-}
-
-/**
- * Fetch Bitbucket PR patch/diff content (Cloud or Data Center).
- *
- * Cloud flow: parse diff URL -> GET PR API -> use links.diff.href -> GET diff (avoids 302).
- * Data Center flow: direct GET of the /rest/api/1.0/...pull-requests/{id}/diff endpoint.
- *
- * @param {string} diffUrl - Diff URL (api.bitbucket.org for Cloud; {origin}/rest/api/1.0/... for DC)
+ * @param {string} diffUrl
  * @param {{ token: string|null, email: string|null }} credentials
- *   For Cloud: email = Atlassian account email, token = app password.
- *   For Data Center: email = username, token = password or personal access token.
- * @returns {Promise<{ success: true, content: string }|{ success: false, error: string, bitbucketAuthRequired: boolean }>}
+ *   Cloud:       email = Atlassian account email, token = app-password
+ *   Data Center: token = HTTP access token (email/username not used)
+ * @returns {Promise<{ success: true, content: string } | { success: false, error: string, bitbucketAuthRequired: boolean, serverMessage: string|null }>}
  */
 export async function fetchPatchContent(diffUrl, { token, email }) {
-  const trimmedToken = token && String(token).trim() ? token.trim() : null;
-  const trimmedEmail = (email != null && email !== '' && String(email).trim()) ? String(email).trim() : null;
-
-  try {
-    if (isDataCenterUrl(diffUrl)) {
-      // Bitbucket Data Center: Bearer token auth; API always returns JSON (not unified diff text)
-      const headers = buildDataCenterAuthHeaders(trimmedToken, trimmedEmail);
-      dbgLog('Fetching Bitbucket Data Center diff from:', diffUrl, trimmedToken ? '(Bearer auth)' : '(no token)');
-
-      // Collect all file diffs, handling DC pagination (isLastPage / nextPageStart)
-      const allDiffs = [];
-      let fetchUrl = diffUrl;
-      let pageCount = 0;
-      const MAX_PAGES = 20;
-
-      while (fetchUrl && pageCount < MAX_PAGES) {
-        pageCount++;
-        const response = await fetch(fetchUrl, { headers: { ...headers, 'Accept': 'application/json' } });
-        if (!response.ok) {
-          const authRequired = response.status === 401 || response.status === 403;
-          let serverMessage = null;
-          try { serverMessage = (await response.text()).trim() || null; } catch (_) {}
-          const err = new Error(`Failed to fetch Bitbucket Data Center patch: ${response.status} ${response.statusText}`);
-          err.bitbucketAuthRequired = authRequired;
-          err.serverMessage = serverMessage;
-          throw err;
-        }
-
-        const diffJson = await response.json();
-        const pageDiffs = diffJson.diffs || diffJson.values || [];
-        allDiffs.push(...pageDiffs);
-
-        // Advance to next page if available
-        if (!diffJson.isLastPage && diffJson.nextPageStart != null) {
-          const separator = fetchUrl.includes('?') ? '&' : '?';
-          fetchUrl = `${diffUrl}${separator}start=${diffJson.nextPageStart}`;
-        } else {
-          fetchUrl = null;
-        }
-      }
-
-      const patchContent = convertDataCenterDiffToUnifiedPatch({ diffs: allDiffs });
-      dbgLog('Converted Bitbucket Data Center diff to unified patch, files:', allDiffs.length, 'length:', patchContent.length);
-      return { success: true, content: patchContent };
-    }
-
-    // Bitbucket Cloud: Basic auth (email + app-password), parse diff URL -> PR API -> follow links.diff.href
-    const headers = buildAuthHeaders(trimmedToken, trimmedEmail);
-    const parsed = parseBitbucketPrDiffUrl(diffUrl);
-    let urlToFetch = diffUrl;
-
-    if (parsed) {
-      const prApiUrl = getBitbucketPrApiUrl(parsed.workspace, parsed.repoSlug, parsed.prId);
-      dbgLog('Fetching Bitbucket Cloud PR:', prApiUrl);
-      const prRes = await fetch(prApiUrl, { headers });
-      if (!prRes.ok) {
-        const authRequired = prRes.status === 401 || prRes.status === 403;
-        let serverMessage = null;
-        try { serverMessage = (await prRes.text()).trim() || null; } catch (_) {}
-        const err = new Error(`Failed to fetch Bitbucket PR: ${prRes.status} ${prRes.statusText}`);
-        err.bitbucketAuthRequired = authRequired;
-        err.serverMessage = serverMessage;
-        throw err;
-      }
-      const prJson = await prRes.json();
-      const diffHref = prJson?.links?.diff?.href;
-      if (!diffHref) {
-        throw new Error('Bitbucket PR response missing links.diff.href');
-      }
-      urlToFetch = diffHref;
-      dbgLog('Fetching Bitbucket Cloud diff from links.diff.href');
-    } else {
-      dbgLog('Fetching Bitbucket diff from:', diffUrl, trimmedToken ? '(with auth)' : '(no token)');
-    }
-
-    const response = await fetch(urlToFetch, { headers: { ...headers, 'Accept': 'text/plain,*/*' } });
-    if (!response.ok) {
-      const authRequired = response.status === 401 || response.status === 403;
-      let serverMessage = null;
-      try { serverMessage = (await response.text()).trim() || null; } catch (_) {}
-      const err = new Error(`Failed to fetch Bitbucket patch: ${response.status} ${response.statusText}`);
-      err.bitbucketAuthRequired = authRequired;
-      err.serverMessage = serverMessage;
-      throw err;
-    }
-    const patchContent = await response.text();
-    dbgLog('Successfully fetched Bitbucket diff, length:', patchContent.length);
-    return { success: true, content: patchContent };
-  } catch (error) {
-    dbgError('Error fetching Bitbucket patch:', error?.message || String(error));
-    const msg = String(error && error.message || '');
-    const authRequired = (error && error.bitbucketAuthRequired === true) || /401|403|unauthorized|forbidden/i.test(msg);
-    return {
-      success: false,
-      error: error?.message || msg || 'Request failed',
-      bitbucketAuthRequired: authRequired,
-      serverMessage: error?.serverMessage || null
-    };
+  if (isDataCenterUrl(diffUrl)) {
+    return fetchDataCenterPatchContent(diffUrl, { token });
   }
+  return fetchCloudPatchContent(diffUrl, { token, email });
 }

--- a/services/bitbucket-cloud-api.js
+++ b/services/bitbucket-cloud-api.js
@@ -1,0 +1,90 @@
+// bitbucket-cloud-api.js
+// Fetches PR diff/patch from Bitbucket Cloud (api.bitbucket.org).
+// Auth: HTTP Basic using Atlassian account email + app-password.
+// Flow: diff URL → PR API (to resolve links.diff.href) → GET diff text.
+import { dbgLog, dbgError } from '../utils/logger.js';
+import { parseBitbucketPrDiffUrl, getBitbucketPrApiUrl } from '../utils/bitbucket-api-urls.js';
+
+/**
+ * Build Basic auth headers for Bitbucket Cloud (email + app-password).
+ * Falls back to Bearer when no email is provided.
+ * @param {string|null} token
+ * @param {string|null} email
+ * @returns {Record<string, string>}
+ */
+function buildCloudAuthHeaders(token, email) {
+  const headers = { 'Accept': 'application/json' };
+  if (!token) return headers;
+  if (email) {
+    try {
+      const encoded = btoa(unescape(encodeURIComponent(`${email}:${token}`)));
+      headers['Authorization'] = `Basic ${encoded}`;
+    } catch (_) {
+      headers['Authorization'] = `Bearer ${token}`;
+    }
+  } else {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+  return headers;
+}
+
+/**
+ * Fetch Bitbucket Cloud PR diff as unified patch text.
+ *
+ * @param {string} diffUrl - api.bitbucket.org diff URL
+ * @param {{ token: string|null, email: string|null }} credentials
+ * @returns {Promise<{ success: true, content: string } | { success: false, error: string, bitbucketAuthRequired: boolean, serverMessage: string|null }>}
+ */
+export async function fetchCloudPatchContent(diffUrl, { token, email }) {
+  const trimmedToken = token && String(token).trim() ? token.trim() : null;
+  const trimmedEmail = email && String(email).trim() ? String(email).trim() : null;
+  const headers = buildCloudAuthHeaders(trimmedToken, trimmedEmail);
+
+  try {
+    // Resolve the actual diff URL via the PR API (avoids a 302 redirect on the direct diff URL)
+    const parsed = parseBitbucketPrDiffUrl(diffUrl);
+    let urlToFetch = diffUrl;
+
+    if (parsed) {
+      const prApiUrl = getBitbucketPrApiUrl(parsed.workspace, parsed.repoSlug, parsed.prId);
+      dbgLog('Fetching Bitbucket Cloud PR:', prApiUrl);
+      const prRes = await fetch(prApiUrl, { headers });
+      if (!prRes.ok) {
+        const authRequired = prRes.status === 401 || prRes.status === 403;
+        let serverMessage = null;
+        try { serverMessage = (await prRes.text()).trim() || null; } catch (_) {}
+        const err = new Error(`Failed to fetch Bitbucket PR: ${prRes.status} ${prRes.statusText}`);
+        err.bitbucketAuthRequired = authRequired;
+        err.serverMessage = serverMessage;
+        throw err;
+      }
+      const prJson = await prRes.json();
+      const diffHref = prJson?.links?.diff?.href;
+      if (!diffHref) throw new Error('Bitbucket PR response missing links.diff.href');
+      urlToFetch = diffHref;
+      dbgLog('Fetching Bitbucket Cloud diff from links.diff.href');
+    } else {
+      dbgLog('Fetching Bitbucket Cloud diff from:', diffUrl, trimmedToken ? '(with auth)' : '(no token)');
+    }
+
+    const response = await fetch(urlToFetch, { headers: { ...headers, 'Accept': 'text/plain,*/*' } });
+    if (!response.ok) {
+      const authRequired = response.status === 401 || response.status === 403;
+      let serverMessage = null;
+      try { serverMessage = (await response.text()).trim() || null; } catch (_) {}
+      const err = new Error(`Failed to fetch Bitbucket patch: ${response.status} ${response.statusText}`);
+      err.bitbucketAuthRequired = authRequired;
+      err.serverMessage = serverMessage;
+      throw err;
+    }
+
+    const content = await response.text();
+    dbgLog('Successfully fetched Bitbucket Cloud diff, length:', content.length);
+    return { success: true, content };
+  } catch (error) {
+    dbgError('Error fetching Bitbucket Cloud patch:', error?.message || String(error));
+    const msg = String(error?.message || '');
+    const authRequired = error?.bitbucketAuthRequired === true || /401|403|unauthorized|forbidden/i.test(msg);
+    return { success: false, error: msg || 'Request failed', bitbucketAuthRequired: authRequired, serverMessage: error?.serverMessage || null };
+  }
+}

--- a/services/bitbucket-dc-api.js
+++ b/services/bitbucket-dc-api.js
@@ -1,0 +1,135 @@
+// bitbucket-dc-api.js
+// Fetches PR diff/patch from Bitbucket Data Center (self-hosted).
+// Auth: Bearer token (HTTP access token). Basic auth is often disabled on DC instances.
+// The DC diff endpoint always returns JSON (diffs/hunks/segments), never unified diff text,
+// so responses are converted to unified patch format before being returned.
+import { dbgLog, dbgError } from '../utils/logger.js';
+
+/**
+ * Build Bearer auth headers for Bitbucket Data Center.
+ * HTTP access tokens are self-contained — no username is required.
+ * @param {string|null} token
+ * @returns {Record<string, string>}
+ */
+function buildDataCenterAuthHeaders(token) {
+  const headers = { 'Accept': 'application/json' };
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+  return headers;
+}
+
+/**
+ * Convert Bitbucket Data Center diff JSON to unified diff (patch) format.
+ *
+ * DC diff JSON structure:
+ *   { diffs: [ { source, destination, binary, hunks: [
+ *     { sourceLine, sourceSpan, destinationLine, destinationSpan, context,
+ *       segments: [ { type: 'CONTEXT'|'ADDED'|'REMOVED', lines: [{ line }] } ] }
+ *   ] } ] }
+ *
+ * @param {Object} diffJson - Parsed JSON from /rest/api/1.0/…/pull-requests/{id}/diff
+ * @returns {string} Unified diff text
+ */
+export function convertDataCenterDiffToUnifiedPatch(diffJson) {
+  const output = [];
+  const diffs = diffJson.diffs || diffJson.values || [];
+
+  for (const diff of diffs) {
+    const srcPath = diff.source?.toString ?? null;
+    const dstPath = diff.destination?.toString ?? null;
+    const aPath = srcPath || dstPath || 'unknown';
+    const bPath = dstPath || srcPath || 'unknown';
+
+    output.push(`diff --git a/${aPath} b/${bPath}`);
+
+    if (diff.binary) {
+      output.push(`Binary files a/${aPath} and b/${bPath} differ`);
+      continue;
+    }
+
+    if (!srcPath && dstPath) {
+      output.push('new file mode 100644');
+      output.push('--- /dev/null');
+      output.push(`+++ b/${dstPath}`);
+    } else if (srcPath && !dstPath) {
+      output.push('deleted file mode 100644');
+      output.push(`--- a/${srcPath}`);
+      output.push('+++ /dev/null');
+    } else {
+      output.push(`--- a/${aPath}`);
+      output.push(`+++ b/${bPath}`);
+    }
+
+    for (const hunk of (diff.hunks || [])) {
+      const srcStart = hunk.sourceLine      ?? 1;
+      const srcSpan  = hunk.sourceSpan      ?? 0;
+      const dstStart = hunk.destinationLine ?? 1;
+      const dstSpan  = hunk.destinationSpan ?? 0;
+      const ctx      = hunk.context ? ` ${hunk.context}` : '';
+      output.push(`@@ -${srcStart},${srcSpan} +${dstStart},${dstSpan} @@${ctx}`);
+
+      for (const segment of (hunk.segments || [])) {
+        const prefix = segment.type === 'ADDED' ? '+' : segment.type === 'REMOVED' ? '-' : ' ';
+        for (const ln of (segment.lines || [])) {
+          output.push(`${prefix}${ln.line ?? ''}`);
+        }
+      }
+    }
+  }
+
+  return output.join('\n') + (output.length ? '\n' : '');
+}
+
+/**
+ * Fetch Bitbucket Data Center PR diff and return it as unified patch text.
+ * Handles DC API pagination (isLastPage / nextPageStart) for large PRs.
+ *
+ * @param {string} diffUrl - {origin}/rest/api/1.0/…/pull-requests/{id}/diff
+ * @param {{ token: string|null }} credentials
+ * @returns {Promise<{ success: true, content: string } | { success: false, error: string, bitbucketAuthRequired: boolean, serverMessage: string|null }>}
+ */
+export async function fetchDataCenterPatchContent(diffUrl, { token }) {
+  const trimmedToken = token && String(token).trim() ? token.trim() : null;
+  const headers = buildDataCenterAuthHeaders(trimmedToken);
+
+  try {
+    const allDiffs = [];
+    let fetchUrl = diffUrl;
+    let pageCount = 0;
+    const MAX_PAGES = 20;
+
+    while (fetchUrl && pageCount < MAX_PAGES) {
+      pageCount++;
+      dbgLog(`Fetching Bitbucket Data Center diff (page ${pageCount}):`, fetchUrl, trimmedToken ? '(Bearer auth)' : '(no token)');
+
+      const response = await fetch(fetchUrl, { headers });
+      if (!response.ok) {
+        const authRequired = response.status === 401 || response.status === 403;
+        let serverMessage = null;
+        try { serverMessage = (await response.text()).trim() || null; } catch (_) {}
+        const err = new Error(`Failed to fetch Bitbucket Data Center patch: ${response.status} ${response.statusText}`);
+        err.bitbucketAuthRequired = authRequired;
+        err.serverMessage = serverMessage;
+        throw err;
+      }
+
+      const diffJson = await response.json();
+      allDiffs.push(...(diffJson.diffs || diffJson.values || []));
+
+      if (!diffJson.isLastPage && diffJson.nextPageStart != null) {
+        const sep = diffUrl.includes('?') ? '&' : '?';
+        fetchUrl = `${diffUrl}${sep}start=${diffJson.nextPageStart}`;
+      } else {
+        fetchUrl = null;
+      }
+    }
+
+    const content = convertDataCenterDiffToUnifiedPatch({ diffs: allDiffs });
+    dbgLog('Converted Bitbucket Data Center diff to unified patch, files:', allDiffs.length, 'length:', content.length);
+    return { success: true, content };
+  } catch (error) {
+    dbgError('Error fetching Bitbucket Data Center patch:', error?.message || String(error));
+    const msg = String(error?.message || '');
+    const authRequired = error?.bitbucketAuthRequired === true || /401|403|unauthorized|forbidden/i.test(msg);
+    return { success: false, error: msg || 'Request failed', bitbucketAuthRequired: authRequired, serverMessage: error?.serverMessage || null };
+  }
+}

--- a/services/bitbucket-detector.js
+++ b/services/bitbucket-detector.js
@@ -1,7 +1,11 @@
 // bitbucket-detector.js
-// Detects Bitbucket Cloud pull request pages and extracts relevant information
+// Detects Bitbucket Cloud and Bitbucket Data Center pull request pages and extracts relevant information
 import { dbgLog, dbgWarn, dbgError } from '../utils/logger.js';
-import { getBitbucketDiffApiUrl } from '../utils/bitbucket-api-urls.js';
+import {
+  getBitbucketDiffApiUrl,
+  parseBitbucketDataCenterPrPath,
+  getBitbucketDataCenterDiffApiUrl
+} from '../utils/bitbucket-api-urls.js';
 
 /**
  * Parse Bitbucket PR URL path into workspace, repo_slug, and PR id.
@@ -28,12 +32,14 @@ function parseBitbucketPRFromPath(pathname) {
 
 /**
  * Bitbucket Detector Service
- * Handles detection of Bitbucket Cloud pull request pages and extraction of PR information
+ * Handles detection of Bitbucket Cloud and Bitbucket Data Center pull request pages
  */
 export class BitbucketDetector {
   constructor() {
     this.isInitialized = false;
     this.currentPageInfo = null;
+    /** @type {string[]} Normalized hostnames for Bitbucket Data Center instances */
+    this.customDomains = [];
   }
 
   /**
@@ -47,35 +53,63 @@ export class BitbucketDetector {
   }
 
   /**
-   * Check if the current page is on Bitbucket Cloud (bitbucket.org)
+   * Set custom Bitbucket Data Center domains (self-hosted).
+   * @param {string[]} domains - Array of domain URLs or hostnames from storage
+   */
+  setCustomDomains(domains) {
+    this.customDomains = (domains || []).map(d => {
+      try {
+        const hasProtocol = d.startsWith('http://') || d.startsWith('https://');
+        return new URL(hasProtocol ? d : `https://${d}`).hostname;
+      } catch {
+        return d;
+      }
+    }).filter(Boolean);
+    dbgLog('Bitbucket Data Center custom domains set:', this.customDomains);
+  }
+
+  /**
+   * Check if the current hostname is a configured Bitbucket Data Center instance.
+   * @returns {boolean}
+   */
+  isDataCenterDomain() {
+    return this.customDomains.includes(window.location.hostname);
+  }
+
+  /**
+   * Check if the current page is on Bitbucket Cloud (bitbucket.org) or a Data Center instance.
    * @returns {boolean}
    */
   isBitbucketDomain() {
-    const hostname = window.location.hostname;
-    return hostname === 'bitbucket.org';
+    return window.location.hostname === 'bitbucket.org' || this.isDataCenterDomain();
   }
 
   /**
-   * Check if the current page is a Bitbucket pull request page
-   * @returns {boolean} True if the current page is a Bitbucket PR page
+   * Check if the current page is a Bitbucket pull request page (Cloud or Data Center).
+   * @returns {boolean}
    */
   isBitbucketPRPage() {
     const hostname = window.location.hostname;
-    if (hostname !== 'bitbucket.org') {
-      return false;
+
+    if (hostname === 'bitbucket.org') {
+      const prInfo = parseBitbucketPRFromPath(window.location.pathname);
+      const isPRPath = !!prInfo;
+      dbgLog('Bitbucket Cloud PR detection:', { isPRPath, url: window.location.href.substring(0, 100) + '...' });
+      return isPRPath;
     }
-    const prInfo = parseBitbucketPRFromPath(window.location.pathname);
-    const isPRPath = !!prInfo;
-    dbgLog('Bitbucket PR detection:', {
-      isBitbucketDomain: true,
-      isPRPath,
-      url: window.location.href.substring(0, 100) + '...'
-    });
-    return isPRPath;
+
+    if (this.isDataCenterDomain()) {
+      const prInfo = parseBitbucketDataCenterPrPath(window.location.pathname);
+      const isPRPath = !!prInfo;
+      dbgLog('Bitbucket Data Center PR detection:', { isPRPath, url: window.location.href.substring(0, 100) + '...' });
+      return isPRPath;
+    }
+
+    return false;
   }
 
   /**
-   * Extract pull request information from the current page
+   * Extract pull request information from the current page (Cloud or Data Center).
    * @returns {Object|null} Pull request information or null if not found
    */
   extractPRInfo() {
@@ -84,16 +118,45 @@ export class BitbucketDetector {
     }
 
     try {
-      const parsed = parseBitbucketPRFromPath(window.location.pathname);
+      const hostname = window.location.hostname;
+      const isDataCenter = this.isDataCenterDomain();
+
+      if (!isDataCenter) {
+        const parsed = parseBitbucketPRFromPath(window.location.pathname);
+        const prInfo = {
+          url: window.location.href,
+          hostname,
+          prId: parsed.prId,
+          workspace: parsed.workspace,
+          repoSlug: parsed.repoSlug,
+          isDataCenter: false,
+          repository: {
+            name: parsed.repoSlug,
+            fullName: `${parsed.workspace}/${parsed.repoSlug}`
+          },
+          title: this.extractPRTitle(),
+          sourceBranch: this.extractSourceBranch(),
+          targetBranch: this.extractTargetBranch(),
+          status: this.extractPRStatus(),
+          author: this.extractAuthor(),
+          timestamp: Date.now()
+        };
+        dbgLog('Extracted Bitbucket Cloud PR info:', prInfo);
+        return prInfo;
+      }
+
+      const parsed = parseBitbucketDataCenterPrPath(window.location.pathname);
       const prInfo = {
         url: window.location.href,
-        hostname: window.location.hostname,
+        hostname,
         prId: parsed.prId,
-        workspace: parsed.workspace,
+        namespace: parsed.namespace,
+        namespaceType: parsed.namespaceType,
         repoSlug: parsed.repoSlug,
+        isDataCenter: true,
         repository: {
           name: parsed.repoSlug,
-          fullName: `${parsed.workspace}/${parsed.repoSlug}`
+          fullName: `${parsed.namespace}/${parsed.repoSlug}`
         },
         title: this.extractPRTitle(),
         sourceBranch: this.extractSourceBranch(),
@@ -102,8 +165,7 @@ export class BitbucketDetector {
         author: this.extractAuthor(),
         timestamp: Date.now()
       };
-
-      dbgLog('Extracted Bitbucket PR info:', prInfo);
+      dbgLog('Extracted Bitbucket Data Center PR info:', prInfo);
       return prInfo;
     } catch (error) {
       dbgWarn('Error extracting Bitbucket PR info:', error);
@@ -112,12 +174,24 @@ export class BitbucketDetector {
   }
 
   /**
-   * Get the Bitbucket API 2.0 URL for PR diff.
-   * Returns the pullrequests/{id}/diff form; background resolves this to the repository diff
-   * URL (repositories/.../diff/...:commit?from_pullrequest_id=...) via PR API to avoid 302.
-   * @returns {string|null} e.g. https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests/1/diff
+   * Get the API URL for fetching the PR diff.
+   * - Cloud: api.bitbucket.org/2.0/repositories/{ws}/{repo}/pullrequests/{id}/diff
+   * - Data Center: {origin}/rest/api/1.0/{projects|users}/{ns}/repos/{repo}/pull-requests/{id}/diff
+   * @returns {string|null}
    */
   getPatchApiUrl() {
+    if (this.isDataCenterDomain()) {
+      const parsed = parseBitbucketDataCenterPrPath(window.location.pathname);
+      if (!parsed) return null;
+      return getBitbucketDataCenterDiffApiUrl(
+        window.location.origin,
+        parsed.namespaceType,
+        parsed.namespace,
+        parsed.repoSlug,
+        parsed.prId
+      );
+    }
+
     const parsed = parseBitbucketPRFromPath(window.location.pathname);
     if (!parsed) return null;
     return getBitbucketDiffApiUrl(parsed.workspace, parsed.repoSlug, parsed.prId);

--- a/services/platform-detector.js
+++ b/services/platform-detector.js
@@ -323,6 +323,14 @@ export class PlatformDetector {
   }
 
   /**
+   * Set custom Bitbucket Data Center domains (self-hosted). Call after init.
+   * @param {string[]} domains - Array of URLs or hostnames from storage (bitbucketDataCenterDomains)
+   */
+  setBitbucketCustomDomains(domains) {
+    bitbucketDetector.setCustomDomains(domains || []);
+  }
+
+  /**
    * Check if we're on an Azure DevOps site (regardless of being on a PR page)
    * @returns {boolean} True if on Azure DevOps domain (built-in or custom)
    */

--- a/utils/bitbucket-api-urls.js
+++ b/utils/bitbucket-api-urls.js
@@ -1,10 +1,18 @@
 // bitbucket-api-urls.js
-// Shared Bitbucket API 2.0 URL parsing and construction. Used by background.js and bitbucket-detector.js.
+// Shared Bitbucket API 2.0 (Cloud) and Data Center REST API URL parsing and construction.
+// Used by background.js and bitbucket-detector.js.
 
 const BITBUCKET_API_BASE = 'https://api.bitbucket.org/2.0';
 
 /** Regex for .../repositories/{workspace}/{repoSlug}/pullrequests/{prId}/diff */
 const PR_DIFF_PATH_REGEX = /\/repositories\/([^/]+)\/([^/]+)\/pullrequests\/(\d+)\/diff/;
+
+/**
+ * Regex for Bitbucket Data Center PR paths:
+ *   /projects/{projectKey}/repos/{repoSlug}/pull-requests/{id}[/...]
+ *   /users/{username}/repos/{repoSlug}/pull-requests/{id}[/...]
+ */
+const DC_PR_PATH_REGEX = /\/(projects|users)\/([^/]+)\/repos\/([^/]+)\/pull-requests\/(\d+)/;
 
 /**
  * Parse a Bitbucket API diff URL into workspace, repoSlug, and prId.
@@ -38,4 +46,51 @@ export function getBitbucketPrApiUrl(workspace, repoSlug, prId) {
  */
 export function getBitbucketDiffApiUrl(workspace, repoSlug, prId) {
   return `${BITBUCKET_API_BASE}/repositories/${workspace}/${repoSlug}/pullrequests/${prId}/diff`;
+}
+
+// ---------------------------------------------------------------------------
+// Bitbucket Data Center (self-hosted) helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a Bitbucket Data Center PR path into namespace type, namespace, repoSlug, and prId.
+ * Supports:
+ *   /projects/{projectKey}/repos/{repoSlug}/pull-requests/{id}[/...]
+ *   /users/{username}/repos/{repoSlug}/pull-requests/{id}[/...]
+ *
+ * @param {string} pathname
+ * @returns {{ namespaceType: 'projects'|'users', namespace: string, repoSlug: string, prId: string } | null}
+ */
+export function parseBitbucketDataCenterPrPath(pathname) {
+  if (!pathname || typeof pathname !== 'string') return null;
+  const match = pathname.match(DC_PR_PATH_REGEX);
+  if (!match) return null;
+  return {
+    namespaceType: match[1],
+    namespace: match[2],
+    repoSlug: match[3],
+    prId: match[4]
+  };
+}
+
+/**
+ * Build the Bitbucket Data Center REST API 1.0 base URL for a given origin.
+ * @param {string} origin - e.g. 'https://bitbucket.mycompany.com'
+ * @returns {string}
+ */
+export function getBitbucketDataCenterApiBase(origin) {
+  return `${origin}/rest/api/1.0`;
+}
+
+/**
+ * Build the Bitbucket Data Center diff endpoint URL.
+ * @param {string} origin - e.g. 'https://bitbucket.mycompany.com'
+ * @param {'projects'|'users'} namespaceType
+ * @param {string} namespace - projectKey or username
+ * @param {string} repoSlug
+ * @param {string} prId
+ * @returns {string}
+ */
+export function getBitbucketDataCenterDiffApiUrl(origin, namespaceType, namespace, repoSlug, prId) {
+  return `${getBitbucketDataCenterApiBase(origin)}/${namespaceType}/${namespace}/repos/${repoSlug}/pull-requests/${prId}/diff`;
 }


### PR DESCRIPTION
1. Introduces comprehensive support for Bitbucket Data Center (self-hosted) instances, complementing the existing Bitbucket Cloud integration.
2. Refactors the Bitbucket API service into a modular architecture, utilizing a router to delegate requests to platform-specific implementations (Cloud vs. Data Center).
3. Implements a custom JSON-to-Unified-Diff converter (`convertDataCenterDiffToUnifiedPatch`) to handle Bitbucket Data Center's lack of a native raw patch API endpoint.
4. Updates the background script to manage separate credential sets, using Bearer tokens for Data Center and Basic Auth for Cloud.
5. Enhances the extension popup with a new configuration UI for managing custom domains, including dynamic permission requests via `chrome.permissions.request`.
6. Adds robust pagination logic for Data Center API calls to ensure large pull requests are fully captured across multiple API pages.
7. Improves error handling by surfacing raw server error messages directly in the UI, aiding users in debugging connectivity or permission issues.