### PR TITLE
fix: queue manual review when auto review is in progress

### DIFF
--- a/content.js
+++ b/content.js
@@ -574,8 +574,8 @@ async function checkAndTriggerReviewForNewPR() {
 function getAutoStartReview() {
   return new Promise((resolve) => {
     chrome.storage.local.get(['autoStartReview'], (result) => {
-      // Respect the "Start review automatically" option for all providers
-      resolve(result.autoStartReview !== false);
+      // Respect the "Start review automatically" option for all providers (default off when unset)
+      resolve(result.autoStartReview === true);
     });
   });
 }

--- a/content.js
+++ b/content.js
@@ -49,6 +49,11 @@ setTimeout(() => {
 // Track if a review request is in progress to prevent duplicates
 let isReviewInProgress = false;
 
+// When the user requests a manual review while another run is in flight (e.g. auto-review
+// still fetching patch or running the auto decision maker), remember it and run after the
+// current invocation finishes so REVIEW_PATCH_CODE / reviewPatchCode_1_1 is not dropped.
+let pendingManualReview = null;
+
 // Track current PR ID for detecting navigation to new PRs
 let currentPRId = null;
 
@@ -549,7 +554,8 @@ async function checkAndTriggerReviewForNewPR() {
     }
     
     isReviewInProgress = false;
-    
+    pendingManualReview = null;
+
     // Trigger new review only if auto-start is enabled
     const autoStart = await getAutoStartReview();
     if (autoStart && isSupportedPage()) {
@@ -1142,8 +1148,11 @@ async function getAzureDevOpsToken() {
  * Supports both GitLab (patch) and Azure DevOps (API) platforms
  */
 async function fetchAndDisplayCodeReview(forceRegenerate = false, isAutoTriggered = false) {
-  // If already processing a review, ignore this request
+  // If already processing a review, ignore duplicate auto runs but queue manual intent
   if (isReviewInProgress) {
+    if (!isAutoTriggered) {
+      pendingManualReview = { forceRegenerate: !!forceRegenerate };
+    }
     return;
   }
   
@@ -1566,6 +1575,18 @@ async function fetchAndDisplayCodeReview(forceRegenerate = false, isAutoTriggere
     }
     // Reset flag when done
     isReviewInProgress = false;
+
+    const pending = pendingManualReview;
+    pendingManualReview = null;
+    if (pending) {
+      const reviewContent = document.getElementById('review-content');
+      const hasReview = reviewContent && !reviewContent.classList.contains('gl-hidden');
+      // Avoid a redundant cloud call if the in-flight run already produced a review, unless
+      // the user explicitly asked to regenerate.
+      if (pending.forceRegenerate || !hasReview) {
+        void fetchAndDisplayCodeReview(pending.forceRegenerate, false);
+      }
+    }
   }
 }
 
@@ -1670,7 +1691,8 @@ async function toggleReviewPanel() {
     const hasError = reviewError && !reviewError.classList.contains('gl-hidden');
     
     // If no review has been generated yet (no content and no error), trigger the review
-    if (!hasReview && !hasError && !isReviewInProgress) {
+    // (even while a review is in progress — fetchAndDisplayCodeReview queues manual runs)
+    if (!hasReview && !hasError) {
       fetchAndDisplayCodeReview(false, false);
     }
   } else {

--- a/content.js
+++ b/content.js
@@ -1584,7 +1584,9 @@ async function fetchAndDisplayCodeReview(forceRegenerate = false, isAutoTriggere
       // Avoid a redundant cloud call if the in-flight run already produced a review, unless
       // the user explicitly asked to regenerate.
       if (pending.forceRegenerate || !hasReview) {
-        void fetchAndDisplayCodeReview(pending.forceRegenerate, false);
+        fetchAndDisplayCodeReview(pending.forceRegenerate, false).catch((err) => {
+          dbgWarn('Pending manual review failed:', err?.message || err);
+        });
       }
     }
   }

--- a/popup.html
+++ b/popup.html
@@ -409,11 +409,11 @@
               <span class="auto-start-label">Start review automatically</span>
               <div class="auto-start-options">
                 <div class="auto-start-option">
-                  <label><input type="radio" name="auto-start-review" value="on" id="auto-start-review-on" checked><span> On</span></label>
+                  <label><input type="radio" name="auto-start-review" value="on" id="auto-start-review-on"><span> On</span></label>
                   <span class="auto-start-info-icon" data-tooltip="Review starts automatically when you open a PR/MR page." aria-label="Info">ⓘ</span>
                 </div>
                 <div class="auto-start-option">
-                  <label><input type="radio" name="auto-start-review" value="off" id="auto-start-review-off"><span> Off</span></label>
+                  <label><input type="radio" name="auto-start-review" value="off" id="auto-start-review-off" checked><span> Off</span></label>
                   <span class="auto-start-info-icon" data-tooltip="Review only starts when you click the ThinkReview button." aria-label="Info">ⓘ</span>
                 </div>
               </div>

--- a/popup.js
+++ b/popup.js
@@ -760,7 +760,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 // Domain Management Functionality
 const DEFAULT_DOMAINS = ['https://gitlab.com'];
 
-// Auto-start review option (default true)
+// Auto-start review option (default off when unset in storage)
 function initializeAutoStartReviewSettings() {
   loadAutoStartReview();
   const onRadio = document.getElementById('auto-start-review-on');
@@ -820,7 +820,7 @@ function setupAutoStartInfoTooltips() {
 async function loadAutoStartReview() {
   try {
     const result = await chrome.storage.local.get(['autoStartReview']);
-    const enabled = result.autoStartReview !== false;
+    const enabled = result.autoStartReview === true;
     const onRadio = document.getElementById('auto-start-review-on');
     const offRadio = document.getElementById('auto-start-review-off');
     if (onRadio) onRadio.checked = enabled;


### PR DESCRIPTION
1. Added a queuing mechanism (`pendingManualReview`) to handle manual review requests that occur while an automated review is already in progress.
2. Updated the `fetchAndDisplayCodeReview` function to capture manual review intents and execute them after the current review finishes, preventing dropped requests.
3. Modified the default behavior of the "Start review automatically" setting from enabled to disabled when unset in storage.
4. Updated `popup.html` to set the "Off" radio button as the default checked option for the auto-start review setting.
5. Adjusted `popup.js` to correctly load and reflect the new default disabled state for the auto-start review setting.
6. Updated `toggleReviewPanel` to trigger a review even if one is currently in progress, relying on the new queuing mechanism to handle it.
7. Reset the `pendingManualReview` state when checking and triggering reviews for new PRs to avoid carrying over stale pending reviews.