### PR TITLE
Refactor review triggers: temporary manual-only mode and better state management

### DIFF
--- a/components/agent-review-tabs.js
+++ b/components/agent-review-tabs.js
@@ -148,6 +148,7 @@ export function renderAgentLoadingTabs(enabledReviewAgents, tabButtons, panelsWr
       '<div class="thinkreview-agent-state-title">Agent Running</div>' +
       '<div class="thinkreview-agent-state-subtitle">Analyzing your code changes…</div>' +
       '<div class="thinkreview-agent-state-bar"><div class="thinkreview-agent-state-bar-fill"></div></div>' +
+      '<p class="loader-close-hint">Feel free to close this panel and return in a few seconds; this agent\'s review will keep running in the cloud.</p>' +
       '</div>';
 
     scrollWrap.appendChild(inner);
@@ -207,6 +208,7 @@ export function renderAgentPanelState(inner, row, processors, timeoutInfo) {
       '</div>' +
       '<div class="thinkreview-agent-state-title">Still Processing</div>' +
       `<div class="thinkreview-agent-state-subtitle">${extra || 'The agent is still working.'} Check back in a moment.</div>` +
+      '<p class="loader-close-hint">Feel free to close this panel and return in a few seconds; this agent\'s review will keep running in the cloud.</p>' +
       '</div>';
     return;
   }

--- a/components/helpful-tip-banner.js
+++ b/components/helpful-tip-banner.js
@@ -1,9 +1,7 @@
 /**
- * Manages the helpful tip banner that guides users to toggle auto review settings.
- * Handles styles injection, HTML generation, and settings button click handling.
+ * Upgrade-prompt tip banner (HTML currently empty; styles + wire kept for reuse).
  */
 
-// UI identifiers
 const STYLES_ID = 'helpful-tip-styles';
 const SETTINGS_BUTTON_ID = 'helpful-tip-settings-btn';
 const USAGE_BUTTON_ID = 'helpful-tip-usage-btn';
@@ -74,20 +72,11 @@ export function injectStyles() {
 }
 
 /**
- * Returns the HTML markup for the tip banner.
+ * Returns the HTML markup for the tip banner (empty while auto-start UI is hidden app-wide).
  * @returns {string} HTML string for the banner
  */
 export function getHTML() {
-  return `
-    <div class="helpful-tip-banner">
-      <span class="helpful-tip-icon">💡</span>
-      <span class="helpful-tip-text">You can switch the auto-review setting to manual mode to better manage your daily review credits.</span>
-      <div class="helpful-tip-actions">
-        <button id="${SETTINGS_BUTTON_ID}" type="button" class="helpful-tip-settings-btn">Go to Settings</button>
-        <button id="${USAGE_BUTTON_ID}" type="button" class="helpful-tip-usage-btn">View my usage</button>
-      </div>
-    </div>
-  `;
+  return '';
 }
 
 /**

--- a/components/integrated-review.js
+++ b/components/integrated-review.js
@@ -189,23 +189,23 @@ function clearPatchContentAndHistory() {
     chatLog.replaceChildren();
   }
 
-  const reviewLoading = document.getElementById('review-loading');
-  const reviewContent = document.getElementById('review-content');
-  const reviewError = document.getElementById('review-error');
-  const reviewScrollMain = document.getElementById('review-scroll-main');
-  const tokenError = document.getElementById('review-azure-token-error');
-  const bitbucketTokenErr = document.getElementById('review-bitbucket-token-error');
-  const loginPrompt = document.getElementById('review-login-prompt');
-  const patchSizeBanner = document.getElementById('review-patch-size-banner');
+  const elementsToHide = [
+    'review-loading',
+    'review-content',
+    'review-error',
+    'review-azure-token-error',
+    'review-bitbucket-token-error',
+    'review-login-prompt',
+    'review-patch-size-banner',
+  ];
 
-  if (reviewLoading) reviewLoading.classList.add('gl-hidden');
-  if (reviewContent) reviewContent.classList.add('gl-hidden');
-  if (reviewError) reviewError.classList.add('gl-hidden');
+  elementsToHide.forEach((id) => {
+    const el = document.getElementById(id);
+    if (el) el.classList.add('gl-hidden');
+  });
+
+  const reviewScrollMain = document.getElementById('review-scroll-main');
   if (reviewScrollMain) reviewScrollMain.classList.remove('gl-hidden');
-  if (tokenError) tokenError.classList.add('gl-hidden');
-  if (bitbucketTokenErr) bitbucketTokenErr.classList.add('gl-hidden');
-  if (loginPrompt) loginPrompt.classList.add('gl-hidden');
-  if (patchSizeBanner) patchSizeBanner.classList.add('gl-hidden');
 
   dbgLog('Cleared patch content, conversation history, and review panel state for new PR');
 }

--- a/components/integrated-review.js
+++ b/components/integrated-review.js
@@ -177,15 +177,39 @@ let currentPatchContent = '';
  * Clears the stored patch content and conversation history
  * This should be called when navigating to a new PR to free up memory
  * Also clears the chat log DOM so previous messages are not shown in the new review
+ * Resets review panel visibility so a manual ThinkReview open runs fetch for the new PR
+ * (otherwise #review-content stayed visible and toggleReviewPanel skipped fetch)
  */
 function clearPatchContentAndHistory() {
   currentPatchContent = '';
   conversationHistory = [];
+  currentReviewData = null;
+  stopEnhancedLoader();
+
   const chatLog = document.getElementById('chat-log');
   if (chatLog) {
     chatLog.replaceChildren();
   }
-  dbgLog('Cleared patch content and conversation history');
+
+  const reviewLoading = document.getElementById('review-loading');
+  const reviewContent = document.getElementById('review-content');
+  const reviewError = document.getElementById('review-error');
+  const reviewScrollMain = document.getElementById('review-scroll-main');
+  const tokenError = document.getElementById('review-azure-token-error');
+  const bitbucketTokenErr = document.getElementById('review-bitbucket-token-error');
+  const loginPrompt = document.getElementById('review-login-prompt');
+  const patchSizeBanner = document.getElementById('review-patch-size-banner');
+
+  if (reviewLoading) reviewLoading.classList.add('gl-hidden');
+  if (reviewContent) reviewContent.classList.add('gl-hidden');
+  if (reviewError) reviewError.classList.add('gl-hidden');
+  if (reviewScrollMain) reviewScrollMain.classList.remove('gl-hidden');
+  if (tokenError) tokenError.classList.add('gl-hidden');
+  if (bitbucketTokenErr) bitbucketTokenErr.classList.add('gl-hidden');
+  if (loginPrompt) loginPrompt.classList.add('gl-hidden');
+  if (patchSizeBanner) patchSizeBanner.classList.add('gl-hidden');
+
+  dbgLog('Cleared patch content, conversation history, and review panel state for new PR');
 }
 
 // Expose function for content.js to call when navigating to new PR

--- a/components/integrated-review.js
+++ b/components/integrated-review.js
@@ -174,11 +174,9 @@ let conversationHistory = [];
 let currentPatchContent = '';
 
 /**
- * Clears the stored patch content and conversation history
- * This should be called when navigating to a new PR to free up memory
- * Also clears the chat log DOM so previous messages are not shown in the new review
- * Resets review panel visibility so a manual ThinkReview open runs fetch for the new PR
- * (otherwise #review-content stayed visible and toggleReviewPanel skipped fetch)
+ * Clears stored patch content, conversation history, and review panel UI.
+ * Intended when navigating from one PR/MR to another (not when leaving for a non-PR page).
+ * Resets visibility so a manual ThinkReview open runs fetch for the new PR.
  */
 function clearPatchContentAndHistory() {
   currentPatchContent = '';
@@ -212,7 +210,7 @@ function clearPatchContentAndHistory() {
   dbgLog('Cleared patch content, conversation history, and review panel state for new PR');
 }
 
-// Expose function for content.js to call when navigating to new PR
+// Expose for content.js when switching to a different PR URL
 window.clearPatchContentAndHistory = clearPatchContentAndHistory;
 
 // Enhanced loader functionality

--- a/content.js
+++ b/content.js
@@ -479,21 +479,16 @@ function getCurrentPRId() {
 }
 
 /**
- * Check if we've navigated to a new PR and trigger review if needed
+ * Check if we've navigated to a new PR and trigger review if needed.
+ * Clears panel state only when the URL identifies a different PR than currentPRId
+ * (not when navigating to non-PR pages).
  */
 async function checkAndTriggerReviewForNewPR() {
   // Only check if we're on a supported page (PR page)
   if (!isSupportedPage()) {
-    // Not on a PR page - reset tracking and hide score popup
-    if (currentPRId !== null) {
-      currentPRId = null;
-      
-      // Clear patch content and conversation history when leaving PR page
-      if (typeof window.clearPatchContentAndHistory === 'function') {
-        window.clearPatchContentAndHistory();
-      }
-    }
-    
+    // Not on a PR page: do not clear the integrated panel or reset currentPRId.
+    // Keeping currentPRId lets us detect a switch to a *different* PR after browsing
+    // elsewhere (clear + optional auto-run only runs in that branch below).
     // Hide score popup when navigating to a non-PR page
     try {
       const scorePopupModule = await import(chrome.runtime.getURL('components/popup-modules/score-popup.js'));

--- a/content.js
+++ b/content.js
@@ -1125,18 +1125,21 @@ async function getAzureDevOpsToken() {
 
 /** Show in-panel loader as soon as review work begins (before patch fetch / filter). */
 function showIntegratedReviewLoadingUI() {
+  const elementsToHide = [
+    'review-content',
+    'review-error',
+    'review-login-prompt',
+    'review-azure-token-error',
+    'review-bitbucket-token-error',
+  ];
+
+  elementsToHide.forEach((id) => {
+    const el = document.getElementById(id);
+    if (el) el.classList.add('gl-hidden');
+  });
+
   const reviewLoading = document.getElementById('review-loading');
-  const reviewContent = document.getElementById('review-content');
-  const reviewError = document.getElementById('review-error');
-  const loginPrompt = document.getElementById('review-login-prompt');
   if (reviewLoading) reviewLoading.classList.remove('gl-hidden');
-  if (reviewContent) reviewContent.classList.add('gl-hidden');
-  if (reviewError) reviewError.classList.add('gl-hidden');
-  if (loginPrompt) loginPrompt.classList.add('gl-hidden');
-  const azureTokenErr = document.getElementById('review-azure-token-error');
-  const bitbucketTokenErr = document.getElementById('review-bitbucket-token-error');
-  if (azureTokenErr) azureTokenErr.classList.add('gl-hidden');
-  if (bitbucketTokenErr) bitbucketTokenErr.classList.add('gl-hidden');
   if (typeof startEnhancedLoader === 'function') {
     startEnhancedLoader();
   }

--- a/content.js
+++ b/content.js
@@ -614,8 +614,12 @@ async function injectIntegratedReviewPanel(opts = {}) {
   
   dbgLog('Integrated review panel created');
   
-  // If the user explicitly triggered this (button click), expand the panel immediately
+  // Track current PR ID (before review fetch so SPA state stays consistent)
+  currentPRId = getCurrentPRId();
+
+  // If the user explicitly triggered this (button click), expand the panel and start review in parallel
   if (opts.triggerReview === true) {
+    const fetchPromise = fetchAndDisplayCodeReview(false, false);
     const createdPanel = document.getElementById('gitlab-mr-integrated-review');
     if (createdPanel) {
       createdPanel.classList.remove('thinkreview-panel-minimized-to-button');
@@ -626,17 +630,16 @@ async function injectIntegratedReviewPanel(opts = {}) {
       } else if (expandSettings.sidebarSide === 'left') {
         // In overlay mode, still apply the sidebar side for positioning alignment
         createdPanel.classList.add('thinkreview-panel-overlay-left');
+      } else {
+        createdPanel.classList.remove('thinkreview-panel-overlay-left');
       }
       applyDockedBodyMargin(true, expandSettings.panelMode, expandSettings.sidebarSide);
     }
-  }
-  
-  // Track current PR ID
-  currentPRId = getCurrentPRId();
-  
-  // Trigger the code review only when: user explicitly requested (button click) or auto-start is enabled
-  if (opts.triggerReview === true) {
-    fetchAndDisplayCodeReview(false, false);
+    try {
+      await fetchPromise;
+    } catch (e) {
+      dbgWarn('Review fetch failed:', e?.message || e);
+    }
   } else if (await getAutoStartReview()) {
     fetchAndDisplayCodeReview(false, true);
   }
@@ -1120,6 +1123,33 @@ async function getAzureDevOpsToken() {
   });
 }
 
+/** Show in-panel loader as soon as review work begins (before patch fetch / filter). */
+function showIntegratedReviewLoadingUI() {
+  const reviewLoading = document.getElementById('review-loading');
+  const reviewContent = document.getElementById('review-content');
+  const reviewError = document.getElementById('review-error');
+  const loginPrompt = document.getElementById('review-login-prompt');
+  if (reviewLoading) reviewLoading.classList.remove('gl-hidden');
+  if (reviewContent) reviewContent.classList.add('gl-hidden');
+  if (reviewError) reviewError.classList.add('gl-hidden');
+  if (loginPrompt) loginPrompt.classList.add('gl-hidden');
+  const azureTokenErr = document.getElementById('review-azure-token-error');
+  const bitbucketTokenErr = document.getElementById('review-bitbucket-token-error');
+  if (azureTokenErr) azureTokenErr.classList.add('gl-hidden');
+  if (bitbucketTokenErr) bitbucketTokenErr.classList.add('gl-hidden');
+  if (typeof startEnhancedLoader === 'function') {
+    startEnhancedLoader();
+  }
+}
+
+function dismissIntegratedReviewLoadingUI() {
+  if (typeof stopEnhancedLoader === 'function') {
+    stopEnhancedLoader();
+  }
+  const reviewLoading = document.getElementById('review-loading');
+  if (reviewLoading) reviewLoading.classList.add('gl-hidden');
+}
+
 /**
  * Fetches code changes and sends them for AI review
  * Supports both GitLab (patch) and Azure DevOps (API) platforms
@@ -1165,6 +1195,8 @@ async function fetchAndDisplayCodeReview(forceRegenerate = false, isAutoTriggere
       isReviewInProgress = false;
       return;
     }
+
+    showIntegratedReviewLoadingUI();
 
     // Determine platform and get code changes
     let codeContent = '';
@@ -1331,27 +1363,8 @@ async function fetchAndDisplayCodeReview(forceRegenerate = false, isAutoTriggere
       throw new Error('Unsupported platform');
     }
 
-    // Show loading state and start enhanced loader
-    // Note: Daily limit checking is now handled server-side in the cloud function
-    const reviewLoading = document.getElementById('review-loading');
-    const reviewContent = document.getElementById('review-content');
-    const reviewError = document.getElementById('review-error');
-    const loginPrompt = document.getElementById('review-login-prompt');
-    
-    if (reviewLoading) reviewLoading.classList.remove('gl-hidden');
-    if (reviewContent) reviewContent.classList.add('gl-hidden');
-    if (reviewError) reviewError.classList.add('gl-hidden');
-    if (loginPrompt) loginPrompt.classList.add('gl-hidden');
-    const azureTokenErr = document.getElementById('review-azure-token-error');
-    const bitbucketTokenErr = document.getElementById('review-bitbucket-token-error');
-    if (azureTokenErr) azureTokenErr.classList.add('gl-hidden');
-    if (bitbucketTokenErr) bitbucketTokenErr.classList.add('gl-hidden');
-    
-    // Start the enhanced loader if available
-    if (typeof startEnhancedLoader === 'function') {
-      startEnhancedLoader();
-    }
-    
+    // In-panel loader already shown after login; keep UI through filter + cloud call.
+
     // Apply filtering for GitLab, GitHub, and Bitbucket patches (Azure DevOps changes are already filtered)
     let filteredCodeContent = codeContent;
     let filterSummaryText = null;
@@ -1390,6 +1403,7 @@ async function fetchAndDisplayCodeReview(forceRegenerate = false, isAutoTriggere
       const decision = shouldProceedWithAutoReview(filteredCodeContent, { platform, mrId: reviewId });
       if (!decision.proceed) {
         dbgLog('Auto review skipped by autoReviewDecisionMaker:', decision.reason, decision.details);
+        dismissIntegratedReviewLoadingUI();
         return;
       }
     }
@@ -1618,7 +1632,14 @@ async function toggleReviewPanel() {
       panel.classList.remove('thinkreview-panel-overlay-left');
     }
     applyDockedBodyMargin(true, expandSettings.panelMode, expandSettings.sidebarSide);
-    
+
+    const reviewContent = document.getElementById('review-content');
+    const reviewError = document.getElementById('review-error');
+    const hasReview = reviewContent && !reviewContent.classList.contains('gl-hidden');
+    const hasError = reviewError && !reviewError.classList.contains('gl-hidden');
+    const reviewPromise =
+      !hasReview && !hasError ? fetchAndDisplayCodeReview(false, false) : null;
+
     // Hide score popup when panel is expanded
     try {
       const scorePopupModule = await import(chrome.runtime.getURL('components/popup-modules/score-popup.js'));
@@ -1662,17 +1683,13 @@ async function toggleReviewPanel() {
     if (arrowSpan) {
       arrowSpan.textContent = '▼';
     }
-    
-    // Check if this is the first time expanding and no review has been generated yet
-    const reviewContent = document.getElementById('review-content');
-    const reviewError = document.getElementById('review-error');
-    const hasReview = reviewContent && !reviewContent.classList.contains('gl-hidden');
-    const hasError = reviewError && !reviewError.classList.contains('gl-hidden');
-    
-    // If no review has been generated yet (no content and no error), trigger the review
-    // (even while a review is in progress — fetchAndDisplayCodeReview queues manual runs)
-    if (!hasReview && !hasError) {
-      fetchAndDisplayCodeReview(false, false);
+
+    if (reviewPromise) {
+      try {
+        await reviewPromise;
+      } catch (e) {
+        dbgWarn('Review fetch failed:', e?.message || e);
+      }
     }
   } else {
     // If panel is already visible, minimize it (even if review is in progress)

--- a/content.js
+++ b/content.js
@@ -10,6 +10,9 @@ if (typeof DEBUG === 'undefined') {
 const TIMEOUT_AUTO_REVIEW_DELAY = 500;
 const MAX_PATCH_SIZE_FALLBACK = 50_000;
 
+/** Set to false to restore automatic review on PR load (and autoReviewDecisionMaker for those runs). */
+const TEMP_FORCE_MANUAL_REVIEW_ONLY = true;
+
 // Logger functions - loaded dynamically to avoid module import issues in content scripts
 // Provide fallback functions immediately, then upgrade when logger loads
 // Check if variables already exist to avoid redeclaration errors
@@ -574,6 +577,13 @@ async function checkAndTriggerReviewForNewPR() {
 function getAutoStartReview() {
   return new Promise((resolve) => {
     chrome.storage.local.get(['autoStartReview'], (result) => {
+      if (TEMP_FORCE_MANUAL_REVIEW_ONLY) {
+        if (result.autoStartReview === true) {
+          dbgLog('TEMP_FORCE_MANUAL_REVIEW_ONLY: ignoring autoStartReview storage (manual reviews only)');
+        }
+        resolve(false);
+        return;
+      }
       // Respect the "Start review automatically" option for all providers (default off when unset)
       resolve(result.autoStartReview === true);
     });

--- a/popup.css
+++ b/popup.css
@@ -1456,6 +1456,11 @@ footer {
   margin-bottom: 4px;
 }
 
+/* [hidden] alone loses to .auto-start-review-row { display: flex } without this rule */
+.auto-start-review-row[hidden] {
+  display: none !important;
+}
+
 .auto-start-label {
   font-size: 12px;
   color: #333;

--- a/popup.html
+++ b/popup.html
@@ -405,8 +405,8 @@
                 </p>
               </div>
             </div>
-            <!-- Auto-start review (shown only when Ollama is selected) -->
-            <div id="auto-start-review-section" class="auto-start-review-row">
+            <!-- Auto-start review: hidden (manual-only / no UI toggle) -->
+            <div id="auto-start-review-section" class="auto-start-review-row" hidden>
               <span class="auto-start-label">Start review automatically</span>
               <div class="auto-start-options">
                 <div class="auto-start-option">

--- a/popup.js
+++ b/popup.js
@@ -405,9 +405,6 @@ document.addEventListener('DOMContentLoaded', async () => {
   
   // Set up domain settings
   initializeDomainSettings();
-  
-  // Set up auto-start review option
-  initializeAutoStartReviewSettings();
 
   // Set up Azure DevOps settings
   initializeAzureSettings();
@@ -805,76 +802,6 @@ document.addEventListener('DOMContentLoaded', async () => {
 
 // Domain Management Functionality
 const DEFAULT_DOMAINS = ['https://gitlab.com'];
-
-// Auto-start review option (default off when unset in storage)
-function initializeAutoStartReviewSettings() {
-  loadAutoStartReview();
-  const onRadio = document.getElementById('auto-start-review-on');
-  const offRadio = document.getElementById('auto-start-review-off');
-  if (onRadio) {
-    onRadio.addEventListener('change', async () => {
-      if (onRadio.checked) {
-        chrome.storage.local.set({ autoStartReview: true });
-        try {
-          const { trackUserAction } = await import('./utils/analytics-service.js');
-          trackUserAction('auto_start_review_enabled', { context: 'popup' }).catch(() => {});
-        } catch (e) { /* silent */ }
-      }
-    });
-  }
-  if (offRadio) {
-    offRadio.addEventListener('change', async () => {
-      if (offRadio.checked) {
-        chrome.storage.local.set({ autoStartReview: false });
-        try {
-          const { trackUserAction } = await import('./utils/analytics-service.js');
-          trackUserAction('auto_start_review_disabled', { context: 'popup' }).catch(() => {});
-        } catch (e) { /* silent */ }
-      }
-    });
-  }
-  setupAutoStartInfoTooltips();
-}
-
-function setupAutoStartInfoTooltips() {
-  const icons = document.querySelectorAll('.auto-start-info-icon');
-  if (icons.length === 0) return;
-  let tooltipEl = document.getElementById('auto-start-tooltip');
-  if (!tooltipEl) {
-    tooltipEl = document.createElement('div');
-    tooltipEl.id = 'auto-start-tooltip';
-    tooltipEl.className = 'auto-start-js-tooltip';
-    document.body.appendChild(tooltipEl);
-  }
-  icons.forEach(icon => {
-    icon.addEventListener('mouseenter', function showTooltip(e) {
-      const text = this.getAttribute('data-tooltip');
-      if (!text) return;
-      tooltipEl.textContent = text;
-      tooltipEl.classList.add('visible');
-      const rect = this.getBoundingClientRect();
-      tooltipEl.style.left = `${rect.left + rect.width / 2}px`;
-      tooltipEl.style.top = `${rect.top - 4}px`;
-      tooltipEl.style.transform = 'translate(-50%, -100%)';
-    });
-    icon.addEventListener('mouseleave', function hideTooltip() {
-      tooltipEl.classList.remove('visible');
-    });
-  });
-}
-
-async function loadAutoStartReview() {
-  try {
-    const result = await chrome.storage.local.get(['autoStartReview']);
-    const enabled = result.autoStartReview === true;
-    const onRadio = document.getElementById('auto-start-review-on');
-    const offRadio = document.getElementById('auto-start-review-off');
-    if (onRadio) onRadio.checked = enabled;
-    if (offRadio) offRadio.checked = !enabled;
-  } catch (error) {
-    dbgWarn('Error loading auto-start review setting:', error);
-  }
-}
 
 function initializeDomainSettings() {
   loadDomains();
@@ -2115,12 +2042,6 @@ async function loadAIProviderSettings() {
     if (ollamaConfig) {
       ollamaConfig.style.display = provider === 'ollama' ? 'block' : 'none';
     }
-    // Show "Start review automatically" for all providers
-    const autoStartSection = document.getElementById('auto-start-review-section');
-    if (autoStartSection) {
-      autoStartSection.style.display = 'flex';
-    }
-    
     // Load Ollama config values
     const urlInput = document.getElementById('ollama-url');
     const modelSelect = document.getElementById('ollama-model');
@@ -2163,11 +2084,6 @@ function handleProviderChange(event) {
   if (ollamaConfig) {
     ollamaConfig.style.display = provider === 'ollama' ? 'block' : 'none';
   }
-  const autoStartSection = document.getElementById('auto-start-review-section');
-  if (autoStartSection) {
-    autoStartSection.style.display = 'flex';
-  }
-  
   // Auto-save provider selection
   chrome.storage.local.set({ aiProvider: provider }, () => {
     dbgLog('AI Provider changed to:', provider);


### PR DESCRIPTION
- Added a hint in the agent review tabs to inform users that reviews continue running in the cloud even if the panel is closed.
- Temporarily disabled the auto-start review feature by introducing a `TEMP_FORCE_MANUAL_REVIEW_ONLY` flag in `content.js` and hiding the corresponding UI in the popup.
- Removed the HTML content of the helpful tip banner, keeping only the styles and wiring for future reuse.
- Enhanced the integrated review panel's state management to properly clear UI elements and loaders when navigating between different PRs.
- Refactored the loading UI logic in `content.js` by extracting `showIntegratedReviewLoadingUI` and `dismissIntegratedReviewLoadingUI` functions.
- Updated the review triggering logic to fetch reviews in parallel when the panel is explicitly expanded by the user.
- Cleaned up unused auto-start review settings logic and tooltips from `popup.js`.