### PR TITLE
Popup: overlay loader while user and subscription data load

### DIFF
--- a/components/loader/loader.css
+++ b/components/loader/loader.css
@@ -1,0 +1,246 @@
+/* ThinkReview premium loader — visual parity with Thinkreview-webapp LoadingState */
+
+@keyframes tr-loader-spin-outer {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+@keyframes tr-loader-spin-inner {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(-360deg); }
+}
+
+@keyframes tr-loader-breathe {
+  0% {
+    transform: scale(0.94);
+    filter: drop-shadow(0 0 6px rgba(59, 130, 246, 0.45));
+  }
+  50% {
+    transform: scale(1.04);
+    filter: drop-shadow(0 0 18px rgba(99, 102, 241, 0.75));
+  }
+  100% {
+    transform: scale(0.94);
+    filter: drop-shadow(0 0 6px rgba(59, 130, 246, 0.45));
+  }
+}
+
+@keyframes tr-loader-glow-pulse {
+  0% { opacity: 0.35; transform: scale(0.9); }
+  50% { opacity: 0.65; transform: scale(1.1); }
+  100% { opacity: 0.35; transform: scale(0.9); }
+}
+
+@keyframes tr-loader-scanline {
+  0% { top: -105%; }
+  100% { top: 105%; }
+}
+
+@keyframes tr-loader-orbit-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+@keyframes tr-loader-text-fade {
+  0% { opacity: 0; transform: translateY(10px); }
+  10% { opacity: 1; transform: translateY(0); }
+  90% { opacity: 1; transform: translateY(0); }
+  100% { opacity: 0; transform: translateY(-10px); }
+}
+
+@keyframes tr-loader-subtle-pulse {
+  0%, 100% { opacity: 0.75; }
+  50% { opacity: 1; }
+}
+
+.tr-loader-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+}
+
+.tr-loader-overlay[hidden] {
+  display: none !important;
+}
+
+.tr-loader-content {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  min-height: min(400px, 70vh);
+  gap: 28px;
+  padding: 24px;
+  box-sizing: border-box;
+}
+
+.tr-loader-icon-outer {
+  position: relative;
+  margin: 0 auto;
+  overflow: visible;
+}
+
+.tr-loader-rings-center {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 2;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.tr-loader-ring-outer {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  padding: 4px;
+  background: conic-gradient(from 0deg, #3b82f6, #6366f1, #8b5cf6, #ec4899, #3b82f6);
+  -webkit-mask: radial-gradient(farthest-side, transparent calc(100% - 4px), white calc(100% - 4px));
+  mask: radial-gradient(farthest-side, transparent calc(100% - 4px), white calc(100% - 4px));
+  animation: tr-loader-spin-outer 3s linear infinite;
+  box-shadow: 0 0 20px rgba(99, 102, 241, 0.35);
+}
+
+.tr-loader-ring-inner {
+  position: absolute;
+  border-radius: 50%;
+  border: 2px dashed rgba(139, 92, 246, 0.45);
+  animation: tr-loader-spin-inner 4s linear infinite;
+}
+
+.tr-loader-glow {
+  position: absolute;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(99, 102, 241, 0.22) 0%, transparent 70%);
+  animation: tr-loader-glow-pulse 2.4s ease-in-out infinite;
+}
+
+.tr-loader-logo-wrap {
+  position: relative;
+  border-radius: 18%;
+  overflow: hidden;
+  animation: tr-loader-breathe 2.4s ease-in-out infinite;
+  z-index: 2;
+}
+
+.tr-loader-logo-wrap img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.tr-loader-scanline {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 45%;
+  background: linear-gradient(to bottom, transparent 0%, rgba(255, 255, 255, 0.28) 50%, transparent 100%);
+  animation: tr-loader-scanline 2.2s ease-in-out infinite;
+  pointer-events: none;
+}
+
+.tr-loader-orbit-arm {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 0;
+  height: 0;
+  z-index: 1;
+  animation: tr-loader-orbit-spin 2.8s linear infinite;
+}
+
+.tr-loader-orbit-dot {
+  position: absolute;
+  border-radius: 50%;
+  box-shadow: 0 0 8px 2px rgba(0, 0, 0, 0.08);
+}
+
+.tr-loader-messages {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-width: 500px;
+  text-align: center;
+}
+
+.tr-loader-title {
+  font-family: 'Roboto', system-ui, sans-serif;
+  font-size: 1.15rem;
+  font-weight: 700;
+  line-height: 1.35;
+  margin: 0 0 10px 0;
+  background: linear-gradient(135deg, #1f2937, #4b5563);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: #1f2937;
+}
+
+.tr-loader-sub {
+  font-family: 'Roboto', system-ui, sans-serif;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #6366f1;
+  margin: 0 0 14px 0;
+  line-height: 1.45;
+  animation: tr-loader-subtle-pulse 3s ease-in-out infinite;
+}
+
+.tr-loader-fact-wrap {
+  min-height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.tr-loader-fact {
+  font-family: 'Roboto', system-ui, sans-serif;
+  font-size: 0.875rem;
+  font-style: italic;
+  color: #6b7280;
+  line-height: 1.6;
+  margin: 0;
+  animation: tr-loader-text-fade 12s ease-in-out;
+  animation-fill-mode: forwards;
+  opacity: 0;
+}
+
+.tr-loader-fact-label {
+  font-weight: 700;
+  font-style: normal;
+  color: #4b5563;
+  margin-right: 6px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tr-loader-ring-outer,
+  .tr-loader-ring-inner,
+  .tr-loader-glow,
+  .tr-loader-logo-wrap,
+  .tr-loader-scanline,
+  .tr-loader-orbit-arm,
+  .tr-loader-sub,
+  .tr-loader-fact {
+    animation: none !important;
+  }
+
+  .tr-loader-logo-wrap {
+    transform: none;
+    filter: drop-shadow(0 0 8px rgba(99, 102, 241, 0.4));
+  }
+
+  .tr-loader-fact {
+    opacity: 1;
+    transform: none;
+  }
+}

--- a/components/loader/loader.js
+++ b/components/loader/loader.js
@@ -1,0 +1,280 @@
+/**
+ * Premium full-page loader — visual parity with Thinkreview-webapp `LoadingState`.
+ * Vanilla DOM + CSS (no React/MUI). Safe for extension pages and content contexts
+ * that expose `chrome.runtime.getURL`.
+ */
+
+import { getRandomFact } from './loadingMessages.js';
+
+const STYLE_LINK_ID = 'thinkreview-loader-stylesheet';
+
+function ensureLoaderStyles() {
+  if (document.getElementById(STYLE_LINK_ID)) return;
+  const link = document.createElement('link');
+  link.id = STYLE_LINK_ID;
+  link.rel = 'stylesheet';
+  if (typeof chrome !== 'undefined' && chrome.runtime?.getURL) {
+    link.href = chrome.runtime.getURL('components/loader/loader.css');
+  } else {
+    link.href = new URL('loader.css', import.meta.url).href;
+  }
+  document.head.appendChild(link);
+}
+
+function extensionIconUrl(file) {
+  if (typeof chrome !== 'undefined' && chrome.runtime?.getURL) {
+    return chrome.runtime.getURL(file);
+  }
+  return file;
+}
+
+/**
+ * @typedef {Object} ThinkReviewLoaderOptions
+ * @property {string} [message]
+ * @property {string|null} [subMessage]
+ * @property {boolean} [showAnalyzing]
+ * @property {number} [size] Scale multiplier (default 0.52 for extension tab)
+ * @property {boolean} [showFacts]
+ * @property {number|null} [minHeight] Min height of inner content in px
+ */
+
+export class ThinkReviewLoader {
+  /**
+   * @param {HTMLElement} rootElement Host node (e.g. #user-data-loading-overlay). Cleared on first mount.
+   * @param {ThinkReviewLoaderOptions} [options]
+   */
+  constructor(rootElement, options = {}) {
+    this.root = rootElement;
+    this.options = {
+      message: options.message ?? 'Loading...',
+      subMessage: options.subMessage ?? null,
+      showAnalyzing: !!options.showAnalyzing,
+      size: typeof options.size === 'number' ? options.size : 0.52,
+      showFacts: options.showFacts !== false,
+      minHeight: options.minHeight ?? null,
+    };
+    /** @type {HTMLElement|null} */
+    this._inner = null;
+    /** @type {HTMLElement|null} */
+    this._titleEl = null;
+    /** @type {HTMLElement|null} */
+    this._subEl = null;
+    /** @type {HTMLElement|null} */
+    this._factEl = null;
+    this._factInterval = null;
+    this._mounted = false;
+  }
+
+  mount() {
+    if (this._mounted) return;
+    ensureLoaderStyles();
+
+    this.root.textContent = '';
+    this.root.classList.add('tr-loader-overlay');
+
+    const { size } = this.options;
+    const BASE = 96 * size;
+    const dotSize = 7 * size;
+    const logoHalf = BASE * 0.31;
+    const logoReachPx = logoHalf * Math.SQRT2 * 1.06;
+    const orbitRadiusPx = logoReachPx + dotSize / 2 + 6 * size;
+    const orbitExtentPx = orbitRadiusPx + dotSize / 2 + 4 * size;
+    const padPx = Math.max(0, orbitExtentPx - BASE / 2);
+    const boxSizePx = BASE + 2 * padPx;
+
+    const content = document.createElement('div');
+    content.className = 'tr-loader-content';
+    content.setAttribute('role', 'status');
+    if (this.options.minHeight != null) {
+      content.style.minHeight = `${this.options.minHeight}px`;
+    }
+
+    const iconOuter = document.createElement('div');
+    iconOuter.className = 'tr-loader-icon-outer';
+    iconOuter.style.width = `${boxSizePx}px`;
+    iconOuter.style.height = `${boxSizePx}px`;
+
+    const orbitColors = ['#3b82f6', '#10b981', '#8b5cf6'];
+    const orbitDelays = [0, 0.93, 1.87];
+    orbitColors.forEach((color, i) => {
+      const arm = document.createElement('div');
+      arm.className = 'tr-loader-orbit-arm';
+      arm.style.animationDelay = `${orbitDelays[i]}s`;
+      const dot = document.createElement('div');
+      dot.className = 'tr-loader-orbit-dot';
+      dot.style.width = `${dotSize}px`;
+      dot.style.height = `${dotSize}px`;
+      dot.style.background = color;
+      dot.style.boxShadow = `0 0 8px 2px ${color}55`;
+      dot.style.left = `${orbitRadiusPx - dotSize / 2}px`;
+      dot.style.top = `${-dotSize / 2}px`;
+      arm.appendChild(dot);
+      iconOuter.appendChild(arm);
+    });
+
+    const ringsCenter = document.createElement('div');
+    ringsCenter.className = 'tr-loader-rings-center';
+    ringsCenter.style.width = `${BASE}px`;
+    ringsCenter.style.height = `${BASE}px`;
+
+    const ringOuter = document.createElement('div');
+    ringOuter.className = 'tr-loader-ring-outer';
+
+    const ringInner = document.createElement('div');
+    ringInner.className = 'tr-loader-ring-inner';
+    const innerInset = BASE * 0.1;
+    ringInner.style.top = `${innerInset}px`;
+    ringInner.style.right = `${innerInset}px`;
+    ringInner.style.bottom = `${innerInset}px`;
+    ringInner.style.left = `${innerInset}px`;
+
+    const glow = document.createElement('div');
+    glow.className = 'tr-loader-glow';
+    const glowInset = BASE * 0.15;
+    glow.style.top = `${glowInset}px`;
+    glow.style.right = `${glowInset}px`;
+    glow.style.bottom = `${glowInset}px`;
+    glow.style.left = `${glowInset}px`;
+
+    const logoWrap = document.createElement('div');
+    logoWrap.className = 'tr-loader-logo-wrap';
+    logoWrap.style.width = `${BASE * 0.62}px`;
+    logoWrap.style.height = `${BASE * 0.62}px`;
+
+    const img = document.createElement('img');
+    img.src = extensionIconUrl('images/icon128.png');
+    img.alt = 'ThinkReview';
+    img.addEventListener('error', () => {
+      img.src = extensionIconUrl('images/icon48.png');
+    }, { once: true });
+
+    const scanline = document.createElement('div');
+    scanline.className = 'tr-loader-scanline';
+
+    logoWrap.appendChild(img);
+    logoWrap.appendChild(scanline);
+
+    ringsCenter.appendChild(ringOuter);
+    ringsCenter.appendChild(ringInner);
+    ringsCenter.appendChild(glow);
+    ringsCenter.appendChild(logoWrap);
+    iconOuter.appendChild(ringsCenter);
+
+    const messages = document.createElement('div');
+    messages.className = 'tr-loader-messages';
+
+    const title = document.createElement('h2');
+    title.className = 'tr-loader-title';
+    title.textContent = this.options.message;
+    messages.appendChild(title);
+
+    const subText =
+      this.options.subMessage ||
+      (this.options.showAnalyzing
+        ? 'Processing your data and calculating metrics. Please wait...'
+        : '');
+    if (subText) {
+      const sub = document.createElement('p');
+      sub.className = 'tr-loader-sub';
+      sub.textContent = subText;
+      messages.appendChild(sub);
+      this._subEl = sub;
+    } else {
+      this._subEl = null;
+    }
+
+    if (this.options.showFacts) {
+      const factWrap = document.createElement('div');
+      factWrap.className = 'tr-loader-fact-wrap';
+      this._factEl = document.createElement('p');
+      this._factEl.className = 'tr-loader-fact';
+      factWrap.appendChild(this._factEl);
+      messages.appendChild(factWrap);
+      this._applyFactContent();
+    }
+
+    content.appendChild(iconOuter);
+    content.appendChild(messages);
+    this.root.appendChild(content);
+
+    this._inner = content;
+    this._titleEl = title;
+    this._mounted = true;
+  }
+
+  _applyFactContent() {
+    if (!this._factEl) return;
+    const fact = getRandomFact();
+    this._factEl.textContent = '';
+    const label = document.createElement('span');
+    label.className = 'tr-loader-fact-label';
+    label.textContent = 'Did you know?';
+    this._factEl.appendChild(label);
+    this._factEl.appendChild(document.createTextNode(` ${fact}`));
+  }
+
+  /** Restart the fact line fade animation (call after swapping text). */
+  _restartFactAnimation() {
+    if (!this._factEl) return;
+    this._factEl.style.animation = 'none';
+    // reflow
+    void this._factEl.offsetHeight;
+    this._factEl.style.removeProperty('animation');
+  }
+
+  /**
+   * @param {string} message
+   * @param {string|null} [subMessage]
+   */
+  setMessages(message, subMessage = null) {
+    this.options.message = message;
+    this.options.subMessage = subMessage;
+    if (!this._mounted) return;
+    if (this._titleEl) this._titleEl.textContent = message;
+    if (subMessage) {
+      if (this._subEl) {
+        this._subEl.textContent = subMessage;
+      } else {
+        const messages = this._inner?.querySelector('.tr-loader-messages');
+        if (messages && this._titleEl) {
+          const sub = document.createElement('p');
+          sub.className = 'tr-loader-sub';
+          sub.textContent = subMessage;
+          this._titleEl.insertAdjacentElement('afterend', sub);
+          this._subEl = sub;
+        }
+      }
+    } else if (this._subEl) {
+      this._subEl.remove();
+      this._subEl = null;
+    }
+  }
+
+  show() {
+    this.mount();
+    if (this.options.showFacts && this._factEl) {
+      this._stopFactRotation();
+      this._applyFactContent();
+      this._restartFactAnimation();
+      this._factInterval = window.setInterval(() => {
+        this._applyFactContent();
+        this._restartFactAnimation();
+      }, 12000);
+    }
+    this.root.hidden = false;
+    this.root.setAttribute('aria-busy', 'true');
+  }
+
+  hide() {
+    this._stopFactRotation();
+    this.root.hidden = true;
+    this.root.setAttribute('aria-busy', 'false');
+  }
+
+  _stopFactRotation() {
+    if (this._factInterval != null) {
+      window.clearInterval(this._factInterval);
+      this._factInterval = null;
+    }
+  }
+}

--- a/components/loader/loadingMessages.js
+++ b/components/loader/loadingMessages.js
@@ -1,0 +1,29 @@
+/**
+ * Educational tech and AI facts (aligned with Thinkreview-webapp loading UX).
+ */
+export const loadingFacts = [
+  'The first computer mouse, invented in 1964 by Doug Engelbart, was made of wood.',
+  'The term "bug" for a computer glitch was popularized by Grace Hopper in 1947 after finding a real moth in a relay.',
+  'The first AI program, "Logic Theorist", was written in 1955 by Allen Newell, Cliff Shaw, and Herbert Simon.',
+  'ARPANET, the precursor to the internet, successfully sent its first message in 1969. It was "LO" (the system crashed before finishing "LOGIN").',
+  'The first domain name ever registered was symbolics.com on March 15, 1985.',
+  "The world's first website and web browser were created by Tim Berners-Lee in 1990 at CERN.",
+  'The first 1GB hard drive was announced by IBM in 1980. It weighed over 500 pounds and cost $40,000.',
+  'The QWERTY keyboard layout was designed in 1873 to slow down typists and prevent typewriter keys from jamming.',
+  'JavaScript was created by Brendan Eich in just 10 days in May 1995.',
+  'The first 10-megabyte hard drive cost $3,495 when it was introduced by Apple in 1981.',
+  'CAPTCHA stands for "Completely Automated Public Turing test to tell Computers and Humans Apart."',
+  'The first webcam was created at Cambridge University in 1991 to monitor the level of a coffee pot in the lab.',
+  'The name "Google" was originally a misspelling of "Googol", which is the number 1 followed by 100 zeros.',
+  'The first computer virus, known as "Creeper", was created in 1971 by Bob Thomas as an experimental self-duplicating program.',
+  "IBM's Deep Blue became the first computer to beat a reigning world chess champion, Garry Kasparov, in 1997.",
+  'The Python programming language was named after the British comedy group Monty Python, not the snake.',
+  'The first mobile phone call was made by Martin Cooper in 1973 using a Motorola DynaTAC that weighed 2.5 pounds.',
+  'The Apollo 11 Guidance Computer that took humanity to the moon operated at 0.043 MHz and had only 4KB of RAM.',
+  'Alan Turing introduced the concept of the Turing Test in his 1950 paper "Computing Machinery and Intelligence."',
+  'More than 50% of global internet traffic is currently driven by bots, both malicious and benign.',
+];
+
+export function getRandomFact() {
+  return loadingFacts[Math.floor(Math.random() * loadingFacts.length)];
+}

--- a/popup.css
+++ b/popup.css
@@ -340,62 +340,6 @@ h1 {
   display: none;
 }
 
-/* Full-page overlay while ThinkReviewGetUserData / subscription CFs load */
-.user-data-loading-overlay {
-  position: fixed;
-  inset: 0;
-  z-index: 10000;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 24px;
-  background: rgba(255, 255, 255, 0.72);
-  backdrop-filter: blur(6px);
-  -webkit-backdrop-filter: blur(6px);
-}
-
-.user-data-loading-overlay[hidden] {
-  display: none !important;
-}
-
-.user-data-loading-card {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 14px;
-  max-width: 280px;
-  padding: 28px 32px;
-  background: #fff;
-  border-radius: 12px;
-  box-shadow: 0 8px 32px rgba(107, 79, 187, 0.12), 0 2px 8px rgba(0, 0, 0, 0.06);
-  border: 1px solid rgba(107, 79, 187, 0.15);
-  text-align: center;
-}
-
-.user-data-loading-spinner {
-  width: 40px;
-  height: 40px;
-  border: 3px solid #ede7f6;
-  border-top-color: #6b4fbb;
-  border-radius: 50%;
-  animation: spin 0.85s linear infinite;
-}
-
-.user-data-loading-title {
-  font-size: 15px;
-  font-weight: 600;
-  color: #2d2640;
-  margin: 0;
-  line-height: 1.3;
-}
-
-.user-data-loading-sub {
-  font-size: 13px;
-  color: #5c5470;
-  margin: 0;
-  line-height: 1.45;
-}
-
 /* Status Messages */
 #current-status {
   padding: 8px 12px;
@@ -680,12 +624,6 @@ input:focus {
     animation: none;
   }
 
-  .user-data-loading-spinner {
-    animation: none;
-    border-top-color: #6b4fbb;
-    opacity: 0.85;
-  }
-  
   #authenticated-content {
     transition: none;
   }

--- a/popup.css
+++ b/popup.css
@@ -340,9 +340,60 @@ h1 {
   display: none;
 }
 
-#authenticated-content.loading {
-  opacity: 0.6;
-  pointer-events: none;
+/* Full-page overlay while ThinkReviewGetUserData / subscription CFs load */
+.user-data-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(255, 255, 255, 0.72);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+}
+
+.user-data-loading-overlay[hidden] {
+  display: none !important;
+}
+
+.user-data-loading-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  max-width: 280px;
+  padding: 28px 32px;
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 8px 32px rgba(107, 79, 187, 0.12), 0 2px 8px rgba(0, 0, 0, 0.06);
+  border: 1px solid rgba(107, 79, 187, 0.15);
+  text-align: center;
+}
+
+.user-data-loading-spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid #ede7f6;
+  border-top-color: #6b4fbb;
+  border-radius: 50%;
+  animation: spin 0.85s linear infinite;
+}
+
+.user-data-loading-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: #2d2640;
+  margin: 0;
+  line-height: 1.3;
+}
+
+.user-data-loading-sub {
+  font-size: 13px;
+  color: #5c5470;
+  margin: 0;
+  line-height: 1.45;
 }
 
 /* Status Messages */
@@ -627,6 +678,12 @@ input:focus {
 @media (prefers-reduced-motion: reduce) {
   .loading-spinner {
     animation: none;
+  }
+
+  .user-data-loading-spinner {
+    animation: none;
+    border-top-color: #6b4fbb;
+    opacity: 0.85;
   }
   
   #authenticated-content {

--- a/popup.html
+++ b/popup.html
@@ -9,13 +9,7 @@
 </head>
 <body>
   <div id="popup-container">
-    <div id="user-data-loading-overlay" class="user-data-loading-overlay" hidden aria-live="polite" aria-busy="false">
-      <div class="user-data-loading-card" role="status">
-        <div class="user-data-loading-spinner" aria-hidden="true"></div>
-        <p class="user-data-loading-title">Loading your account</p>
-        <p class="user-data-loading-sub">Fetching plan and usage…</p>
-      </div>
-    </div>
+    <div id="user-data-loading-overlay" hidden aria-live="polite" aria-busy="false"></div>
     <header class="app-header">
       <div class="header-top-row">
         <div class="title-with-logo">

--- a/popup.html
+++ b/popup.html
@@ -9,6 +9,13 @@
 </head>
 <body>
   <div id="popup-container">
+    <div id="user-data-loading-overlay" class="user-data-loading-overlay" hidden aria-live="polite" aria-busy="false">
+      <div class="user-data-loading-card" role="status">
+        <div class="user-data-loading-spinner" aria-hidden="true"></div>
+        <p class="user-data-loading-title">Loading your account</p>
+        <p class="user-data-loading-sub">Fetching plan and usage…</p>
+      </div>
+    </div>
     <header class="app-header">
       <div class="header-top-row">
         <div class="title-with-logo">

--- a/popup.js
+++ b/popup.js
@@ -1,6 +1,12 @@
 // popup.js
 // Shows patch status and recent patches
 
+import { ThinkReviewLoader } from './components/loader/loader.js';
+import { subscriptionStatus } from './components/popup-modules/subscription-status.js';
+import { reviewCount } from './components/popup-modules/review-count.js';
+import { dbgLog, dbgWarn, dbgError } from './utils/logger.js';
+import { clampTemperature, clampTopP, clampTopK } from './utils/ollama-options.js';
+
 // Timing constants (in milliseconds)
 const TIMEOUT_AUTO_SIGNIN_WAIT = 500;
 const TIMEOUT_SETTINGS_SCROLL = 400;
@@ -14,32 +20,40 @@ function delay(ms) {
 
 let userDataLoadingOverlayDepth = 0;
 
+/** @type {ThinkReviewLoader|null} */
+let accountUserDataLoader = null;
+
+function getAccountUserDataLoader() {
+  const el = document.getElementById('user-data-loading-overlay');
+  if (!el) return null;
+  if (!accountUserDataLoader) {
+    accountUserDataLoader = new ThinkReviewLoader(el, {
+      message: 'Loading your account',
+      subMessage: 'Fetching plan and usage…',
+      size: 0.52,
+      showFacts: true,
+    });
+  }
+  return accountUserDataLoader;
+}
+
 function pushUserDataLoadingOverlay() {
   userDataLoadingOverlayDepth += 1;
-  const el = document.getElementById('user-data-loading-overlay');
-  if (el) {
-    el.hidden = false;
-    el.setAttribute('aria-busy', 'true');
+  const loader = getAccountUserDataLoader();
+  if (loader && userDataLoadingOverlayDepth === 1) {
+    loader.show();
   }
 }
 
 function popUserDataLoadingOverlay() {
   userDataLoadingOverlayDepth = Math.max(0, userDataLoadingOverlayDepth - 1);
   if (userDataLoadingOverlayDepth === 0) {
-    const el = document.getElementById('user-data-loading-overlay');
-    if (el) {
-      el.hidden = true;
-      el.setAttribute('aria-busy', 'false');
+    const loader = getAccountUserDataLoader();
+    if (loader) {
+      loader.hide();
     }
   }
 }
-
-// Import modules for better modularity
-import { subscriptionStatus } from './components/popup-modules/subscription-status.js';
-import { reviewCount } from './components/popup-modules/review-count.js';
-
-import { dbgLog, dbgWarn, dbgError } from './utils/logger.js';
-import { clampTemperature, clampTopP, clampTopK } from './utils/ollama-options.js';
 
 // State management
 let isInitialized = false;
@@ -69,7 +83,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   }
 });
 
-// Function to show loading state (status line only; user-data fetch uses #user-data-loading-overlay)
+// Function to show loading state (status line only; user-data fetch uses ThinkReviewLoader on #user-data-loading-overlay)
 function showLoadingState() {
   const authenticatedContent = document.getElementById('authenticated-content');
   const statusDiv = document.getElementById('current-status');

--- a/popup.js
+++ b/popup.js
@@ -8,6 +8,32 @@ const TIMEOUT_HIGHLIGHT_ANIMATION = 2500;
 const TIMEOUT_CLEAR_TOKEN_STATUS = 5000;
 const TIMEOUT_TOAST_VISIBILITY = 1500;
 
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+let userDataLoadingOverlayDepth = 0;
+
+function pushUserDataLoadingOverlay() {
+  userDataLoadingOverlayDepth += 1;
+  const el = document.getElementById('user-data-loading-overlay');
+  if (el) {
+    el.hidden = false;
+    el.setAttribute('aria-busy', 'true');
+  }
+}
+
+function popUserDataLoadingOverlay() {
+  userDataLoadingOverlayDepth = Math.max(0, userDataLoadingOverlayDepth - 1);
+  if (userDataLoadingOverlayDepth === 0) {
+    const el = document.getElementById('user-data-loading-overlay');
+    if (el) {
+      el.hidden = true;
+      el.setAttribute('aria-busy', 'false');
+    }
+  }
+}
+
 // Import modules for better modularity
 import { subscriptionStatus } from './components/popup-modules/subscription-status.js';
 import { reviewCount } from './components/popup-modules/review-count.js';
@@ -43,14 +69,14 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   }
 });
 
-// Function to show loading state
+// Function to show loading state (status line only; user-data fetch uses #user-data-loading-overlay)
 function showLoadingState() {
   const authenticatedContent = document.getElementById('authenticated-content');
   const statusDiv = document.getElementById('current-status');
   
   if (authenticatedContent) {
     authenticatedContent.style.display = 'block';
-    authenticatedContent.classList.add('loading');
+    authenticatedContent.classList.remove('loading');
   }
   
   if (statusDiv) {
@@ -169,58 +195,64 @@ function isUserLoggedIn() {
   });
 }
 
-// Function to fetch and display review count with retry logic
-async function fetchAndDisplayUserData(retryCount = 0) {
+// Function to fetch and display review count with retry logic (ThinkReviewGetUserData + subscription CFs)
+async function fetchAndDisplayUserData() {
   const maxRetries = 3;
-  
+  pushUserDataLoadingOverlay();
   try {
-    // Check if CloudService is available
-    if (!window.CloudService) {
-      if (retryCount < maxRetries) {
-        // Use exponential backoff for retries (1s, 2s, 4s)
-        const backoffTime = Math.pow(2, retryCount) * 500;
-        dbgLog(`CloudService not available, retrying in ${backoffTime/1000}s (attempt ${retryCount + 1}/${maxRetries})`);
-        setTimeout(() => fetchAndDisplayUserData(retryCount + 1), backoffTime);
-        return;
-      } else {
+    let cloudRetry = 0;
+    while (!window.CloudService) {
+      if (cloudRetry >= maxRetries) {
         dbgWarn('CloudService not available after retries');
-              showErrorState('Unable to load user data');
-      updateReviewCount('error');
-      await updateSubscriptionStatus('Free', null, false, null);
+        showErrorState('Unable to load user data');
+        updateReviewCount('error');
+        await updateSubscriptionStatus('Free', null, false, null);
         return;
       }
+      const backoffTime = Math.pow(2, cloudRetry) * 500;
+      dbgLog(`CloudService not available, retrying in ${backoffTime / 1000}s (attempt ${cloudRetry + 1}/${maxRetries})`);
+      await delay(backoffTime);
+      cloudRetry += 1;
     }
-    
-    // Double-check that CloudService is actually ready
+
     if (!cloudServiceReady) {
-      cloudServiceReady = true; // Mark as ready since we have the service
+      cloudServiceReady = true;
       dbgLog('CloudService detected as ready during fetch');
     }
-    const userData = await window.CloudService.getUserDataWithSubscription();
-    updateReviewCount(userData.reviewCount);
-    // Use consolidated fields: subscriptionType and cancellationRequested
-    const subscriptionType = userData.subscriptionType || userData.stripeSubscriptionType || 'Free';
-    const cancellationRequested = userData.cancellationRequested || false;
-    const initialTrialEndDate = userData.initialTrialEndDate || null;
-    await updateSubscriptionStatus(subscriptionType, userData.currentPlanValidTo, cancellationRequested, userData.stripeCanceledDate, initialTrialEndDate);
-    dbgLog('User data updated:', userData);
-    
-    // Show success state if we got valid data
-    if (userData.reviewCount !== null && userData.reviewCount !== undefined) {
-      // showSuccessState('User data loaded successfully');
+
+    let fetchAttempt = 0;
+    while (true) {
+      try {
+        const userData = await window.CloudService.getUserDataWithSubscription();
+        updateReviewCount(userData.reviewCount);
+        const subscriptionType = userData.subscriptionType || userData.stripeSubscriptionType || 'Free';
+        const cancellationRequested = userData.cancellationRequested || false;
+        const initialTrialEndDate = userData.initialTrialEndDate || null;
+        await updateSubscriptionStatus(
+          subscriptionType,
+          userData.currentPlanValidTo,
+          cancellationRequested,
+          userData.stripeCanceledDate,
+          initialTrialEndDate
+        );
+        dbgLog('User data updated:', userData);
+        return;
+      } catch (error) {
+        dbgWarn('Error fetching user data:', error);
+        if (fetchAttempt >= maxRetries) {
+          showErrorState('Failed to load user data');
+          updateReviewCount('error');
+          await updateSubscriptionStatus('Free', null, false, null);
+          return;
+        }
+        const backoffTime = Math.pow(2, fetchAttempt) * 500;
+        dbgLog(`Retrying user data fetch in ${backoffTime / 1000}s (attempt ${fetchAttempt + 1}/${maxRetries})`);
+        await delay(backoffTime);
+        fetchAttempt += 1;
+      }
     }
-  } catch (error) {
-    dbgWarn('Error fetching user data:', error);
-    if (retryCount < maxRetries) {
-      // Use exponential backoff for retries (1s, 2s, 4s)
-      const backoffTime = Math.pow(2, retryCount) * 500;
-      dbgLog(`Retrying user data fetch in ${backoffTime/1000}s (attempt ${retryCount + 1}/${maxRetries})`);
-      setTimeout(() => fetchAndDisplayUserData(retryCount + 1), backoffTime);
-    } else {
-      showErrorState('Failed to load user data');
-      updateReviewCount('error');
-      await updateSubscriptionStatus('Free', null, false, null);
-    }
+  } finally {
+    popUserDataLoadingOverlay();
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
While `ThinkReviewGetUserData` and `getUserSubscriptionDataThinkReview` run (via `CloudService.getUserDataWithSubscription()`), the popup no longer relies on a dimmed `#authenticated-content` state. A fixed overlay with blur, spinner, and short copy covers the popup until the fetch completes or fails after retries.

## Implementation notes
- Added `#user-data-loading-overlay` in `popup.html` with accessible `aria-live` / `aria-busy` and `role="status"`.
- Styled the overlay and card in `popup.css`; respects `prefers-reduced-motion` for the spinner.
- `fetchAndDisplayUserData()` now uses `async`/`await` with `delay()` for backoff so the overlay stays visible through retries; a depth counter handles overlapping calls (e.g. init + `forceRefreshUserData`).
- `showLoadingState()` no longer adds the `loading` class to `#authenticated-content` (only updates the status line).

## Testing
- `npm install && npm run test` (pass)
- `npm run validate && npm run lint` (pass)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-999f06ef-7f11-458a-8dfb-c21744d43f3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-999f06ef-7f11-458a-8dfb-c21744d43f3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

