### PR TITLE
Fix/azure devops onprem tfs collection path detection

### DIFF
--- a/content.js
+++ b/content.js
@@ -131,7 +131,7 @@ async function initializePlatformDetection() {
       const pathParts = window.location.pathname.split('/').filter(Boolean);
       const collection = pathParts.length > 0 ? pathParts[0] : '';
       const origin = window.location.origin;
-      apiModule.detectAndCacheServerVersion(origin, collection)
+      apiModule.detectAndCacheServerVersion(origin, collection, window.location.pathname)
         .then((result) => {
           if (!result || result.fromCache !== false) return;
           // Send to cloud via background script (avoids content script fetch to external API / CSP)

--- a/services/azure-devops-api.js
+++ b/services/azure-devops-api.js
@@ -2,6 +2,7 @@
 // Azure DevOps API service for fetching pull request data and code changes
 import { dbgLog, dbgWarn, dbgError } from '../utils/logger.js';
 import { getRequestApiVersion, DEFAULT_API_VERSION } from './azure-api-versions/index.js';
+import { parseAzureDevOpsServerPath } from './azure-devops-server-path.js';
 
 // jsdiff (vendor/diff.min.js) exposes global Diff when loaded before this script; used for memory-efficient line diff
 const Diff = (typeof self !== 'undefined' && self.Diff) || (typeof globalThis !== 'undefined' && globalThis.Diff) || null;
@@ -781,10 +782,13 @@ export function getCachedAzureApiVersion(origin) {
  * were never stored or were null/invalid; otherwise returns cached.
  * Call from content script when on an Azure DevOps page (uses same origin as the page).
  * @param {string} origin - e.g. window.location.origin
- * @param {string} collection - First path segment (e.g. DefaultCollection or org name)
+ * @param {string} collection - First path segment used as collection (e.g. DefaultCollection). Callers pass pathParts[0].
+ * @param {string} [pathname] - Optional full pathname (window.location.pathname). When provided and all stage-1
+ *   probes return 404, a second-stage retry is attempted using the corrected collection path derived from the
+ *   pathname (e.g. /tfs/HM/... → tfs/HM). Existing callers that do not pass pathname are unaffected.
  * @returns {Promise<{ version: string, fromCache: boolean, azureOnPremiseVersion?: string|null, azureOnPremiseApiVersion?: string|null }>}
  */
-export async function detectAndCacheServerVersion(origin, collection) {
+export async function detectAndCacheServerVersion(origin, collection, pathname) {
   const fallback = { version: 'Unknown (storage not available)', fromCache: false, azureOnPremiseVersion: null, azureOnPremiseApiVersion: null };
   if (!origin || !collection) {
     return { version: 'Unknown (missing origin or collection)', fromCache: false, azureOnPremiseVersion: null, azureOnPremiseApiVersion: null };
@@ -813,31 +817,62 @@ export async function detectAndCacheServerVersion(origin, collection) {
     }
   }
 
-  const baseUrl = `${origin}/${collection}/_apis/projects`;
-  let detectedVersion = 'Unknown / Could not connect';
-  let azureOnPremiseApiVersion = null;
-  let azureOnPremiseVersion = null;
+  /** Probe all VERSIONS_TO_CHECK against a given base URL. Returns detected fields or null if every probe was a 404. */
+  async function _probeCollectionPath(baseUrl) {
+    let detectedVersion = null;
+    let azureOnPremiseApiVersion = null;
+    let azureOnPremiseVersion = null;
+    let allWere404 = true;
 
-  for (const v of VERSIONS_TO_CHECK) {
-    try {
-      const testUrl = `${baseUrl}?api-version=${v.api}`;
-      const response = await fetch(testUrl, {
-        method: 'GET',
-        credentials: 'include',
-        headers: { Accept: 'application/json' }
-      });
-      if (response.ok) {
-        detectedVersion = `${v.label} (Supports API ${v.api})`;
-        azureOnPremiseApiVersion = v.api;
-        azureOnPremiseVersion = v.label;
-        break;
+    for (const v of VERSIONS_TO_CHECK) {
+      try {
+        const testUrl = `${baseUrl}?api-version=${v.api}`;
+        const response = await fetch(testUrl, {
+          method: 'GET',
+          credentials: 'include',
+          headers: { Accept: 'application/json' }
+        });
+        if (response.ok) {
+          detectedVersion = `${v.label} (Supports API ${v.api})`;
+          azureOnPremiseApiVersion = v.api;
+          azureOnPremiseVersion = v.label;
+          allWere404 = false;
+          break;
+        }
+        if (response.status === 401) {
+          detectedVersion = '401 Unauthorized (Auth works, but version check blocked)';
+          allWere404 = false;
+          break;
+        }
+        if (response.status !== 404) {
+          allWere404 = false;
+        }
+      } catch (e) {
+        allWere404 = false;
       }
-      if (response.status === 401) {
-        detectedVersion = '401 Unauthorized (Auth works, but version check blocked)';
-        break;
+    }
+
+    return { detectedVersion, azureOnPremiseApiVersion, azureOnPremiseVersion, allWere404 };
+  }
+
+  // Stage 1: existing behaviour — use the caller-supplied collection (pathParts[0])
+  const stage1 = await _probeCollectionPath(`${origin}/${collection}/_apis/projects`);
+  let detectedVersion = stage1.detectedVersion || 'Unknown / Could not connect';
+  let azureOnPremiseApiVersion = stage1.azureOnPremiseApiVersion;
+  let azureOnPremiseVersion = stage1.azureOnPremiseVersion;
+
+  // Stage 2: only when every stage-1 probe was a 404 AND a pathname was supplied that yields a
+  // different (deeper) collection path — e.g. /tfs/HM/... → collection tfs/HM vs stage-1 tfs
+  if (stage1.allWere404 && pathname) {
+    const { collectionPath } = parseAzureDevOpsServerPath(pathname);
+    if (collectionPath && collectionPath !== collection) {
+      dbgLog('Azure DevOps Server version: stage-1 probes all 404, retrying with corrected collection path:', { collection, collectionPath });
+      const stage2 = await _probeCollectionPath(`${origin}/${collectionPath}/_apis/projects`);
+      if (stage2.detectedVersion) {
+        detectedVersion = stage2.detectedVersion;
+        azureOnPremiseApiVersion = stage2.azureOnPremiseApiVersion;
+        azureOnPremiseVersion = stage2.azureOnPremiseVersion;
       }
-    } catch (e) {
-      // Continue to next version
     }
   }
 

--- a/services/azure-devops-api.js
+++ b/services/azure-devops-api.js
@@ -35,6 +35,44 @@ export class AzureDevOpsAPI {
     this.isInitialized = false;
     /** @type {Promise<void>|null} One-time promise for lazy project resolution (on-prem when project not in URL) */
     this._projectResolutionPromise = null;
+    /** Full page pathname stored for TFS second-stage path correction. */
+    this._pathname = null;
+    /** True once a TFS collection-path correction has been applied to avoid double-correction. */
+    this._tfsPathCorrected = false;
+  }
+
+  /**
+   * Second-stage correction for Azure DevOps Server / TFS instances where the URL sub-path prefix
+   * (e.g. /tfs) is not a valid REST collection root. Uses the stored page pathname to derive the real
+   * collection path (e.g. tfs/HM) and the actual team project (e.g. hm3), then updates baseUrl,
+   * organization, and project in-place. Only runs once per instance (_tfsPathCorrected guard).
+   * @returns {boolean} True when a correction was applied.
+   */
+  _applyCorrectedTfsPath() {
+    if (!this._pathname || this._tfsPathCorrected) return false;
+    const { collectionPath, teamProject } = parseAzureDevOpsServerPath(this._pathname);
+    if (!collectionPath || collectionPath === this.organization) return false;
+
+    try {
+      const parsed = new URL(this.baseUrl);
+      const correctedBase = `${parsed.protocol}//${parsed.host}/${collectionPath}`;
+      dbgLog('Azure DevOps API: applying TFS path correction (second stage):', {
+        oldOrganization: this.organization,
+        oldProject: this.project,
+        oldBaseUrl: this.baseUrl,
+        collectionPath,
+        teamProject,
+        correctedBase
+      });
+      this.organization = collectionPath;
+      this.project = teamProject;
+      this.baseUrl = correctedBase;
+      this._tfsPathCorrected = true;
+      return true;
+    } catch (e) {
+      dbgWarn('Azure DevOps API: TFS path correction failed to parse baseUrl:', e);
+      return false;
+    }
   }
 
   /**
@@ -46,7 +84,8 @@ export class AzureDevOpsAPI {
    * @param {string} hostname - Hostname (optional, used to determine base URL for visualstudio.com domains)
    * @param {string} protocol - Protocol (optional, e.g. 'http:' or 'https:'; used for custom/on-prem to match page)
    * @param {string|null} apiVersion - API version (optional, e.g. '4.1' for on-prem; default 7.1)
-   * @param {{ useSessionCookies?: boolean }} [options] - If useSessionCookies, token may be omitted (Azure DevOps Services cloud only).
+   * @param {{ useSessionCookies?: boolean, pagePathname?: string }} [options] - If useSessionCookies, token may be omitted (Azure DevOps Services cloud only).
+   *   pagePathname: full page pathname (window.location.pathname); when supplied enables TFS second-stage path correction.
    */
   async init(token, organization, project, repository, hostname = null, protocol = null, apiVersion = null, options = {}) {
     const useSessionCookies = options.useSessionCookies === true;
@@ -80,6 +119,8 @@ export class AzureDevOpsAPI {
     this.repositoryId = repository;
     this.apiVersion = apiVersion != null ? getRequestApiVersion(apiVersion) : DEFAULT_API_VERSION;
     this.isInitialized = true;
+    this._pathname = (typeof options.pagePathname === 'string' && options.pagePathname) ? options.pagePathname : null;
+    this._tfsPathCorrected = false;
 
     // On-prem URL can be /{collection}/_git/{repo} with no project segment; resolve project lazily in makeRequest (no await in init)
 
@@ -279,6 +320,25 @@ export class AzureDevOpsAPI {
             );
           }
           
+          // Second-stage TFS path correction: when the server says a project name is required,
+          // the collection path used as organization was wrong (e.g. /tfs instead of /tfs/HM).
+          // Correct baseUrl/organization/project from the stored page pathname and retry once.
+          if (
+            response.status === 400 &&
+            errorMessage.toLowerCase().includes('project name is required') &&
+            this._pathname &&
+            !this._tfsPathCorrected
+          ) {
+            const corrected = this._applyCorrectedTfsPath();
+            if (corrected) {
+              dbgLog('Azure DevOps API: retrying request after TFS path correction:', { endpoint });
+              const retryResponse = await this._fetchApi(endpoint, undefined, options);
+              if (retryResponse.ok) return retryResponse;
+              const retryText = await retryResponse.text();
+              throw new Error(`Azure DevOps API error: ${retryResponse.status} ${retryResponse.statusText} - ${retryText}`);
+            }
+          }
+
           throw new Error(`Azure DevOps API error: ${response.status} ${response.statusText} - ${errorText}`);
         }
 

--- a/services/azure-devops-fetcher.js
+++ b/services/azure-devops-fetcher.js
@@ -58,6 +58,10 @@ export class AzureDevOpsFetcher {
     }
 
     // Initialize the API service
+    let pagePathname = null;
+    if (prInfo.url) {
+      try { pagePathname = new URL(prInfo.url).pathname; } catch (e) { /* ignore */ }
+    }
     await azureDevOpsAPI.init(
       useSessionCookies ? null : token,
       prInfo.organization,
@@ -66,7 +70,7 @@ export class AzureDevOpsFetcher {
       prInfo.hostname,
       prInfo.protocol,
       apiVersion,
-      { useSessionCookies }
+      { useSessionCookies, pagePathname }
     );
 
     this.isInitialized = true;

--- a/services/azure-devops-server-path.js
+++ b/services/azure-devops-server-path.js
@@ -1,0 +1,36 @@
+/**
+ * Parse Azure DevOps Server (on-prem / TFS) pathname for REST collection root and team project.
+ *
+ * REST base is https://{host}/{collectionPath}/_apis/...
+ * Team-project-scoped calls add /{teamProject}/ before _apis.
+ *
+ * Supports:
+ * - /tfs/{Collection}/_git/{repo}/... → collectionPath tfs/{Collection}, teamProject null
+ * - /tfs/{Collection}/{TeamProject}/_git/{repo}/... → teamProject set
+ * - /{Collection}/_git/... (no IIS app segment) → collectionPath = first segment
+ *
+ * @param {string} pathname - window.location.pathname
+ * @returns {{ collectionPath: string, teamProject: string | null }}
+ */
+export function parseAzureDevOpsServerPath(pathname) {
+  const pathParts = (pathname || '').split('/').filter(Boolean);
+  if (pathParts.length === 0) {
+    return { collectionPath: '', teamProject: null };
+  }
+
+  if (pathParts[0].toLowerCase() === 'tfs' && pathParts.length >= 2 && pathParts[1] !== '_git') {
+    const collectionPath = `${pathParts[0]}/${pathParts[1]}`;
+    const afterCollection = pathParts[2];
+    if (afterCollection == null || afterCollection === '_git') {
+      return { collectionPath, teamProject: null };
+    }
+    return { collectionPath, teamProject: afterCollection };
+  }
+
+  const collectionPath = pathParts[0];
+  const firstAfter = pathParts[1];
+  if (firstAfter == null || firstAfter === '_git') {
+    return { collectionPath, teamProject: null };
+  }
+  return { collectionPath, teamProject: firstAfter };
+}


### PR DESCRIPTION
Fixes on-prem Azure DevOps Server URLs where the collection root is two path segments (e.g. /tfs/{Collection}/...). The extension used only the first segment, so version checks hit the wrong _apis path (404s) and Git calls could fail with “project name required” (400).

**Changes**

Version probe: After all stage‑1 probes 404, retry using the collection path derived from the full pathname (parseAzureDevOpsServerPath).
API calls: On that specific 400, apply the same pathname-based collection/project correction once and retry.
New helper: services/azure-devops-server-path.js. Detector parsing unchanged for compatibility.

**Test**
On-prem PR under /tfs/{Collection}/{Project}/_git/... — review loads; cloud and single-segment collections unchanged.