### PR TITLE
Fix integrated review panel resize for left-side layout

### DIFF
--- a/components/integrated-review.css
+++ b/components/integrated-review.css
@@ -73,6 +73,7 @@
 #gitlab-mr-integrated-review .thinkreview-resize-handle {
   position: absolute;
   left: -4px;
+  right: auto;
   top: 0;
   width: 8px;
   height: 100%;
@@ -81,6 +82,13 @@
   opacity: 0;
   transition: opacity 0.2s ease;
   z-index: var(--thinkreview-z-resize-handle);
+}
+
+/* For left-side layouts the resize edge faces right */
+#gitlab-mr-integrated-review.thinkreview-panel-docked-left .thinkreview-resize-handle,
+#gitlab-mr-integrated-review.thinkreview-panel-overlay-left .thinkreview-resize-handle {
+  left: auto;
+  right: -4px;
 }
 
 #gitlab-mr-integrated-review:hover .thinkreview-resize-handle {

--- a/components/integrated-review.js
+++ b/components/integrated-review.js
@@ -1038,7 +1038,9 @@ function initializeResizeHandle(container) {
   });
   
   const doResize = (e) => {
-    const deltaX = startX - e.clientX;
+    const isLeftLayout = container.classList.contains('thinkreview-panel-docked-left') ||
+                         container.classList.contains('thinkreview-panel-overlay-left');
+    const deltaX = isLeftLayout ? e.clientX - startX : startX - e.clientX;
     const newWidth = Math.max(400, Math.min(800, startWidth + deltaX)); // Min 400px, Max 800px
     container.style.width = newWidth + 'px';
 

--- a/components/integrated-review.js
+++ b/components/integrated-review.js
@@ -1011,6 +1011,9 @@ function detectAzureDevOpsTheme() {
   return 'light';
 }
 
+const INTEGRATED_REVIEW_PANEL_RESIZE_MIN_WIDTH_PX = 400;
+const INTEGRATED_REVIEW_PANEL_RESIZE_MAX_WIDTH_PX = 800;
+
 /**
  * Initializes the resize handle functionality for the review panel
  * @param {HTMLElement} container - The review panel container
@@ -1041,7 +1044,10 @@ function initializeResizeHandle(container) {
     const isLeftLayout = container.classList.contains('thinkreview-panel-docked-left') ||
                          container.classList.contains('thinkreview-panel-overlay-left');
     const deltaX = isLeftLayout ? e.clientX - startX : startX - e.clientX;
-    const newWidth = Math.max(400, Math.min(800, startWidth + deltaX)); // Min 400px, Max 800px
+    const newWidth = Math.max(
+      INTEGRATED_REVIEW_PANEL_RESIZE_MIN_WIDTH_PX,
+      Math.min(INTEGRATED_REVIEW_PANEL_RESIZE_MAX_WIDTH_PX, startWidth + deltaX)
+    );
     container.style.width = newWidth + 'px';
 
     // Sync body margin with panel width so page content isn't obscured or gapped


### PR DESCRIPTION
1. Added CSS rules to properly position the resize handle on the right side when the panel is configured for a left-docked or left-overlay layout.
2. Extracted hardcoded minimum (400px) and maximum (800px) panel width values into named constants (`INTEGRATED_REVIEW_PANEL_RESIZE_MIN_WIDTH_PX` and `INTEGRATED_REVIEW_PANEL_RESIZE_MAX_WIDTH_PX`) to improve maintainability.
3. Updated the `doResize` JavaScript function to dynamically calculate the width delta based on the panel's layout position, reversing the calculation direction for left-sided layouts.