### PR TITLE
Fix/integrated panel summary bullet lists

### DIFF
--- a/OLLAMA_SETUP.md
+++ b/OLLAMA_SETUP.md
@@ -170,7 +170,7 @@ Set `OLLAMA_ORIGINS` permanently so you don't need to set it every time you run 
 Once configured, ThinkReview will automatically use Ollama for all code reviews:
 
 1. Navigate to a GitLab merge request or Azure DevOps pull request
-2. Click the **"AI Review"** button
+2. Click the **ThinkReview** button
 3. Your code will be analyzed locally using Ollama
 4. Review results appear in the integrated panel
 

--- a/background.js
+++ b/background.js
@@ -34,6 +34,9 @@ const OPEN_PAGE_ALLOWED_ORIGINS = [
   'app.thinkreview.dev'
 ];
 
+/** Portal page for extension sign-up / sign-in (same as popup google-signin). */
+const SIGNIN_EXTENSION_PORTAL_URL = 'https://portal.thinkreview.dev/signin-extension';
+
 // Azure fetcher/API use singleton state, so serialize requests to avoid cross-tab races.
 let azureFetchQueue = Promise.resolve();
 
@@ -677,6 +680,26 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     });
     
     return true; // Keep message channel open for async response
+  }
+
+  // Open portal sign-in in a new tab (integrated panel + anywhere in extension; fixed URL only).
+  if (message.type === 'OPEN_SIGNIN_PORTAL') {
+    if (!checkOpenPageRateLimit()) {
+      dbgWarn('OPEN_SIGNIN_PORTAL rejected: rate limit exceeded');
+      sendResponse({ success: false, error: 'Rate limit exceeded' });
+      return true;
+    }
+    dbgLog('Opening portal sign-in extension page in new tab');
+    chrome.tabs.create({ url: SIGNIN_EXTENSION_PORTAL_URL }, (tab) => {
+      if (chrome.runtime.lastError) {
+        dbgWarn('Error opening portal sign-in:', chrome.runtime.lastError);
+        sendResponse({ success: false, error: chrome.runtime.lastError.message });
+      } else {
+        dbgLog('Portal sign-in opened in tab:', tab.id);
+        sendResponse({ success: true, tabId: tab.id });
+      }
+    });
+    return true;
   }
 
   if (message.type === 'TRIGGER_GOOGLE_SIGNIN') {

--- a/components/integrated-review.css
+++ b/components/integrated-review.css
@@ -11,7 +11,7 @@
   --thinkreview-panel-width: 520px;
 
   /* Panel vertical positioning: top offset and bottom gap define max-height.
-     Bottom gap keeps a small buffer above the floating AI Review button. */
+     Bottom gap keeps a small buffer above the floating ThinkReview button. */
   --thinkreview-panel-top: 100px;
   --thinkreview-panel-bottom-gap: 80px;
   --thinkreview-panel-max-height: calc(100vh - var(--thinkreview-panel-top) - var(--thinkreview-panel-bottom-gap));
@@ -2537,7 +2537,7 @@ body.thinkreview-body-docked-left {
   transition: margin-left 0.5s ease;
 }
 
-/* Toggle button styles removed - using only arrow down and AI Review button */
+/* Toggle button styles removed - using only arrow down and ThinkReview button */
 
 #gitlab-mr-integrated-review .btn {
   padding: 6px 10px;

--- a/components/integrated-review.css
+++ b/components/integrated-review.css
@@ -2821,6 +2821,16 @@ body[data-theme="high-contrast"] #gitlab-mr-integrated-review .thinkreview-card-
   line-height: 1.4 !important;
 }
 
+#gitlab-mr-integrated-review .thinkreview-login-description a {
+  color: var(--thinkreview-accent, #6b4fbb) !important;
+  word-break: break-all;
+}
+
+#gitlab-mr-integrated-review .thinkreview-login-refresh-hint {
+  margin-top: 12px !important;
+  margin-bottom: 0 !important;
+}
+
 /* Dark theme overrides for login prompt */
 body[data-theme="dark"] #gitlab-mr-integrated-review .thinkreview-login-heading,
 body[data-theme="high-contrast"] #gitlab-mr-integrated-review .thinkreview-login-heading {

--- a/components/integrated-review.js
+++ b/components/integrated-review.js
@@ -70,6 +70,7 @@ document.head.appendChild(itemCopyButtonLinkElement);
 
 // Formatting utils
 let markdownToHtml = null;
+let markdownToSummaryHtml = null;
 let preprocessAIResponse = null;
 let applySimpleSyntaxHighlighting = null;
 let setupCopyHandler = null;
@@ -101,6 +102,7 @@ async function initFormattingUtils() {
   try {
     const module = await import(chrome.runtime.getURL('components/utils/formatting.js'));
     markdownToHtml = module.markdownToHtml;
+    markdownToSummaryHtml = module.markdownToSummaryHtml;
     preprocessAIResponse = module.preprocessAIResponse;
     applySimpleSyntaxHighlighting = module.applySimpleSyntaxHighlighting;
     setupCopyHandler = module.setupCopyHandler;
@@ -1886,7 +1888,9 @@ async function displayIntegratedReview(
   };
 
   // Populate static review content
-  const summaryHtml = markdownToHtml(preprocessAIResponse(review.summary || 'No summary provided.'));
+  const summaryHtml = markdownToSummaryHtml
+    ? markdownToSummaryHtml(review.summary || 'No summary provided.')
+    : markdownToHtml(preprocessAIResponse(review.summary || 'No summary provided.'));
   reviewSummary.innerHTML = summaryHtml;
   // Highlight code in summary
   applySimpleSyntaxHighlighting(reviewSummary);

--- a/components/integrated-review.js
+++ b/components/integrated-review.js
@@ -275,7 +275,7 @@ function stopEnhancedLoader() {
 
 // applySimpleSyntaxHighlighting is provided by utils/formatting.js via dynamic import
 
-// Toggle button removed as per user request - using only the arrow down button and AI Review button
+// Toggle button removed as per user request - using only the arrow down button and ThinkReview button
 
 /**
  * Creates and injects the integrated review panel into the GitLab MR page
@@ -1832,7 +1832,7 @@ async function displayIntegratedReview(
     });
   }
 
-  // Show score popup and notification indicator on AI Review button if panel is minimized
+  // Show score popup and notification indicator on ThinkReview button if panel is minimized
   const panel = document.getElementById('gitlab-mr-integrated-review');
   if (panel && panel.classList.contains('thinkreview-panel-minimized-to-button')) {
     // Show score popup if metrics are available

--- a/components/popup-modules/button-loading-indicator.js
+++ b/components/popup-modules/button-loading-indicator.js
@@ -1,6 +1,6 @@
 /**
  * Button Loading Indicator Module
- * Adds a loading indicator to the AI Review trigger (floating button or sidebar tab) when review is in progress and panel is minimized.
+ * Adds a loading indicator to the ThinkReview trigger (floating button or sidebar tab) when review is in progress and panel is minimized.
  * On side layout, the indicator is shown at the bottom of the tab for visibility.
  */
 

--- a/components/popup-modules/button-notification.js
+++ b/components/popup-modules/button-notification.js
@@ -1,6 +1,6 @@
 /**
  * Button Notification Module
- * Adds a notification indicator to the AI Review trigger (floating button or sidebar tab) when review is completed but panel hasn't been opened.
+ * Adds a notification indicator to the ThinkReview trigger (floating button or sidebar tab) when review is completed but panel hasn't been opened.
  * On side layout, the dot is shown at the bottom of the tab for visibility.
  */
 

--- a/components/popup-modules/score-popup.css
+++ b/components/popup-modules/score-popup.css
@@ -1,4 +1,4 @@
-/* Score Popup on AI Review Button - Circular Gauge */
+/* Score Popup on ThinkReview Button - Circular Gauge */
 .thinkreview-score-popup {
   position: fixed;
   background: transparent;

--- a/components/popup-modules/score-popup.js
+++ b/components/popup-modules/score-popup.js
@@ -1,6 +1,6 @@
 /**
  * Score Popup Module
- * Displays a quality score popup on the AI Review button when the panel is minimized
+ * Displays a quality score popup on the ThinkReview button when the panel is minimized
  */
 
 // Load CSS for the score popup
@@ -171,7 +171,7 @@ function createPopup(overallScore) {
 }
 
 /**
- * Shows a score popup on the AI Review button when panel is minimized
+ * Shows a score popup on the ThinkReview button when panel is minimized
  * @param {number} overallScore - The overall quality score (0-100)
  */
 export function showScorePopupOnButton(overallScore) {

--- a/components/utils/formatting.js
+++ b/components/utils/formatting.js
@@ -235,6 +235,18 @@ export function markdownToHtml(markdown) {
   return html;
 }
 
+/**
+ * Renders the main review summary: same as markdownToHtml on preprocessed text, but
+ * lines written as ordered lists (1. 2. …) are shown as bullet lists in the integrated panel.
+ */
+export function markdownToSummaryHtml(markdown) {
+  const html = markdownToHtml(preprocessAIResponse(markdown));
+  return html
+    .replace(/<ol\b[^>]*>/g, '<ul>')
+    .replace(/<\/ol>/g, '</ul>')
+    .replace(/data-list-type="ol"/g, 'data-list-type="ul"');
+}
+
 export function applySimpleSyntaxHighlighting(rootElement) {
   const root = rootElement || document;
   const codeBlocks = root.querySelectorAll('pre code[class^="language-"], pre code[class*=" language-"]');

--- a/content.js
+++ b/content.js
@@ -683,11 +683,16 @@ function showLoginPrompt() {
   if (reviewContent) reviewContent.classList.add('gl-hidden');
   if (reviewError) reviewError.classList.add('gl-hidden');
   
-  // Create login prompt if it doesn't exist
+  // Create login prompt if it doesn't exist (replace legacy Google-only prompt)
   let loginPrompt = document.getElementById('review-login-prompt');
+  if (loginPrompt && loginPrompt.dataset.signinFlow !== 'portal-v2') {
+    loginPrompt.remove();
+    loginPrompt = null;
+  }
   if (!loginPrompt) {
     loginPrompt = document.createElement('div');
     loginPrompt.id = 'review-login-prompt';
+    loginPrompt.dataset.signinFlow = 'portal-v2';
     loginPrompt.className = 'gl-p-5 gl-text-center';
     
     // Create the login message
@@ -707,13 +712,14 @@ function showLoginPrompt() {
     // Add heading
     const heading = document.createElement('h3');
     heading.className = 'thinkreview-login-heading';
-    heading.textContent = 'Please log in to start generating reviews';
+    heading.textContent = 'Sign in to start generating reviews';
     messageContainer.appendChild(heading);
     
-    // Add description
+    const portalSignInUrl = 'https://portal.thinkreview.dev/signin-extension';
     const description = document.createElement('p');
     description.className = 'thinkreview-login-description';
-    description.textContent = 'Sign in with your Google account to access AI code reviews';
+    description.innerHTML =
+      `Click the button below or open <a href="${portalSignInUrl}" target="_blank" rel="noopener noreferrer">${portalSignInUrl}</a>.`;
     messageContainer.appendChild(description);
     
     loginPrompt.appendChild(messageContainer);
@@ -723,75 +729,41 @@ function showLoginPrompt() {
     signInContainer.id = 'gitlab-mr-signin-container';
     signInContainer.className = 'thinkreview-signin-container';
     
-    // Create a button that will trigger the Google Sign-In flow
     const signInButton = document.createElement('button');
+    signInButton.type = 'button';
     signInButton.className = 'thinkreview-signin-button';
-    signInButton.style.backgroundColor = '#4285F4';
-    signInButton.style.color = 'white';
-    signInButton.style.border = 'none';
-    signInButton.style.padding = '10px 16px';
-    signInButton.style.borderRadius = '4px';
-    signInButton.style.display = 'inline-flex';
-    signInButton.style.alignItems = 'center';
-    signInButton.style.justifyContent = 'center';
-    signInButton.style.cursor = 'pointer';
-    signInButton.innerHTML = `
-      <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 48 48" style="margin-right: 8px;">
-        <path fill="#FFC107" d="M43.611,20.083H42V20H24v8h11.303c-1.649,4.657-6.08,8-11.303,8c-6.627,0-12-5.373-12-12c0-6.627,5.373-12,12-12c3.059,0,5.842,1.154,7.961,3.039l5.657-5.657C34.046,6.053,29.268,4,24,4C12.955,4,4,12.955,4,24c0,11.045,8.955,20,20,20c11.045,0,20-8.955,20-20C44,22.659,43.862,21.35,43.611,20.083z"/>
-        <path fill="#FF3D00" d="M6.306,14.691l6.571,4.819C14.655,15.108,18.961,12,24,12c3.059,0,5.842,1.154,7.961,3.039l5.657-5.657C34.046,6.053,29.268,4,24,4C16.318,4,9.656,8.337,6.306,14.691z"/>
-        <path fill="#4CAF50" d="M24,44c5.166,0,9.86-1.977,13.409-5.192l-6.19-5.238C29.211,35.091,26.715,36,24,36c-5.202,0-9.619-3.317-11.283-7.946l-6.522,5.025C9.505,39.556,16.227,44,24,44z"/>
-        <path fill="#1976D2" d="M43.611,20.083H42V20H24v8h11.303c-0.792,2.237-2.231,4.166-4.087,5.571c0.001-0.001,0.002-0.001,0.003-0.002l6.19,5.238C36.971,39.205,44,34,44,24C44,22.659,43.862,21.35,43.611,20.083z"/>
-      </svg>
-      Sign in with Google
-    `;
+    signInButton.textContent = 'Signup / Sign in';
     
-    // Add click event to open extension page for sign-in
     signInButton.addEventListener('click', () => {
-      dbgLog('Requesting background to open extension page for sign-in');
-      
-      // Ask background script to open the extension page (content scripts can't do this directly)
-      chrome.runtime.sendMessage({ type: 'OPEN_EXTENSION_PAGE' }, (response) => {
+      dbgLog('Requesting background to open portal sign-in page');
+      signInButton.disabled = true;
+      const prevLabel = signInButton.textContent;
+      signInButton.textContent = 'Opening…';
+      chrome.runtime.sendMessage({ type: 'OPEN_SIGNIN_PORTAL' }, (response) => {
         if (chrome.runtime.lastError) {
-          dbgWarn('Error opening extension page:', chrome.runtime.lastError);
+          dbgWarn('Error opening portal sign-in:', chrome.runtime.lastError);
+          signInButton.disabled = false;
+          signInButton.textContent = prevLabel;
           return;
         }
-        
-        if (response && response.success) {
-          // Update button to show it was opened
-          signInButton.innerHTML = `
-            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-right: 8px;">
-              <circle cx="12" cy="12" r="10"></circle>
-              <polyline points="16 12 12 8 8 12"></polyline>
-              <line x1="12" y1="16" x2="12" y2="8"></line>
-            </svg>
-            Opening sign-in...
-          `;
-          signInButton.disabled = true;
-          
-          // Add instructions container with steps
-          const instructionsContainer = document.createElement('div');
-          instructionsContainer.className = 'signin-instructions-container';
-          
-          const instructionsTitle = document.createElement('p');
-          instructionsTitle.className = 'signin-instructions-title';
-          instructionsTitle.textContent = 'After signing in:';
-          instructionsContainer.appendChild(instructionsTitle);
-          
-          const instructionsList = document.createElement('ol');
-          instructionsList.className = 'signin-instructions-list';
-          instructionsList.innerHTML = `
-            <li>Complete the sign-in on the new tab</li>
-            <li><strong>Refresh this page</strong> (or press F5)</li>
-            <li>Click <strong>"AI Review"</strong> button again</li>
-          `;
-          instructionsContainer.appendChild(instructionsList);
-          
-          signInContainer.appendChild(instructionsContainer);
+        if (!response || !response.success) {
+          dbgWarn('Portal sign-in open failed:', response && response.error);
+          signInButton.disabled = false;
+          signInButton.textContent = prevLabel;
+          return;
         }
+        signInButton.textContent = prevLabel;
+        signInButton.disabled = false;
       });
     });
     
     signInContainer.appendChild(signInButton);
+
+    const refreshHint = document.createElement('p');
+    refreshHint.className = 'thinkreview-login-description thinkreview-login-refresh-hint';
+    refreshHint.textContent = 'After signing in, refresh this page.';
+    signInContainer.appendChild(refreshHint);
+
     loginPrompt.appendChild(signInContainer);
     
     // Add the login prompt to the panel

--- a/content.js
+++ b/content.js
@@ -208,7 +208,7 @@ function isSupportedPage() {
 }
 
 /**
- * Check if we should show the AI Review button
+ * Check if we should show the ThinkReview trigger button
  * For Azure DevOps and GitHub, always show the button (since they're SPAs)
  * For GitLab, only show on MR pages
  * @returns {boolean} True if button should be shown
@@ -379,7 +379,7 @@ function _injectFallbackButton() {
   const reviewBtn = document.createElement('button');
   reviewBtn.id = 'code-review-btn';
   reviewBtn.style.cssText = 'padding:8px 12px;background:#6b4fbb;color:white;border:none;border-radius:4px;cursor:pointer;display:flex;align-items:center;justify-content:center;';
-  reviewBtn.innerHTML = '<span style="margin-right:5px;">AI Review</span><span style="font-size:10px;">▼</span>';
+  reviewBtn.innerHTML = '<span style="margin-right:5px;">ThinkReview</span><span style="font-size:10px;">▼</span>';
   reviewBtn.onclick = (e) => { e.preventDefault(); e.stopPropagation(); toggleReviewPanel(); };
   container.appendChild(reviewBtn);
   document.body.appendChild(container);
@@ -583,7 +583,7 @@ function getAutoStartReview() {
 /**
  * Injects the integrated review panel into the GitLab MR page.
  * @param {Object} [opts] - Options
- * @param {boolean} [opts.triggerReview] - If true, trigger the review after creating the panel (e.g. user clicked AI Review button). If false/undefined, trigger only when autoStartReview option is enabled.
+ * @param {boolean} [opts.triggerReview] - If true, trigger the review after creating the panel (e.g. user clicked the ThinkReview button). If false/undefined, trigger only when autoStartReview option is enabled.
  */
 async function injectIntegratedReviewPanel(opts = {}) {
   const panel = document.getElementById('gitlab-mr-integrated-review');
@@ -761,7 +761,7 @@ function showLoginPrompt() {
 
     const refreshHint = document.createElement('p');
     refreshHint.className = 'thinkreview-login-description thinkreview-login-refresh-hint';
-    refreshHint.textContent = 'After signing in, refresh this page.';
+    refreshHint.textContent = 'After signing in, refresh this page, then click the ThinkReview button.';
     signInContainer.appendChild(refreshHint);
 
     loginPrompt.appendChild(signInContainer);
@@ -1564,13 +1564,13 @@ async function fetchAndDisplayCodeReview(forceRegenerate = false, isAutoTriggere
   }
 }
 
-// Toggle button functionality removed - using only arrow down and AI Review button
+// Toggle button functionality removed - using only arrow down and ThinkReview button
 
 // Review count tracking functionality removed
 
 /**
  * Toggles the review panel between minimized-to-button and normal states
- * The AI Review button is used to both maximize and minimize the panel
+ * The ThinkReview button is used to both maximize and minimize the panel
  * The arrow down button in the panel header can also be used to minimize the panel
  */
 async function toggleReviewPanel() {
@@ -1590,7 +1590,7 @@ async function toggleReviewPanel() {
   dbgLog('Panel exists:', !!panel);
   
   if (!panel) {
-    // If panel doesn't exist yet, create it and trigger review (user clicked AI Review button)
+    // If panel doesn't exist yet, create it and trigger review (user clicked ThinkReview button)
     injectIntegratedReviewPanel({ triggerReview: true });
     return;
   }


### PR DESCRIPTION
- Renamed 'AI Review' button references to 'ThinkReview' across markdown documentation, comments, and UI components.
- Replaced the legacy Google-only sign-in prompt with a new portal-based sign-in flow (`portal-v2`) in the content script.
- Added a new message handler `OPEN_SIGNIN_PORTAL` in the background script to securely open the sign-in portal in a new tab with rate limiting.
- Introduced a new formatting utility `markdownToSummaryHtml` to convert ordered lists to unordered lists specifically for the review summary panel.
- Updated CSS to support the new login prompt styling, including link colors and refresh hints.