### PR TITLE
Feature/helpful tip usage and copy

### DIFF
--- a/components/helpful-tip-banner.js
+++ b/components/helpful-tip-banner.js
@@ -97,11 +97,13 @@ export function getHTML() {
 const USAGE_PORTAL_URL = 'https://portal.thinkreview.dev/usage';
 
 export function wireSettingsButton(container) {
+  const analyticsPromise = import(chrome.runtime.getURL('utils/analytics-service.js'));
+
   const settingsBtn = container.querySelector(`#${SETTINGS_BUTTON_ID}`);
   if (settingsBtn) {
     settingsBtn.addEventListener('click', async () => {
       try {
-        const { trackUserAction } = await import(chrome.runtime.getURL('utils/analytics-service.js'));
+        const { trackUserAction } = await analyticsPromise;
         trackUserAction('helpful_tip_banner_settings_clicked', {
           context: 'upgrade_prompt',
           location: 'integrated_panel'
@@ -119,7 +121,7 @@ export function wireSettingsButton(container) {
   if (usageBtn) {
     usageBtn.addEventListener('click', async () => {
       try {
-        const analyticsModule = await import(chrome.runtime.getURL('utils/analytics-service.js'));
+        const analyticsModule = await analyticsPromise;
         analyticsModule
           .trackUserAction(analyticsModule.KEY_EVENT_LIMIT_BANNER_VIEW_MY_USAGE, {
             context: 'daily_limit_upgrade_prompt',

--- a/components/helpful-tip-banner.js
+++ b/components/helpful-tip-banner.js
@@ -91,12 +91,12 @@ export function getHTML() {
 }
 
 /**
- * Wires the settings button click event to open the popup with deep-link.
+ * Wires the helpful tip banner action buttons (settings and usage).
  * @param {HTMLElement} container - The parent container of the banner
  */
 const USAGE_PORTAL_URL = 'https://portal.thinkreview.dev/usage';
 
-export function wireSettingsButton(container) {
+export function wireActionButtons(container) {
   const analyticsPromise = import(chrome.runtime.getURL('utils/analytics-service.js'));
 
   const settingsBtn = container.querySelector(`#${SETTINGS_BUTTON_ID}`);

--- a/components/helpful-tip-banner.js
+++ b/components/helpful-tip-banner.js
@@ -5,7 +5,8 @@
 
 // UI identifiers
 const STYLES_ID = 'helpful-tip-styles';
-const BUTTON_ID = 'helpful-tip-settings-btn';
+const SETTINGS_BUTTON_ID = 'helpful-tip-settings-btn';
+const USAGE_BUTTON_ID = 'helpful-tip-usage-btn';
 
 // Timing constants (in milliseconds)
 const ANALYTICS_IMPORT_TIMEOUT = 5000;
@@ -37,12 +38,19 @@ export function injectStyles() {
       margin-top: 1px;
     }
     .helpful-tip-text {
-      font-size: 12px;
+      font-size: 14px;
       color: #a0aec0;
-      line-height: 1.4;
+      line-height: 1.45;
       flex: 1;
     }
-    .helpful-tip-settings-btn {
+    .helpful-tip-actions {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      flex-shrink: 0;
+    }
+    .helpful-tip-settings-btn,
+    .helpful-tip-usage-btn {
       flex-shrink: 0;
       padding: 5px 10px;
       border-radius: 4px;
@@ -55,7 +63,8 @@ export function injectStyles() {
       white-space: nowrap;
       transition: background 0.15s, border-color 0.15s;
     }
-    .helpful-tip-settings-btn:hover {
+    .helpful-tip-settings-btn:hover,
+    .helpful-tip-usage-btn:hover {
       background: #3d4a5e;
       border-color: #6b4fbb;
       color: #e2e8f0;
@@ -73,7 +82,10 @@ export function getHTML() {
     <div class="helpful-tip-banner">
       <span class="helpful-tip-icon">💡</span>
       <span class="helpful-tip-text">You can switch the auto-review setting to manual mode to better manage your daily review credits.</span>
-      <button id="${BUTTON_ID}" class="helpful-tip-settings-btn">Go to Settings</button>
+      <div class="helpful-tip-actions">
+        <button id="${SETTINGS_BUTTON_ID}" type="button" class="helpful-tip-settings-btn">Go to Settings</button>
+        <button id="${USAGE_BUTTON_ID}" type="button" class="helpful-tip-usage-btn">View my usage</button>
+      </div>
     </div>
   `;
 }
@@ -82,10 +94,12 @@ export function getHTML() {
  * Wires the settings button click event to open the popup with deep-link.
  * @param {HTMLElement} container - The parent container of the banner
  */
+const USAGE_PORTAL_URL = 'https://portal.thinkreview.dev/usage';
+
 export function wireSettingsButton(container) {
-  const btn = container.querySelector(`#${BUTTON_ID}`);
-  if (btn) {
-    btn.addEventListener('click', async () => {
+  const settingsBtn = container.querySelector(`#${SETTINGS_BUTTON_ID}`);
+  if (settingsBtn) {
+    settingsBtn.addEventListener('click', async () => {
       try {
         const { trackUserAction } = await import(chrome.runtime.getURL('utils/analytics-service.js'));
         trackUserAction('helpful_tip_banner_settings_clicked', {
@@ -98,6 +112,22 @@ export function wireSettingsButton(container) {
         type: 'OPEN_EXTENSION_POPUP',
         scrollTo: 'auto-start-review-section'
       });
+    });
+  }
+
+  const usageBtn = container.querySelector(`#${USAGE_BUTTON_ID}`);
+  if (usageBtn) {
+    usageBtn.addEventListener('click', async () => {
+      try {
+        const { trackUserAction } = await import(chrome.runtime.getURL('utils/analytics-service.js'));
+        trackUserAction('helpful_tip_banner_usage_portal_clicked', {
+          context: 'upgrade_prompt',
+          location: 'integrated_panel',
+          url: USAGE_PORTAL_URL
+        }).catch(() => {});
+      } catch (_) { /* silent */ }
+
+      window.open(USAGE_PORTAL_URL, '_blank');
     });
   }
 }

--- a/components/helpful-tip-banner.js
+++ b/components/helpful-tip-banner.js
@@ -119,12 +119,15 @@ export function wireSettingsButton(container) {
   if (usageBtn) {
     usageBtn.addEventListener('click', async () => {
       try {
-        const { trackUserAction } = await import(chrome.runtime.getURL('utils/analytics-service.js'));
-        trackUserAction('helpful_tip_banner_usage_portal_clicked', {
-          context: 'upgrade_prompt',
-          location: 'integrated_panel',
-          url: USAGE_PORTAL_URL
-        }).catch(() => {});
+        const analyticsModule = await import(chrome.runtime.getURL('utils/analytics-service.js'));
+        analyticsModule
+          .trackUserAction(analyticsModule.KEY_EVENT_LIMIT_BANNER_VIEW_MY_USAGE, {
+            context: 'daily_limit_upgrade_prompt',
+            location: 'integrated_panel_helpful_tip',
+            destination: 'portal_usage',
+            url: USAGE_PORTAL_URL
+          })
+          .catch(() => {});
       } catch (_) { /* silent */ }
 
       window.open(USAGE_PORTAL_URL, '_blank');

--- a/content.js
+++ b/content.js
@@ -1069,7 +1069,7 @@ async function showUpgradeMessage(reviewCount, dailyLimit = 3, limitOverride = n
         }
       });
 
-      tipBannerModule.wireSettingsButton(upgradeWrapper);
+      tipBannerModule.wireActionButtons(upgradeWrapper);
     }
   );
 

--- a/popup.css
+++ b/popup.css
@@ -161,6 +161,12 @@ header {
   white-space: nowrap;
 }
 
+.portal-button .thinkreview-new-badge {
+  flex-shrink: 0;
+  overflow: visible;
+  text-overflow: clip;
+}
+
 .portal-button:hover {
   color: #202124;
   background: #e8eaed;

--- a/popup.html
+++ b/popup.html
@@ -37,6 +37,14 @@
               <span>Agents</span>
               <span class="thinkreview-new-badge">New</span>
             </button>
+            <button id="usage-btn" class="portal-button" aria-label="View my usage" title="View my usage">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M21.21 15.89A10 10 0 1 1 8 2.83"></path>
+                <path d="M22 12A10 10 0 0 0 12 2v10z"></path>
+              </svg>
+              <span>Usage</span>
+              <span class="thinkreview-new-badge">New</span>
+            </button>
             <button id="analytics-btn" class="portal-button" aria-label="Open Analytics" title="Analytics">
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M3 3v18h18"></path><rect x="5" y="8" width="3" height="10"></rect>

--- a/popup.js
+++ b/popup.js
@@ -572,6 +572,17 @@ document.addEventListener('DOMContentLoaded', async () => {
       chrome.tabs.create({ url: 'https://portal.thinkreview.dev/agents' });
     });
   }
+
+  const usageBtn = document.getElementById('usage-btn');
+  if (usageBtn) {
+    usageBtn.addEventListener('click', async () => {
+      try {
+        const { trackUserAction } = await import('./utils/analytics-service.js');
+        trackUserAction('usage_opened', { context: 'popup' }).catch(() => {});
+      } catch (e) { /* silent */ }
+      chrome.tabs.create({ url: 'https://portal.thinkreview.dev/usage' });
+    });
+  }
   
   const analyticsBtn = document.getElementById('analytics-btn');
   if (analyticsBtn) {

--- a/utils/analytics-service.js
+++ b/utils/analytics-service.js
@@ -110,6 +110,12 @@ export async function logToAnalytics(level, component, message, additionalData =
 }
 
 /**
+ * GA key event name: user opened the portal usage page from the daily-limit helpful tip
+ * ("View my usage"). Mark this event as a key event in GA4 if you track it as a conversion.
+ */
+export const KEY_EVENT_LIMIT_BANNER_VIEW_MY_USAGE = 'limit_reached_view_my_usage_clicked';
+
+/**
  * Track key user actions/events
  * @param {string} eventName - Event name that describes the action (e.g., 'copy_button', 'refresh_review', 'ai_review_clicked')
  * @param {Object} params - Additional parameters (e.g., { context: 'review_item', location: 'integrated_panel' })
@@ -122,5 +128,6 @@ export const AnalyticsService = {
   sendEvent,
   logToAnalytics,
   trackUserAction,
-  getClientId
+  getClientId,
+  KEY_EVENT_LIMIT_BANNER_VIEW_MY_USAGE
 };


### PR DESCRIPTION
This patch adds a new "View my usage" button to the helpful tip banner and a "Usage" button to the popup interface, both linking to the portal's usage page. 
Key changes include: (1) Added new button constants and CSS styling for the usage button in the helpful tip banner, (2) Created a wrapper div for action buttons with flexbox layout, (3) Extended the wireSettingsButton function to also wire the usage button with analytics tracking, 
(4) Added a new usage button in the popup header with an SVG icon, (5) Added a new analytics event constant KEY_EVENT_LIMIT_BANNER_VIEW_MY_USAGE for tracking the banner interaction.