### PR TITLE
fix(gitlab): prevent host styles from breaking Ollama CORS code blocks

### DIFF
--- a/components/integrated-review.css
+++ b/components/integrated-review.css
@@ -29,6 +29,16 @@
   --thinkreview-z-toast: 1250;
 }
 
+/* Defensive reset: prevent host-page (e.g. GitLab) bare pre/code rules from
+   cascading into the extension panel. Component-specific rules below set the
+   actual values and use !important where needed to win the cascade. */
+#gitlab-mr-integrated-review pre,
+#gitlab-mr-integrated-review code {
+  color: inherit;
+  background: inherit;
+  background-color: inherit;
+}
+
 .thinkreview-panel-container {
   position: fixed;
   right: 20px;
@@ -3645,7 +3655,8 @@ body[data-theme="dark"] #gitlab-mr-integrated-review .thinkreview-progress-bar,
 #gitlab-mr-integrated-review .thinkreview-ollama-cors-code {
   margin: 0 auto 8px;
   padding: 10px 12px;
-  background: #f1f3f5;
+  background: #f1f3f5 !important;
+  background-color: #f1f3f5 !important;
   border: 1px solid #dee2e6;
   border-radius: 6px;
   overflow-x: auto;
@@ -3658,19 +3669,20 @@ body[data-theme="dark"] #gitlab-mr-integrated-review .thinkreview-progress-bar,
 
 #gitlab-mr-integrated-review .thinkreview-ollama-cors-code code {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  color: #212529;
+  color: #212529 !important;
   white-space: pre-wrap;
   word-break: break-word;
 }
 
 @media (prefers-color-scheme: dark) {
   #gitlab-mr-integrated-review .thinkreview-ollama-cors-code {
-    background: #2b3035;
+    background: #2b3035 !important;
+    background-color: #2b3035 !important;
     border-color: #495057;
   }
 
   #gitlab-mr-integrated-review .thinkreview-ollama-cors-code code {
-    color: #e9ecef;
+    color: #e9ecef !important;
   }
 }
 

--- a/components/integrated-review.css
+++ b/components/integrated-review.css
@@ -3656,7 +3656,6 @@ body[data-theme="dark"] #gitlab-mr-integrated-review .thinkreview-progress-bar,
   margin: 0 auto 8px;
   padding: 10px 12px;
   background: #f1f3f5 !important;
-  background-color: #f1f3f5 !important;
   border: 1px solid #dee2e6;
   border-radius: 6px;
   overflow-x: auto;
@@ -3677,7 +3676,6 @@ body[data-theme="dark"] #gitlab-mr-integrated-review .thinkreview-progress-bar,
 @media (prefers-color-scheme: dark) {
   #gitlab-mr-integrated-review .thinkreview-ollama-cors-code {
     background: #2b3035 !important;
-    background-color: #2b3035 !important;
     border-color: #495057;
   }
 


### PR DESCRIPTION
- Add defensive pre/code reset under #gitlab-mr-integrated-review
- Use !important on .thinkreview-ollama-cors-code backgrounds and text colors so GitLab Pajamas rules cannot win the cascade in dark mode

