### PR TITLE
feat/Send manifest extensionVersion to sync and get user endpoints.

### DIFF
--- a/services/cloud-service.js
+++ b/services/cloud-service.js
@@ -16,9 +16,7 @@ const _extensionVersion = (() => {
   return undefined;
 })();
 
-function extensionVersionPayload() {
-  return _extensionVersion ? { extensionVersion: _extensionVersion } : {};
-}
+const EXTENSION_VERSION_PAYLOAD = _extensionVersion ? { extensionVersion: _extensionVersion } : {};
 
 // Cloud function URLs
 const CLOUD_FUNCTIONS_BASE_URL = 'https://us-central1-thinkgpt.cloudfunctions.net';
@@ -73,7 +71,7 @@ export class CloudService {
           locale: userData.locale
         },
         source: 'extension',
-        ...extensionVersionPayload()
+        ...EXTENSION_VERSION_PAYLOAD
       };
       
       // Ensure uid is not undefined or null
@@ -167,7 +165,7 @@ export class CloudService {
         email: email,
         uid: 'query', // Just a placeholder for query operations
         source: 'extension',
-        ...extensionVersionPayload()
+        ...EXTENSION_VERSION_PAYLOAD
       };
       
       // Make the API call to the cloud function
@@ -732,7 +730,7 @@ export class CloudService {
         },
         body: JSON.stringify({
           email,
-          ...extensionVersionPayload()
+          ...EXTENSION_VERSION_PAYLOAD
         })
       });
       
@@ -925,7 +923,7 @@ export class CloudService {
         headers: {
           'Content-Type': 'application/json'
         },
-        body: JSON.stringify({ email, ...extensionVersionPayload() })
+        body: JSON.stringify({ email, ...EXTENSION_VERSION_PAYLOAD })
       });
       
       if (!response.ok) {

--- a/services/cloud-service.js
+++ b/services/cloud-service.js
@@ -1,5 +1,27 @@
 import { dbgLog, dbgWarn, dbgError } from '../utils/logger.js';
 
+/**
+ * Manifest version for optional sync with cloud functions (omitted if unavailable).
+ * @returns {string|undefined}
+ */
+function getExtensionVersionForApi() {
+  try {
+    if (typeof chrome !== 'undefined' && chrome.runtime && typeof chrome.runtime.getManifest === 'function') {
+      const v = chrome.runtime.getManifest()?.version;
+      if (typeof v === 'string' && v.trim()) {
+        return v.trim().slice(0, 64);
+      }
+    }
+  } catch (_) {
+    // Non-extension context or getManifest unavailable
+  }
+  return undefined;
+}
+
+function extensionVersionPayload() {
+  const v = getExtensionVersionForApi();
+  return v ? { extensionVersion: v } : {};
+}
 
 // Cloud function URLs
 const CLOUD_FUNCTIONS_BASE_URL = 'https://us-central1-thinkgpt.cloudfunctions.net';
@@ -53,7 +75,8 @@ export class CloudService {
           email: userData.email,
           locale: userData.locale
         },
-        source: 'extension'
+        source: 'extension',
+        ...extensionVersionPayload()
       };
       
       // Ensure uid is not undefined or null
@@ -146,7 +169,8 @@ export class CloudService {
       const payload = {
         email: email,
         uid: 'query', // Just a placeholder for query operations
-        source: 'extension'
+        source: 'extension',
+        ...extensionVersionPayload()
       };
       
       // Make the API call to the cloud function
@@ -710,7 +734,8 @@ export class CloudService {
           'Content-Type': 'application/json'
         },
         body: JSON.stringify({
-          email
+          email,
+          ...extensionVersionPayload()
         })
       });
       
@@ -903,7 +928,7 @@ export class CloudService {
         headers: {
           'Content-Type': 'application/json'
         },
-        body: JSON.stringify({ email })
+        body: JSON.stringify({ email, ...extensionVersionPayload() })
       });
       
       if (!response.ok) {

--- a/services/cloud-service.js
+++ b/services/cloud-service.js
@@ -1,10 +1,8 @@
 import { dbgLog, dbgWarn, dbgError } from '../utils/logger.js';
 
-/**
- * Manifest version for optional sync with cloud functions (omitted if unavailable).
- * @returns {string|undefined}
- */
-function getExtensionVersionForApi() {
+// Cached once at module load; chrome.runtime.getManifest() is synchronous and
+// returns the same static value for the lifetime of the extension page.
+const _extensionVersion = (() => {
   try {
     if (typeof chrome !== 'undefined' && chrome.runtime && typeof chrome.runtime.getManifest === 'function') {
       const v = chrome.runtime.getManifest()?.version;
@@ -16,11 +14,10 @@ function getExtensionVersionForApi() {
     // Non-extension context or getManifest unavailable
   }
   return undefined;
-}
+})();
 
 function extensionVersionPayload() {
-  const v = getExtensionVersionForApi();
-  return v ? { extensionVersion: v } : {};
+  return _extensionVersion ? { extensionVersion: _extensionVersion } : {};
 }
 
 // Cloud function URLs


### PR DESCRIPTION
1. Added a module-level IIFE `_extensionVersion` to safely retrieve and cache the extension version from `chrome.runtime.getManifest()` at load time.
2. Implemented defensive checks to ensure the `chrome` API is available and limited the version string length to 64 characters.
3. Created a reusable `EXTENSION_VERSION_PAYLOAD` object to conditionally hold the extension version.
4. Updated multiple cloud function API request payloads (e.g., user creation/update, query operations) to include the extension version by spreading `EXTENSION_VERSION_PAYLOAD` into the request bodies.