### PR TITLE
docs(ollama): recommend Gemma 4 and align defaults

### DIFF
--- a/OLLAMA_SETUP.md
+++ b/OLLAMA_SETUP.md
@@ -32,28 +32,40 @@ Download the installer from [ollama.ai/download](https://ollama.ai/download)
 
 ### 2. Pull a Code Review Model
 
-**We recommend [Codestral](https://ollama.com/library/codestral:latest)** — it currently produces the best results for code review with ThinkReview (Mistral AI’s 22B code model, 32k context, 80+ languages).
+**We recommend [Gemma 4](https://ollama.com/library/gemma4)** — Google DeepMind’s multimodal family with strong coding and reasoning, native function calling, and a **128K** context window on the default and edge variants (larger variants offer **256K**). For ThinkReview, start with the default tag or pick a size that fits your RAM:
 
-You can also try **[gpt-oss](https://ollama.com/library/gpt-oss)** (OpenAI’s open-weight models; 20B and 120B variants with strong reasoning and 128K context).
+- **`gemma4`** (latest, ~9.6GB) — default choice for strong overall quality  
+- **`gemma4:e4b`** / **`gemma4:e2b`** — smaller “effective” models for laptops and limited VRAM  
+- **`gemma4:26b`** / **`gemma4:31b`** — workstation-class local models (larger download)  
+- **`gemma4:31b-cloud`** — runs via Ollama’s cloud when you prefer not to host the full 31B locally  
 
-**Tested models:**
-- `codestral` - **Recommended** — best results
-- `qwen2.5-coder:30b` - Tested and recommended
-- `qwen2.5:8b` - Tested and recommended
+**Sampling (optional):** For Gemma 4, Ollama’s docs suggest `temperature=1.0`, `top_p=0.95`, and `top_k=64` as a standardized setup; you can set these in the extension’s Ollama settings.
+
+**Also worth trying:** [Codestral](https://ollama.com/library/codestral:latest), [gpt-oss](https://ollama.com/library/gpt-oss), and coder-focused models below.
+
+**Tested / common alternatives:**
+- `gemma4` — **Recommended** — best default for ThinkReview with Ollama  
+- `codestral` — Strong code model (Mistral, 32k context)  
+- `qwen2.5-coder:30b` / `qwen3-coder:30b` — Widely used for code  
+- `qwen2.5:8b` — Lighter option  
 
 ```bash
-# Recommended (best results)
+# Recommended (best results with Ollama + ThinkReview)
+ollama pull gemma4
+
+# Smaller or larger Gemma 4 variants (pick one that fits your machine)
+ollama pull gemma4:e4b
+ollama pull gemma4:e2b
+ollama pull gemma4:26b
+ollama pull gemma4:31b
+
+# Other strong options
 ollama pull codestral
-
-# Other tested models
 ollama pull qwen2.5-coder:30b
-ollama pull qwen2.5:8b
-
-# Also worth trying
 ollama pull gpt-oss:20b            # OpenAI open-weight, 128K context
-ollama pull codellama              # Fast, 4GB
-ollama pull qwen2.5-coder:7b       # Good balance, 5GB
-ollama pull deepseek-coder:6.7b    # Code-focused, 4GB
+ollama pull codellama              # Fast, smaller footprint
+ollama pull qwen2.5-coder:7b
+ollama pull deepseek-coder:6.7b
 ```
 
 ### 3. Start Ollama Server with CORS Enabled
@@ -166,10 +178,11 @@ Once configured, ThinkReview will automatically use Ollama for all code reviews:
 
 | Model | Size | Status |
 |-------|------|--------|
-| [codestral](https://ollama.com/library/codestral:latest) | ~13GB | ✅ **Recommended** — best results |
+| [gemma4](https://ollama.com/library/gemma4) (default / e2b / e4b / 26b / 31b) | ~7GB–20GB+ | ✅ **Recommended** — best default with Ollama |
+| [codestral](https://ollama.com/library/codestral:latest) | ~13GB | ✅ Strong code reviews |
 | [gpt-oss](https://ollama.com/library/gpt-oss) (20b / 120b) | 14GB / 65GB | ✅ Strong reasoning, 128K context |
-| qwen2.5-coder:30b | ~20GB | ✅ Tested & Recommended |
-| qwen2.5:8b | ~5GB | ✅ Tested & Recommended |
+| qwen2.5-coder:30b / qwen3-coder:30b | ~20GB | ✅ Common coder picks |
+| qwen2.5:8b | ~5GB | ✅ Lighter option |
 
 Other models may work but are not officially tested.
 
@@ -185,7 +198,7 @@ CORS / allowed origins are not set correctly. Use **Option A** above to restart 
 
 ### Model Not Found
 1. List models: `ollama list`
-2. Pull the model: `ollama pull qwen2.5-coder:30b`
+2. Pull the model: `ollama pull gemma4` (or the tag you use, e.g. `gemma4:e4b`)
 3. Refresh in extension settings (🔄 button)
 
 ## Advanced

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ cd thinkreview-browser-extension
 **Cloud AI (Default)** - Works immediately, no setup required  
 **Local AI with Ollama** - For 100% private reviews:
 1. Follow the [Ollama Setup Guide](OLLAMA_SETUP.md) (30 seconds if model is downloaded)
-2. We recommend **[Codestral](https://ollama.com/library/codestral:latest)** for best results; [gpt-oss](https://ollama.com/library/gpt-oss) is also supported.
+2. We recommend **[Gemma 4](https://ollama.com/library/gemma4)** for best results with Ollama; [Codestral](https://ollama.com/library/codestral:latest) and [gpt-oss](https://ollama.com/library/gpt-oss) are solid alternatives.
 3. Open extension popup → Settings → Select "Local Ollama"
 3. That's it! Your reviews now run locally
 

--- a/background.js
+++ b/background.js
@@ -343,7 +343,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         if (provider === 'ollama') {
           // Use Ollama for conversational response
           try {
-            const config = settings.ollamaConfig || { url: 'http://localhost:11434', model: 'qwen3-coder:30b' };
+            const config = settings.ollamaConfig || { url: 'http://localhost:11434', model: 'gemma4' };
             
             dbgLog('Getting conversational response from Ollama:', config);
             
@@ -432,7 +432,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         if (provider === 'ollama') {
           // Use Ollama for local code review
           try {
-            const config = settings.ollamaConfig || { url: 'http://localhost:11434', model: 'qwen3-coder:30b' };
+            const config = settings.ollamaConfig || { url: 'http://localhost:11434', model: 'gemma4' };
             
             dbgLog('Reviewing with Ollama:', config);
             

--- a/components/integrated-review.js
+++ b/components/integrated-review.js
@@ -1463,8 +1463,12 @@ async function handleSendMessage(messageText) {
     appendToChatLog('ai', responseText, rawResponseText);
     conversationHistory.push({ role: 'model', content: responseText });
 
-    // Append context banner once, right after the first AI message
-    if (chatLog && !chatLog.querySelector('.thinkreview-context-banner')) {
+    // Append context banner once, right after the first AI message (cloud only — Ollama has no full-repo tool context)
+    if (
+      chatLog &&
+      !chatLog.querySelector('.thinkreview-context-banner') &&
+      aiResponse.provider !== 'ollama'
+    ) {
       const contextType = aiResponse.contextType || 'patch_only';
       chatLog.appendChild(createContextBanner(contextType));
     }

--- a/content.js
+++ b/content.js
@@ -1704,7 +1704,13 @@ window.getAIResponse = (patchContent, conversationHistory, language = 'English')
           return reject(chrome.runtime.lastError);
         }
         if (response && response.success) {
-          resolve(response.data);
+          const data = response.data;
+          const routedProvider = response.provider || 'cloud';
+          const merged =
+            data && typeof data === 'object' && !Array.isArray(data)
+              ? { ...data, provider: data.provider || routedProvider }
+              : { response: data, provider: routedProvider };
+          resolve(merged);
         } else {
           const error = new Error(response?.error || 'Failed to get AI response.');
           // Pass rate limit error properties if available

--- a/popup.html
+++ b/popup.html
@@ -392,6 +392,7 @@
               <div class="ollama-help">
                 <p class="help-text">
                   <strong>📖 <a href="https://github.com/Thinkode/thinkreview-browser-extension/blob/main/OLLAMA_SETUP.md" target="_blank">Full Setup Guide</a></strong>
+                  — recommended model: <a href="https://ollama.com/library/gemma4" target="_blank">gemma4</a> (<code>ollama pull gemma4</code>)
                 </p>
               </div>
             </div>

--- a/popup.js
+++ b/popup.js
@@ -2090,7 +2090,7 @@ async function loadAIProviderSettings() {
     const provider = result.aiProvider || 'cloud';
     const config = result.ollamaConfig || {
       url: 'http://localhost:11434',
-      model: 'qwen3-coder:30b',
+      model: 'gemma4',
       temperature: 0.3,
       top_p: 0.4,
       top_k: 90
@@ -2254,7 +2254,7 @@ async function fetchAndPopulateModels(url, savedModel = null) {
       dbgLog('Successfully loaded', modelsResult.models.length, 'models from Ollama');
     } else {
       modelSelect.innerHTML = '<option value="">⚠️ No models installed</option>';
-      showOllamaStatus('⚠️ No models found. Install one with: ollama pull qwen3-coder:30b', 'error');
+      showOllamaStatus('⚠️ No models found. Install one with: ollama pull gemma4', 'error');
     }
   } catch (error) {
     dbgWarn('Error fetching models:', error);
@@ -2392,7 +2392,7 @@ async function refreshOllamaModels() {
       updateModelSelect(modelsResult.models);
       showOllamaStatus(`✅ Found ${modelsResult.models.length} model(s)`, 'success');
     } else {
-      showOllamaStatus('⚠️ No models found. Pull a model first: ollama pull codellama', 'error');
+      showOllamaStatus('⚠️ No models found. Pull a model first: ollama pull gemma4', 'error');
     }
   } catch (error) {
     dbgWarn('Error refreshing models:', error);

--- a/services/ollama-service.js
+++ b/services/ollama-service.js
@@ -26,7 +26,7 @@ export class OllamaService {
     try {
       // Get Ollama config from storage
       const config = await chrome.storage.local.get(['ollamaConfig']);
-      const { url = 'http://localhost:11434', model = 'codellama', OllamaModelcontextLength: savedContextLength, temperature: temp, top_p: topP, top_k: topK } = config.ollamaConfig || {};
+      const { url = 'http://localhost:11434', model = 'gemma4', OllamaModelcontextLength: savedContextLength, temperature: temp, top_p: topP, top_k: topK } = config.ollamaConfig || {};
       const { temperature: tempClamped, top_p: topPClamped, top_k: topKClamped } = clampOllamaOptions({ temperature: temp, top_p: topP, top_k: topK });
       
       dbgLog(`Using Ollama at ${url} with model ${model}`);
@@ -254,7 +254,7 @@ Important: Respond ONLY with valid JSON. Do not include any explanatory text bef
       if (error.message.includes('Failed to fetch') || error.message.includes('NetworkError')) {
         throw new Error(`Cannot connect to Ollama at the configured URL. Please ensure Ollama is running and accessible.\n\nTroubleshooting:\n1. Check if Ollama is running: 'ollama serve'\n2. Verify the URL in settings\n3. Try accessing ${error.url || 'http://localhost:11434'} in your browser`);
       } else if (error.message.includes('model')) {
-        throw new Error(`Model error: ${error.message}\n\nMake sure the selected model is installed.\nRun: ollama pull ${error.model || 'codellama'}`);
+        throw new Error(`Model error: ${error.message}\n\nMake sure the selected model is installed.\nRun: ollama pull ${error.model || 'gemma4'}`);
       } else {
         throw new Error(`Ollama error: ${error.message}`);
       }
@@ -280,7 +280,7 @@ Important: Respond ONLY with valid JSON. Do not include any explanatory text bef
     try {
       // Get Ollama config from storage
       const config = await chrome.storage.local.get(['ollamaConfig']);
-      const { url = 'http://localhost:11434', model = 'codellama', temperature: temp, top_p: topP, top_k: topK } = config.ollamaConfig || {};
+      const { url = 'http://localhost:11434', model = 'gemma4', temperature: temp, top_p: topP, top_k: topK } = config.ollamaConfig || {};
       const { temperature: tempClamped, top_p: topPClamped, top_k: topKClamped } = clampOllamaOptions({ temperature: temp, top_p: topP, top_k: topK });
       
       dbgLog(`Using Ollama at ${url} with model ${model} for conversation`);
@@ -385,7 +385,7 @@ Your role is to answer questions about this code review in a helpful, concise ma
    * Parses model_info for *context_length or parameters for num_ctx.
    * When url or model are omitted, reads from stored ollamaConfig (popup settings).
    * @param {string} [url] - Ollama base URL (defaults to stored config or http://localhost:11434)
-   * @param {string} [model] - Model name (e.g. qwen3-coder:30b); defaults to stored config
+   * @param {string} [model] - Model name (e.g. gemma4); defaults to stored config
    * @returns {Promise<{contextLength: number|null, error: string|null}>}
    */
   static async getModelContextLength(url, model) {
@@ -506,12 +506,13 @@ Your role is to answer questions about this code review in a helpful, concise ma
    */
   static getRecommendedModels() {
     return [
-      { name: 'codellama:latest', description: 'Meta\'s Code Llama - Good all-around code model' },
-      { name: 'codellama:13b', description: 'Code Llama 13B - Better quality, slower' },
-      { name: 'deepseek-coder:6.7b', description: 'DeepSeek Coder - Excellent for code understanding' },
-      { name: 'qwen2.5-coder:7b', description: 'Qwen2.5 Coder - Strong code analysis' },
-      { name: 'starcoder2:15b', description: 'StarCoder2 - Great multi-language support' },
-      { name: 'codegemma:7b', description: 'Google\'s CodeGemma - Fast and capable' }
+      { name: 'gemma4', description: 'Gemma 4 (recommended) — strong coding & reasoning, 128K context' },
+      { name: 'gemma4:e4b', description: 'Gemma 4 E4B — edge-friendly, text + image, 128K context' },
+      { name: 'gemma4:e2b', description: 'Gemma 4 E2B — smallest edge variant, 128K context' },
+      { name: 'gemma4:26b', description: 'Gemma 4 26B MoE — workstation-class, 256K context' },
+      { name: 'gemma4:31b', description: 'Gemma 4 31B dense — largest local variant, 256K context' },
+      { name: 'codestral:latest', description: 'Codestral — Mistral code model, 32k context' },
+      { name: 'qwen2.5-coder:7b', description: 'Qwen2.5 Coder — strong code analysis, lighter weight' }
     ];
   }
 


### PR DESCRIPTION
1. Updated documentation (`OLLAMA_SETUP.md`, `README.md`) to recommend `gemma4` as the default local AI model instead of `codestral` or `qwen3-coder:30b`.
2. Added detailed information about various Gemma 4 model sizes and variants (e.g., `e4b`, `e2b`, `26b`, `31b`) and their recommended sampling parameters.
3. Changed the fallback model to `gemma4` in background scripts (`background.js`) and popup settings (`popup.js`).
4. Updated error messages and UI hints in `popup.html` and `popup.js` to prompt users to pull `gemma4` if no models are found.
5. Refreshed the list of recommended models in `ollama-service.js` to prominently feature Gemma 4 variants while retaining strong alternatives like Codestral and Qwen.