### PR TITLE
fix: use static import for analytics in implement-via button handlers

### DIFF
--- a/utils/ide-integration/claude-code-suggestion.js
+++ b/utils/ide-integration/claude-code-suggestion.js
@@ -86,11 +86,11 @@ export async function createClaudeCodeSuggestionIntegration(integrationOpts, opt
               : 'Open Claude Code in VS Code with this suggestion as the prompt'
       );
 
-      btn.addEventListener('click', (e) => {
+      btn.addEventListener('click', async (e) => {
         e.stopPropagation();
         e.preventDefault();
         const analyticsEventName = `open_in_${IDE_ANALYTICS_ID}_${itemKind}_clicked`;
-        trackUserAction(analyticsEventName, {
+        await trackUserAction(analyticsEventName, {
           context: 'integrated_review_panel',
           ide: IDE_ANALYTICS_ID,
           list_section: itemKind,

--- a/utils/ide-integration/claude-code-suggestion.js
+++ b/utils/ide-integration/claude-code-suggestion.js
@@ -86,11 +86,11 @@ export async function createClaudeCodeSuggestionIntegration(integrationOpts, opt
               : 'Open Claude Code in VS Code with this suggestion as the prompt'
       );
 
-      btn.addEventListener('click', async (e) => {
+      btn.addEventListener('click', (e) => {
         e.stopPropagation();
         e.preventDefault();
         const analyticsEventName = `open_in_${IDE_ANALYTICS_ID}_${itemKind}_clicked`;
-        await trackUserAction(analyticsEventName, {
+        trackUserAction(analyticsEventName, {
           context: 'integrated_review_panel',
           ide: IDE_ANALYTICS_ID,
           list_section: itemKind,

--- a/utils/ide-integration/claude-code-suggestion.js
+++ b/utils/ide-integration/claude-code-suggestion.js
@@ -7,6 +7,7 @@ import { buildClaudeCodeOpenDeeplink } from './claude-code-deeplink.js';
 import { createClaudeCodeIconSvg, ensureIdeActionIconsLoaded } from './ide-action-icons.js';
 import { buildReviewSuggestionPromptBody } from './suggestion-prompt-body.js';
 import { openUrlWithTransientAnchor } from './open-deeplink.js';
+import { trackUserAction } from '../analytics-service.js';
 
 const BUTTON_CLASS = 'thinkreview-open-claude-code-btn thinkreview-open-ide-btn';
 const IDE_ANALYTICS_ID = 'claude_code';
@@ -85,26 +86,16 @@ export async function createClaudeCodeSuggestionIntegration(integrationOpts, opt
               : 'Open Claude Code in VS Code with this suggestion as the prompt'
       );
 
-      btn.addEventListener('click', async (e) => {
+      btn.addEventListener('click', (e) => {
         e.stopPropagation();
         e.preventDefault();
-        try {
-          const analyticsModule = await import(getExtensionUrl('utils/analytics-service.js'));
-          const listSection =
-            listCategory === 'practice'
-              ? 'practice'
-              : listCategory === 'security'
-                ? 'security'
-                : 'suggestion';
-          const analyticsEventName = `open_in_${IDE_ANALYTICS_ID}_${listSection}_clicked`;
-          analyticsModule.trackUserAction(analyticsEventName, {
-            context: 'integrated_review_panel',
-            ide: IDE_ANALYTICS_ID,
-            list_section: listSection
-          }).catch(() => {});
-        } catch (err) {
-          /* silent */
-        }
+        const analyticsEventName = `open_in_${IDE_ANALYTICS_ID}_${itemKind}_clicked`;
+        trackUserAction(analyticsEventName, {
+          context: 'integrated_review_panel',
+          ide: IDE_ANALYTICS_ID,
+          list_section: itemKind,
+          prompt_truncated: truncated
+        }).catch(() => {});
         openUrlWithTransientAnchor(href);
       });
 

--- a/utils/ide-integration/cursor-suggestion.js
+++ b/utils/ide-integration/cursor-suggestion.js
@@ -6,6 +6,7 @@
 import { createCursorProductIconSvg, ensureIdeActionIconsLoaded } from './ide-action-icons.js';
 import { buildReviewSuggestionPromptBody } from './suggestion-prompt-body.js';
 import { openUrlWithTransientAnchor } from './open-deeplink.js';
+import { trackUserAction } from '../analytics-service.js';
 
 const BUTTON_CLASS = 'thinkreview-open-cursor-btn thinkreview-open-ide-btn';
 const IDE_ANALYTICS_ID = 'cursor';
@@ -93,26 +94,16 @@ export async function createCursorSuggestionIntegration(integrationOpts, options
               : 'Open in Cursor with this suggestion as the chat prompt'
       );
 
-      btn.addEventListener('click', async (e) => {
+      btn.addEventListener('click', (e) => {
         e.stopPropagation();
         e.preventDefault();
-        try {
-          const analyticsModule = await import(getExtensionUrl('utils/analytics-service.js'));
-          const listSection =
-            listCategory === 'practice'
-              ? 'practice'
-              : listCategory === 'security'
-                ? 'security'
-                : 'suggestion';
-          const analyticsEventName = `open_in_${IDE_ANALYTICS_ID}_${listSection}_clicked`;
-          analyticsModule.trackUserAction(analyticsEventName, {
-            context: 'integrated_review_panel',
-            ide: IDE_ANALYTICS_ID,
-            list_section: listSection
-          }).catch(() => {});
-        } catch (err) {
-          /* silent */
-        }
+        const analyticsEventName = `open_in_${IDE_ANALYTICS_ID}_${itemKind}_clicked`;
+        trackUserAction(analyticsEventName, {
+          context: 'integrated_review_panel',
+          ide: IDE_ANALYTICS_ID,
+          list_section: itemKind,
+          prompt_truncated: truncated
+        }).catch(() => {});
         openUrlWithTransientAnchor(href);
       });
 

--- a/utils/ide-integration/cursor-suggestion.js
+++ b/utils/ide-integration/cursor-suggestion.js
@@ -94,11 +94,11 @@ export async function createCursorSuggestionIntegration(integrationOpts, options
               : 'Open in Cursor with this suggestion as the chat prompt'
       );
 
-      btn.addEventListener('click', (e) => {
+      btn.addEventListener('click', async (e) => {
         e.stopPropagation();
         e.preventDefault();
         const analyticsEventName = `open_in_${IDE_ANALYTICS_ID}_${itemKind}_clicked`;
-        trackUserAction(analyticsEventName, {
+        await trackUserAction(analyticsEventName, {
           context: 'integrated_review_panel',
           ide: IDE_ANALYTICS_ID,
           list_section: itemKind,

--- a/utils/ide-integration/cursor-suggestion.js
+++ b/utils/ide-integration/cursor-suggestion.js
@@ -94,11 +94,11 @@ export async function createCursorSuggestionIntegration(integrationOpts, options
               : 'Open in Cursor with this suggestion as the chat prompt'
       );
 
-      btn.addEventListener('click', async (e) => {
+      btn.addEventListener('click', (e) => {
         e.stopPropagation();
         e.preventDefault();
         const analyticsEventName = `open_in_${IDE_ANALYTICS_ID}_${itemKind}_clicked`;
-        await trackUserAction(analyticsEventName, {
+        trackUserAction(analyticsEventName, {
           context: 'integrated_review_panel',
           ide: IDE_ANALYTICS_ID,
           list_section: itemKind,

--- a/utils/ide-integration/github-copilot-suggestion.js
+++ b/utils/ide-integration/github-copilot-suggestion.js
@@ -85,11 +85,11 @@ export async function createGitHubCopilotSuggestionIntegration(integrationOpts, 
               : 'Open GitHub Copilot Chat with this suggestion as the prompt'
       );
 
-      btn.addEventListener('click', async (e) => {
+      btn.addEventListener('click', (e) => {
         e.stopPropagation();
         e.preventDefault();
         const analyticsEventName = `open_in_${IDE_ANALYTICS_ID}_${itemKind}_clicked`;
-        await trackUserAction(analyticsEventName, {
+        trackUserAction(analyticsEventName, {
           context: 'integrated_review_panel',
           ide: IDE_ANALYTICS_ID,
           list_section: itemKind,

--- a/utils/ide-integration/github-copilot-suggestion.js
+++ b/utils/ide-integration/github-copilot-suggestion.js
@@ -85,11 +85,11 @@ export async function createGitHubCopilotSuggestionIntegration(integrationOpts, 
               : 'Open GitHub Copilot Chat with this suggestion as the prompt'
       );
 
-      btn.addEventListener('click', (e) => {
+      btn.addEventListener('click', async (e) => {
         e.stopPropagation();
         e.preventDefault();
         const analyticsEventName = `open_in_${IDE_ANALYTICS_ID}_${itemKind}_clicked`;
-        trackUserAction(analyticsEventName, {
+        await trackUserAction(analyticsEventName, {
           context: 'integrated_review_panel',
           ide: IDE_ANALYTICS_ID,
           list_section: itemKind,

--- a/utils/ide-integration/github-copilot-suggestion.js
+++ b/utils/ide-integration/github-copilot-suggestion.js
@@ -6,6 +6,7 @@ import { buildGitHubCopilotPromptDeeplink } from './github-copilot-deeplink.js';
 import { createGitHubCopilotIconSvg, ensureIdeActionIconsLoaded } from './ide-action-icons.js';
 import { buildReviewSuggestionPromptBody } from './suggestion-prompt-body.js';
 import { openUrlWithTransientAnchor } from './open-deeplink.js';
+import { trackUserAction } from '../analytics-service.js';
 
 const BUTTON_CLASS = 'thinkreview-open-github-copilot-btn thinkreview-open-ide-btn';
 const IDE_ANALYTICS_ID = 'github_copilot';
@@ -84,26 +85,16 @@ export async function createGitHubCopilotSuggestionIntegration(integrationOpts, 
               : 'Open GitHub Copilot Chat with this suggestion as the prompt'
       );
 
-      btn.addEventListener('click', async (e) => {
+      btn.addEventListener('click', (e) => {
         e.stopPropagation();
         e.preventDefault();
-        try {
-          const analyticsModule = await import(getExtensionUrl('utils/analytics-service.js'));
-          const listSection =
-            listCategory === 'practice'
-              ? 'practice'
-              : listCategory === 'security'
-                ? 'security'
-                : 'suggestion';
-          const analyticsEventName = `open_in_${IDE_ANALYTICS_ID}_${listSection}_clicked`;
-          analyticsModule.trackUserAction(analyticsEventName, {
-            context: 'integrated_review_panel',
-            ide: IDE_ANALYTICS_ID,
-            list_section: listSection
-          }).catch(() => {});
-        } catch (err) {
-          /* silent */
-        }
+        const analyticsEventName = `open_in_${IDE_ANALYTICS_ID}_${itemKind}_clicked`;
+        trackUserAction(analyticsEventName, {
+          context: 'integrated_review_panel',
+          ide: IDE_ANALYTICS_ID,
+          list_section: itemKind,
+          prompt_truncated: truncated
+        }).catch(() => {});
         openUrlWithTransientAnchor(href);
       });
 


### PR DESCRIPTION
Replace the dynamic import of analytics-service.js inside each click handler (via a getExtensionUrl closure) with a static import at the top of each module. The dynamic import through a two-level closure chain was silently failing and swallowed by an empty catch block, causing implement-via button click events to never reach GA4.

Also tracks prompt_truncated and removes duplicated listSection logic by reusing the already-computed itemKind variable.

