### PR TITLE
fix/ThinkReview button stability after update/install

### DIFF
--- a/background.js
+++ b/background.js
@@ -1096,8 +1096,9 @@ const DEFAULT_DOMAINS = ['https://gitlab.com'];
 // Register content scripts for stored domains on startup
 chrome.runtime.onStartup.addListener(updateContentScripts);
 chrome.runtime.onInstalled.addListener(async (details) => {
-  // Update content scripts
-  updateContentScripts();
+  // Await so the service worker stays alive until all scripts are registered/updated.
+  // Without await, the SW can be terminated mid-registration (sporadic missing button on install/update).
+  await updateContentScripts();
   
   // Open onboarding page on first install
   if (details.reason === 'install') {

--- a/content.js
+++ b/content.js
@@ -1796,7 +1796,18 @@ async function initializeExtension() {
     const platform = getCurrentPlatform();
     dbgLog('Initializing for platform:', platform);
     
-    injectButtons();
+    await injectButtons();
+
+    // If the trigger still didn't land (e.g. extension context still warming up right after
+    // install/update), retry once after a short delay before giving up.
+    if (!document.getElementById('code-review-btns') && !document.getElementById('thinkreview-sidebar-tab')) {
+      dbgWarn('Trigger not found after injectButtons(), retrying in 1.5s');
+      setTimeout(async () => {
+        if (!document.getElementById('code-review-btns') && !document.getElementById('thinkreview-sidebar-tab')) {
+          await injectButtons();
+        }
+      }, 1500);
+    }
     
     // Start SPA navigation monitoring for GitHub, Azure DevOps, and Bitbucket (SPAs)
     // Check by site (domain) rather than platform, because platform is null on non-PR pages

--- a/content.js
+++ b/content.js
@@ -52,8 +52,24 @@ let isReviewInProgress = false;
 // Track current PR ID for detecting navigation to new PRs
 let currentPRId = null;
 
-// Holds the active button-injection retry observer so it can be torn down on SPA navigation.
+// State for the button-injection retry observer.
+// Grouped here so _teardownRetryObserver() has a single place to clean up.
 let activeRetryObserver = null;
+let retryObserverTimeoutId = null;  // 10 s hard-stop timer
+let retryDebounceTimerId = null;    // debounce timer inside the observer callback
+let isInjecting = false;            // prevents concurrent injectButtons() calls in the observer
+
+/** Disconnect the retry observer and clear all associated timers in one call. */
+function _teardownRetryObserver() {
+  clearTimeout(retryObserverTimeoutId);
+  retryObserverTimeoutId = null;
+  clearTimeout(retryDebounceTimerId);
+  retryDebounceTimerId = null;
+  if (activeRetryObserver) {
+    activeRetryObserver.disconnect();
+    activeRetryObserver = null;
+  }
+}
 
 // Listen for Ollama metadata bar actions (switch to cloud, change model)
 document.addEventListener('thinkreview-switch-to-cloud', async () => {
@@ -1786,11 +1802,10 @@ function startSPANavigationMonitoring() {
     if (currentUrl !== lastUrl) {
       lastUrl = currentUrl;
 
-      // Tear down any pending button-injection retry observer immediately so it
+      // Tear down any pending retry observer (and its timers) immediately so it
       // doesn't fire on the new page's DOM mutations.
       if (activeRetryObserver) {
-        activeRetryObserver.disconnect();
-        activeRetryObserver = null;
+        _teardownRetryObserver();
         dbgLog('Disconnected stale retryObserver on SPA navigation');
       }
 
@@ -1817,26 +1832,37 @@ async function initializeExtension() {
     // watch for DOM changes and inject as soon as the body is mutated instead of guessing a delay.
     if (!areButtonsInjected()) {
       dbgWarn('Trigger not found after injectButtons(), observing DOM for retry...');
-      activeRetryObserver = new MutationObserver(async (_, obs) => {
-        if (areButtonsInjected()) {
-          obs.disconnect();
-          activeRetryObserver = null;
-          return;
-        }
-        await injectButtons();
-        if (areButtonsInjected()) {
-          obs.disconnect();
-          activeRetryObserver = null;
-        }
+
+      activeRetryObserver = new MutationObserver(() => {
+        // Debounce: coalesce rapid bursts of mutations into a single attempt.
+        clearTimeout(retryDebounceTimerId);
+        retryDebounceTimerId = setTimeout(async () => {
+          retryDebounceTimerId = null;
+
+          if (areButtonsInjected()) {
+            _teardownRetryObserver();
+            return;
+          }
+
+          // Concurrency guard: skip if a previous async attempt is still in flight.
+          if (isInjecting) return;
+          isInjecting = true;
+          try {
+            await injectButtons();
+            if (areButtonsInjected()) {
+              _teardownRetryObserver();
+            }
+          } finally {
+            // Always reset the flag, even if injectButtons() throws.
+            isInjecting = false;
+          }
+        }, 150);
       });
+
       activeRetryObserver.observe(document.body, { childList: true, subtree: true });
-      // Hard-stop: disconnect after 10 s if the page never settles.
-      setTimeout(() => {
-        if (activeRetryObserver) {
-          activeRetryObserver.disconnect();
-          activeRetryObserver = null;
-        }
-      }, 10_000);
+
+      // Hard-stop: clear everything after 10 s if the page never settles.
+      retryObserverTimeoutId = setTimeout(_teardownRetryObserver, 10_000);
     }
     
     // Start SPA navigation monitoring for GitHub, Azure DevOps, and Bitbucket (SPAs)

--- a/content.js
+++ b/content.js
@@ -52,22 +52,23 @@ let isReviewInProgress = false;
 // Track current PR ID for detecting navigation to new PRs
 let currentPRId = null;
 
-// State for the button-injection retry observer.
-// Grouped here so _teardownRetryObserver() has a single place to clean up.
-let activeRetryObserver = null;
-let retryObserverTimeoutId = null;  // 10 s hard-stop timer
-let retryDebounceTimerId = null;    // debounce timer inside the observer callback
-let isInjecting = false;            // prevents concurrent injectButtons() calls in the observer
+// State for the button-injection retry observer — grouped to reduce namespace pollution.
+const retryState = {
+  observer: null,        // MutationObserver instance
+  timeoutId: null,       // 10 s hard-stop timer
+  debounceTimerId: null, // debounce timer inside the observer callback
+  isInjecting: false,    // prevents concurrent injectButtons() calls in the observer
+};
 
 /** Disconnect the retry observer and clear all associated timers in one call. */
 function _teardownRetryObserver() {
-  clearTimeout(retryObserverTimeoutId);
-  retryObserverTimeoutId = null;
-  clearTimeout(retryDebounceTimerId);
-  retryDebounceTimerId = null;
-  if (activeRetryObserver) {
-    activeRetryObserver.disconnect();
-    activeRetryObserver = null;
+  clearTimeout(retryState.timeoutId);
+  retryState.timeoutId = null;
+  clearTimeout(retryState.debounceTimerId);
+  retryState.debounceTimerId = null;
+  if (retryState.observer) {
+    retryState.observer.disconnect();
+    retryState.observer = null;
   }
 }
 
@@ -1804,7 +1805,7 @@ function startSPANavigationMonitoring() {
 
       // Tear down any pending retry observer (and its timers) immediately so it
       // doesn't fire on the new page's DOM mutations.
-      if (activeRetryObserver) {
+      if (retryState.observer) {
         _teardownRetryObserver();
         dbgLog('Disconnected stale retryObserver on SPA navigation');
       }
@@ -1830,14 +1831,14 @@ async function initializeExtension() {
 
     // If the trigger still didn't land (e.g. extension context warming up right after install/update),
     // watch for DOM changes and inject as soon as the body is mutated instead of guessing a delay.
-    if (!areButtonsInjected()) {
+      if (!areButtonsInjected()) {
       dbgWarn('Trigger not found after injectButtons(), observing DOM for retry...');
 
-      activeRetryObserver = new MutationObserver(() => {
+      retryState.observer = new MutationObserver(() => {
         // Debounce: coalesce rapid bursts of mutations into a single attempt.
-        clearTimeout(retryDebounceTimerId);
-        retryDebounceTimerId = setTimeout(async () => {
-          retryDebounceTimerId = null;
+        clearTimeout(retryState.debounceTimerId);
+        retryState.debounceTimerId = setTimeout(async () => {
+          retryState.debounceTimerId = null;
 
           if (areButtonsInjected()) {
             _teardownRetryObserver();
@@ -1845,8 +1846,8 @@ async function initializeExtension() {
           }
 
           // Concurrency guard: skip if a previous async attempt is still in flight.
-          if (isInjecting) return;
-          isInjecting = true;
+          if (retryState.isInjecting) return;
+          retryState.isInjecting = true;
           try {
             await injectButtons();
             if (areButtonsInjected()) {
@@ -1854,15 +1855,15 @@ async function initializeExtension() {
             }
           } finally {
             // Always reset the flag, even if injectButtons() throws.
-            isInjecting = false;
+            retryState.isInjecting = false;
           }
         }, 150);
       });
 
-      activeRetryObserver.observe(document.body, { childList: true, subtree: true });
+      retryState.observer.observe(document.body, { childList: true, subtree: true });
 
       // Hard-stop: clear everything after 10 s if the page never settles.
-      retryObserverTimeoutId = setTimeout(_teardownRetryObserver, 10_000);
+      retryState.timeoutId = setTimeout(_teardownRetryObserver, 10_000);
     }
     
     // Start SPA navigation monitoring for GitHub, Azure DevOps, and Bitbucket (SPAs)

--- a/content.js
+++ b/content.js
@@ -52,6 +52,9 @@ let isReviewInProgress = false;
 // Track current PR ID for detecting navigation to new PRs
 let currentPRId = null;
 
+// Holds the active button-injection retry observer so it can be torn down on SPA navigation.
+let activeRetryObserver = null;
+
 // Listen for Ollama metadata bar actions (switch to cloud, change model)
 document.addEventListener('thinkreview-switch-to-cloud', async () => {
   await chrome.storage.local.set({ aiProvider: 'cloud' });
@@ -1782,6 +1785,15 @@ function startSPANavigationMonitoring() {
     const currentUrl = window.location.href;
     if (currentUrl !== lastUrl) {
       lastUrl = currentUrl;
+
+      // Tear down any pending button-injection retry observer immediately so it
+      // doesn't fire on the new page's DOM mutations.
+      if (activeRetryObserver) {
+        activeRetryObserver.disconnect();
+        activeRetryObserver = null;
+        dbgLog('Disconnected stale retryObserver on SPA navigation');
+      }
+
       checkAndTriggerReviewForNewPR();
     }
   }, 1000);
@@ -1805,19 +1817,26 @@ async function initializeExtension() {
     // watch for DOM changes and inject as soon as the body is mutated instead of guessing a delay.
     if (!areButtonsInjected()) {
       dbgWarn('Trigger not found after injectButtons(), observing DOM for retry...');
-      const retryObserver = new MutationObserver(async (_, obs) => {
+      activeRetryObserver = new MutationObserver(async (_, obs) => {
         if (areButtonsInjected()) {
           obs.disconnect();
+          activeRetryObserver = null;
           return;
         }
         await injectButtons();
         if (areButtonsInjected()) {
           obs.disconnect();
+          activeRetryObserver = null;
         }
       });
-      retryObserver.observe(document.body, { childList: true, subtree: true });
-      // Disconnect after 10 s so we don't keep observing a page that never settles.
-      setTimeout(() => retryObserver.disconnect(), 10_000);
+      activeRetryObserver.observe(document.body, { childList: true, subtree: true });
+      // Hard-stop: disconnect after 10 s if the page never settles.
+      setTimeout(() => {
+        if (activeRetryObserver) {
+          activeRetryObserver.disconnect();
+          activeRetryObserver = null;
+        }
+      }, 10_000);
     }
     
     // Start SPA navigation monitoring for GitHub, Azure DevOps, and Bitbucket (SPAs)

--- a/content.js
+++ b/content.js
@@ -324,8 +324,11 @@ function applyDockedBodyMargin(isExpanded, panelMode, sidebarSide) {
   }
 }
 
+const areButtonsInjected = () =>
+  !!(document.getElementById('code-review-btns') || document.getElementById('thinkreview-sidebar-tab'));
+
 async function injectButtons() {
-  if (document.getElementById('code-review-btns') || document.getElementById('thinkreview-sidebar-tab')) {
+  if (areButtonsInjected()) {
     dbgLog('Buttons already injected');
     return;
   }
@@ -1798,15 +1801,23 @@ async function initializeExtension() {
     
     await injectButtons();
 
-    // If the trigger still didn't land (e.g. extension context still warming up right after
-    // install/update), retry once after a short delay before giving up.
-    if (!document.getElementById('code-review-btns') && !document.getElementById('thinkreview-sidebar-tab')) {
-      dbgWarn('Trigger not found after injectButtons(), retrying in 1.5s');
-      setTimeout(async () => {
-        if (!document.getElementById('code-review-btns') && !document.getElementById('thinkreview-sidebar-tab')) {
-          await injectButtons();
+    // If the trigger still didn't land (e.g. extension context warming up right after install/update),
+    // watch for DOM changes and inject as soon as the body is mutated instead of guessing a delay.
+    if (!areButtonsInjected()) {
+      dbgWarn('Trigger not found after injectButtons(), observing DOM for retry...');
+      const retryObserver = new MutationObserver(async (_, obs) => {
+        if (areButtonsInjected()) {
+          obs.disconnect();
+          return;
         }
-      }, 1500);
+        await injectButtons();
+        if (areButtonsInjected()) {
+          obs.disconnect();
+        }
+      });
+      retryObserver.observe(document.body, { childList: true, subtree: true });
+      // Disconnect after 10 s so we don't keep observing a page that never settles.
+      setTimeout(() => retryObserver.disconnect(), 10_000);
     }
     
     // Start SPA navigation monitoring for GitHub, Azure DevOps, and Bitbucket (SPAs)


### PR DESCRIPTION
… injection

Without await, the MV3 service worker could be terminated before all chrome.scripting.registerContentScripts() calls completed, causing the ThinkReview button to never appear on first install or after auto-update.

Also await injectButtons() in initializeExtension and add a single 1.5s retry if neither trigger element is found after the initial injection, guarding against transient dynamic-import failures during extension context warm-up.

Made-with: Cursor