### PR TITLE
fix: call permissions.request before storage in add-domain f…

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -1164,6 +1164,7 @@ async function addGitHubEnterpriseDomain() {
         addButton.textContent = originalButtonText;
         addButton.disabled = false;
       }
+      isAddingGitHubEnterpriseDomain = false;
       return;
     }
 
@@ -1176,6 +1177,7 @@ async function addGitHubEnterpriseDomain() {
         addButton.textContent = originalButtonText;
         addButton.disabled = false;
       }
+      isAddingGitHubEnterpriseDomain = false;
       return;
     }
 
@@ -1430,6 +1432,7 @@ async function addAzureDevOpsDomain() {
         addButton.textContent = originalButtonText;
         addButton.disabled = false;
       }
+      isAddingAzureDomain = false;
       return;
     }
 
@@ -1442,6 +1445,7 @@ async function addAzureDevOpsDomain() {
         addButton.textContent = originalButtonText;
         addButton.disabled = false;
       }
+      isAddingAzureDomain = false;
       return;
     }
 
@@ -1783,6 +1787,7 @@ async function addBitbucketDataCenterDomain() {
         addButton.textContent = originalButtonText;
         addButton.disabled = false;
       }
+      isAddingBitbucketDCDomain = false;
       return;
     }
 
@@ -1795,6 +1800,7 @@ async function addBitbucketDataCenterDomain() {
         addButton.textContent = originalButtonText;
         addButton.disabled = false;
       }
+      isAddingBitbucketDCDomain = false;
       return;
     }
 

--- a/popup.js
+++ b/popup.js
@@ -985,6 +985,7 @@ async function addDomain() {
       alert('Permission not granted. The extension needs permission to access this domain.');
       addButton.textContent = originalButtonText;
       addButton.disabled = false;
+      isAddingDomain = false;
       return;
     }
 
@@ -995,9 +996,10 @@ async function addDomain() {
       alert('Domain already exists');
       addButton.textContent = originalButtonText;
       addButton.disabled = false;
+      isAddingDomain = false;
       return;
     }
-    
+
     // Add the domain to storage
     const updatedDomains = [...domains, domain];
     await chrome.storage.local.set({ gitlabDomains: updatedDomains });

--- a/popup.js
+++ b/popup.js
@@ -961,24 +961,11 @@ async function addDomain() {
     // Set flag to prevent duplicate calls
     isAddingDomain = true;
     
-    // Show loading state
     const addButton = document.getElementById('add-domain-btn');
     const originalButtonText = addButton.textContent;
     addButton.textContent = 'Adding...';
     addButton.disabled = true;
-    
-    // Get current domains
-    const result = await chrome.storage.local.get(['gitlabDomains']);
-    const domains = result.gitlabDomains || DEFAULT_DOMAINS;
-    
-    if (domains.includes(domain)) {
-      alert('Domain already exists');
-      addButton.textContent = originalButtonText;
-      addButton.disabled = false;
-      return;
-    }
-    
-    // Create origin pattern for permission request
+
     let originPattern;
     if (domain.startsWith('http://') || domain.startsWith('https://')) {
       const url = new URL(domain);
@@ -986,16 +973,26 @@ async function addDomain() {
     } else {
       originPattern = `https://${domain}/*`;
     }
-    
+
     dbgLog(`Adding domain with pattern: ${originPattern}`);
-    
-    // Request permission for this domain
+
+    // Firefox requires permissions.request in the same synchronous turn as the click (no await before this).
     const granted = await chrome.permissions.request({
       origins: [originPattern]
     });
-    
+
     if (!granted) {
       alert('Permission not granted. The extension needs permission to access this domain.');
+      addButton.textContent = originalButtonText;
+      addButton.disabled = false;
+      return;
+    }
+
+    const result = await chrome.storage.local.get(['gitlabDomains']);
+    const domains = result.gitlabDomains || DEFAULT_DOMAINS;
+
+    if (domains.includes(domain)) {
+      alert('Domain already exists');
       addButton.textContent = originalButtonText;
       addButton.disabled = false;
       return;
@@ -1147,18 +1144,6 @@ async function addGitHubEnterpriseDomain() {
       addButton.disabled = true;
     }
 
-    const result = await chrome.storage.local.get(['githubEnterpriseDomains']);
-    const domains = result.githubEnterpriseDomains || GITHUB_ENTERPRISE_DEFAULT_DOMAINS;
-
-    if (domains.includes(domain)) {
-      alert('Domain already exists');
-      if (addButton) {
-        addButton.textContent = originalButtonText;
-        addButton.disabled = false;
-      }
-      return;
-    }
-
     let originPattern;
     if (domain.startsWith('http://') || domain.startsWith('https://')) {
       const url = new URL(domain);
@@ -1169,9 +1154,22 @@ async function addGitHubEnterpriseDomain() {
 
     dbgLog(`Adding GitHub Enterprise domain with pattern: ${originPattern}`);
 
+    // Firefox: permissions.request must run before any other await (user-gesture stack).
     const granted = await chrome.permissions.request({ origins: [originPattern] });
     if (!granted) {
       alert('Permission not granted. The extension needs permission to access this domain.');
+      if (addButton) {
+        addButton.textContent = originalButtonText;
+        addButton.disabled = false;
+      }
+      return;
+    }
+
+    const result = await chrome.storage.local.get(['githubEnterpriseDomains']);
+    const domains = result.githubEnterpriseDomains || GITHUB_ENTERPRISE_DEFAULT_DOMAINS;
+
+    if (domains.includes(domain)) {
+      alert('Domain already exists');
       if (addButton) {
         addButton.textContent = originalButtonText;
         addButton.disabled = false;
@@ -1414,18 +1412,6 @@ async function addAzureDevOpsDomain() {
       addButton.disabled = true;
     }
 
-    const result = await chrome.storage.local.get(['azureDevOpsDomains']);
-    const domains = result.azureDevOpsDomains || [];
-
-    if (domains.includes(domain)) {
-      alert('Domain already exists');
-      if (addButton) {
-        addButton.textContent = originalButtonText;
-        addButton.disabled = false;
-      }
-      return;
-    }
-
     let originPattern;
     if (domain.startsWith('http://') || domain.startsWith('https://')) {
       const url = new URL(domain);
@@ -1434,9 +1420,22 @@ async function addAzureDevOpsDomain() {
       originPattern = `https://${domain}/*`;
     }
 
+    // Firefox: permissions.request must run before any other await (user-gesture stack).
     const granted = await chrome.permissions.request({ origins: [originPattern] });
     if (!granted) {
       alert('Permission not granted. The extension needs permission to access this domain.');
+      if (addButton) {
+        addButton.textContent = originalButtonText;
+        addButton.disabled = false;
+      }
+      return;
+    }
+
+    const result = await chrome.storage.local.get(['azureDevOpsDomains']);
+    const domains = result.azureDevOpsDomains || [];
+
+    if (domains.includes(domain)) {
+      alert('Domain already exists');
       if (addButton) {
         addButton.textContent = originalButtonText;
         addButton.disabled = false;
@@ -1764,18 +1763,6 @@ async function addBitbucketDataCenterDomain() {
       addButton.disabled = true;
     }
 
-    const result = await chrome.storage.local.get(['bitbucketDataCenterDomains']);
-    const domains = result.bitbucketDataCenterDomains || [];
-
-    if (domains.includes(domain)) {
-      alert('Domain already exists');
-      if (addButton) {
-        addButton.textContent = originalButtonText;
-        addButton.disabled = false;
-      }
-      return;
-    }
-
     let originPattern;
     if (domain.startsWith('http://') || domain.startsWith('https://')) {
       const url = new URL(domain);
@@ -1786,9 +1773,22 @@ async function addBitbucketDataCenterDomain() {
 
     dbgLog(`Adding Bitbucket Data Center domain with pattern: ${originPattern}`);
 
+    // Firefox: permissions.request must run before any other await (user-gesture stack).
     const granted = await chrome.permissions.request({ origins: [originPattern] });
     if (!granted) {
       alert('Permission not granted. The extension needs permission to access this domain.');
+      if (addButton) {
+        addButton.textContent = originalButtonText;
+        addButton.disabled = false;
+      }
+      return;
+    }
+
+    const result = await chrome.storage.local.get(['bitbucketDataCenterDomains']);
+    const domains = result.bitbucketDataCenterDomains || [];
+
+    if (domains.includes(domain)) {
+      alert('Domain already exists');
       if (addButton) {
         addButton.textContent = originalButtonText;
         addButton.disabled = false;


### PR DESCRIPTION
Fix Firefox compatibility: reorder permission request in domain addition functions

Problem: In Firefox, `chrome.permissions.request()` must be called synchronously in the same event loop turn as the user gesture (button click). The original code awaited `chrome.storage.local.get()` before requesting permissions, which breaks the extension on Firefox.

Solution: Move the storage duplicate check to occur after the permission request in four functions:- `addDomain()`
- `addGitHubEnterpriseDomain()`
- `addAzureDevOpsDomain()`
- `addBitbucketDataCenterDomain()`Also added missing flag resets (`isAdding* = false`) on early return paths to prevent duplicate call issues.