### PR TITLE
feat: implement dismissible news banner and optimize agent review fetchin

### DIFF
--- a/components/agent-review-tabs.js
+++ b/components/agent-review-tabs.js
@@ -1,6 +1,7 @@
 /**
  * Dynamic tabs for custom review agents: loader until ThinkReviewGetAgentReviewsForPatch returns.
- * After mounting tabs, runs ThinkReviewGetUserData (via REFRESH_USER_DATA_STORAGE), then calls the agent wait CF immediately.
+ * The fetch should start in content.js right after reviewPatchCode_1_1 (via startAgentReviewsFetchForPatch) and
+ * a promise is passed in; if not, we run ThinkReviewGetUserData then start the same fetch (legacy path).
  */
 
 /** Incremented on each mount so stale fetches do not update the DOM after a new review. */
@@ -394,16 +395,19 @@ export function sortAgentTabs(tabButtons, panelsWrap, byId) {
   }
 }
 
+export { startAgentReviewsFetchForPatch } from '../utils/fetch-agent-reviews-background.js';
+
 /**
  * @param {Object} opts
  * @param {Array<{id: string, name: string}>} opts.enabledReviewAgents
  * @param {string} opts.patchContent - exact string sent to reviewPatchCode_1_1
  * @param {string|null|undefined} opts.mrId
  * @param {string} opts.provider - 'cloud' | 'ollama' | etc.
+ * @param {Promise<{ success: boolean, data?: object, error?: string }>|null|undefined} [opts.agentReviewsResultPromise] - from startAgentReviewsFetchForPatch
  * @param {{ dbgLog?: Function, dbgWarn?: Function }} opts.logger
  */
 export async function mountAgentReviewTabs(opts) {
-  const { enabledReviewAgents, patchContent, mrId, provider, logger = {} } = opts;
+  const { enabledReviewAgents, patchContent, mrId, provider, logger = {}, agentReviewsResultPromise } = opts;
   const dbgLog = logger.dbgLog || (() => { });
   const dbgWarn = logger.dbgWarn || (() => { });
 
@@ -469,6 +473,28 @@ export async function mountAgentReviewTabs(opts) {
   };
 
   (async () => {
+    if (agentReviewsResultPromise) {
+      if (myGeneration !== agentTabFetchGeneration) {
+        dbgLog('Skipping stale agent-reviews apply (prefetch promise)');
+        return;
+      }
+      try {
+        dbgLog('Awaiting agent reviews for patch (fetch started with main review response)');
+        const bgResp = await agentReviewsResultPromise;
+        if (myGeneration !== agentTabFetchGeneration) return;
+        if (!bgResp?.success) {
+          dbgWarn('Agent reviews fetch failed:', bgResp?.error);
+          applyResults(null);
+          return;
+        }
+        applyResults(bgResp.data);
+      } catch (e) {
+        dbgWarn('mountAgentReviewTabs prefetch apply error:', e);
+        applyResults(null);
+      }
+      return;
+    }
+
     try {
       await new Promise((resolve) => {
         chrome.runtime.sendMessage({ type: 'REFRESH_USER_DATA_STORAGE' }, (resp) => {

--- a/components/integrated-review.css
+++ b/components/integrated-review.css
@@ -1837,6 +1837,58 @@ body[data-theme="high-contrast"] #gitlab-mr-integrated-review .thinkreview-table
   margin-bottom: 4px;
 }
 
+/* Remote-config news banner (above patch / metadata bar) */
+#gitlab-mr-integrated-review .thinkreview-news-banner {
+  margin-bottom: 12px;
+}
+
+#gitlab-mr-integrated-review .thinkreview-news-banner-inner {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px 12px;
+  background-color: rgba(107, 79, 187, 0.18);
+  border: 1px solid rgba(107, 79, 187, 0.45);
+  border-radius: 4px;
+  font-size: 13px;
+  line-height: 1.45;
+  color: #f0f0f0;
+}
+
+#gitlab-mr-integrated-review .thinkreview-news-banner-text {
+  flex: 1;
+  min-width: 0;
+  word-break: break-word;
+}
+
+#gitlab-mr-integrated-review .thinkreview-news-banner-link {
+  color: #e8dcff;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+#gitlab-mr-integrated-review .thinkreview-news-banner-link:hover {
+  color: #ffffff;
+}
+
+#gitlab-mr-integrated-review .thinkreview-news-banner-close {
+  flex-shrink: 0;
+  margin: -4px -6px -4px 0;
+  padding: 4px 10px;
+  border: none;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+#gitlab-mr-integrated-review .thinkreview-news-banner-close:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+  color: #ffffff;
+}
+
 /* Patch size / metadata banner styles */
 #gitlab-mr-integrated-review .thinkreview-patch-size-banner {
   display: flex;

--- a/components/integrated-review.css
+++ b/components/integrated-review.css
@@ -1844,7 +1844,7 @@ body[data-theme="high-contrast"] #gitlab-mr-integrated-review .thinkreview-table
 
 #gitlab-mr-integrated-review .thinkreview-news-banner-inner {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 10px;
   padding: 10px 12px;
   background-color: rgba(107, 79, 187, 0.18);
@@ -1855,20 +1855,41 @@ body[data-theme="high-contrast"] #gitlab-mr-integrated-review .thinkreview-table
   color: #f0f0f0;
 }
 
+/* Message + CTA on one row; CTA sits at the trailing end of the text row. */
+#gitlab-mr-integrated-review .thinkreview-news-banner-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px 12px;
+}
+
 #gitlab-mr-integrated-review .thinkreview-news-banner-text {
   flex: 1;
   min-width: 0;
   word-break: break-word;
 }
 
-#gitlab-mr-integrated-review .thinkreview-news-banner-link {
-  color: #e8dcff;
-  text-decoration: underline;
-  text-underline-offset: 2px;
+#gitlab-mr-integrated-review .thinkreview-news-banner-cta {
+  display: inline-block;
+  flex-shrink: 0;
+  margin-left: auto;
+  padding: 6px 14px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.3;
+  text-decoration: none;
+  color: #1f1638;
+  background-color: #e8dcff;
+  border: 1px solid rgba(255, 255, 255, 0.35);
 }
 
-#gitlab-mr-integrated-review .thinkreview-news-banner-link:hover {
-  color: #ffffff;
+#gitlab-mr-integrated-review .thinkreview-news-banner-cta:hover {
+  background-color: #ffffff;
+  color: #1f1638;
 }
 
 #gitlab-mr-integrated-review .thinkreview-news-banner-close {

--- a/components/integrated-review.js
+++ b/components/integrated-review.js
@@ -434,6 +434,7 @@ async function createIntegratedReviewPanel(patchUrl) {
             </div>
             <div id="review-scroll-main">
             <div id="review-prompt-container"></div>
+            <div id="review-news-banner" class="thinkreview-news-banner gl-hidden gl-mb-4" role="region" aria-label="ThinkReview announcement"></div>
             <div id="review-patch-size-banner" class="gl-mb-4 gl-hidden"></div>
             <div id="review-metrics-container" class="gl-mb-4"></div>
             <div id="review-summary-container" class="gl-mb-4">
@@ -1594,6 +1595,79 @@ async function handleSendMessage(messageText) {
   }
 }
 
+const THINKREVIEW_NEWS_BANNER_DISMISSED_KEY = 'thinkreview-news-banner-dismissed-version';
+
+/**
+ * Remote-config news banner above the metadata bar; dismiss persists per news `version`.
+ */
+async function refreshThinkReviewNewsBanner() {
+  const el = document.getElementById('review-news-banner');
+  if (!el) return;
+
+  el.replaceChildren();
+  el.classList.add('gl-hidden');
+
+  try {
+    // Same pattern as upgrade prompt in content.js: dynamic import + CloudService (not background sendMessage).
+    const cloudModule = await import(chrome.runtime.getURL('services/cloud-service.js'));
+    const [storage, news] = await Promise.all([
+      chrome.storage.local.get([THINKREVIEW_NEWS_BANNER_DISMISSED_KEY]),
+      cloudModule.CloudService.fetchNewsMessageThinkReview()
+    ]);
+
+    if (!news || !news.message || !news.version) {
+      return;
+    }
+
+    const dismissed = storage[THINKREVIEW_NEWS_BANNER_DISMISSED_KEY];
+    if (dismissed != null && String(dismissed) === String(news.version)) {
+      return;
+    }
+
+    const inner = document.createElement('div');
+    inner.className = 'thinkreview-news-banner-inner';
+
+    const textWrap = document.createElement('div');
+    textWrap.className = 'thinkreview-news-banner-text';
+
+    if (news.url) {
+      const a = document.createElement('a');
+      a.href = news.url;
+      a.target = '_blank';
+      a.rel = 'noopener noreferrer';
+      a.className = 'thinkreview-news-banner-link';
+      a.textContent = news.message;
+      textWrap.appendChild(a);
+    } else {
+      textWrap.textContent = news.message;
+    }
+
+    const closeBtn = document.createElement('button');
+    closeBtn.type = 'button';
+    closeBtn.className = 'thinkreview-news-banner-close';
+    closeBtn.setAttribute('aria-label', 'Dismiss announcement');
+    closeBtn.textContent = '\u00d7';
+    closeBtn.addEventListener('click', async () => {
+      try {
+        await chrome.storage.local.set({
+          [THINKREVIEW_NEWS_BANNER_DISMISSED_KEY]: news.version
+        });
+      } catch (storeErr) {
+        dbgWarn('Failed to persist news banner dismissal:', storeErr);
+      }
+      el.replaceChildren();
+      el.classList.add('gl-hidden');
+    });
+
+    inner.appendChild(textWrap);
+    inner.appendChild(closeBtn);
+    el.appendChild(inner);
+    el.classList.remove('gl-hidden');
+  } catch (error) {
+    dbgWarn('ThinkReview news banner failed:', error);
+  }
+}
+
 async function displayIntegratedReview(
   review,
   patchContent,
@@ -1694,6 +1768,8 @@ async function displayIntegratedReview(
     const slug = displayName.toLowerCase();
     subscriptionLabel.className = 'thinkreview-header-subscription thinkreview-header-subscription-' + slug;
   }
+
+  await refreshThinkReviewNewsBanner();
 
   // Render patch size / metadata banner (Ollama-specific bar vs cloud bar)
   if (patchSizeBanner) {

--- a/components/integrated-review.js
+++ b/components/integrated-review.js
@@ -1597,8 +1597,17 @@ async function handleSendMessage(messageText) {
 
 const THINKREVIEW_NEWS_BANNER_DISMISSED_KEY = 'thinkreview-news-banner-dismissed-version';
 
+/** Cached dynamic import so repeated reviews do not pay import() microtask churn. */
+let thinkReviewNewsBannerCloudModulePromise = null;
+function getThinkReviewNewsBannerCloudModule() {
+  return (thinkReviewNewsBannerCloudModulePromise ??= import(
+    chrome.runtime.getURL('services/cloud-service.js')
+  ));
+}
+
 /**
  * Remote-config news banner above the metadata bar; dismiss persists per news `version`.
+ * Non-blocking: callers must not await this so review UI is not delayed by the news HTTP call.
  */
 async function refreshThinkReviewNewsBanner() {
   const el = document.getElementById('review-news-banner');
@@ -1608,8 +1617,7 @@ async function refreshThinkReviewNewsBanner() {
   el.classList.add('gl-hidden');
 
   try {
-    // Same pattern as upgrade prompt in content.js: dynamic import + CloudService (not background sendMessage).
-    const cloudModule = await import(chrome.runtime.getURL('services/cloud-service.js'));
+    const cloudModule = await getThinkReviewNewsBannerCloudModule();
     const [storage, news] = await Promise.all([
       chrome.storage.local.get([THINKREVIEW_NEWS_BANNER_DISMISSED_KEY]),
       cloudModule.CloudService.fetchNewsMessageThinkReview()
@@ -1769,7 +1777,7 @@ async function displayIntegratedReview(
     subscriptionLabel.className = 'thinkreview-header-subscription thinkreview-header-subscription-' + slug;
   }
 
-  await refreshThinkReviewNewsBanner();
+  void refreshThinkReviewNewsBanner();
 
   // Render patch size / metadata banner (Ollama-specific bar vs cloud bar)
   if (patchSizeBanner) {

--- a/components/integrated-review.js
+++ b/components/integrated-review.js
@@ -2416,6 +2416,7 @@ async function displayIntegratedReview(
       patchContent,
       mrId: integrationOpts?.mrId ?? null,
       provider: integrationOpts?.provider ?? provider ?? 'cloud',
+      agentReviewsResultPromise: integrationOpts?.agentReviewsResultPromise,
       logger: { dbgLog, dbgWarn }
     });
   } catch (error) {

--- a/components/integrated-review.js
+++ b/components/integrated-review.js
@@ -1635,19 +1635,26 @@ async function refreshThinkReviewNewsBanner() {
     const inner = document.createElement('div');
     inner.className = 'thinkreview-news-banner-inner';
 
+    const body = document.createElement('div');
+    body.className = 'thinkreview-news-banner-body';
+
     const textWrap = document.createElement('div');
     textWrap.className = 'thinkreview-news-banner-text';
+    textWrap.textContent = news.message;
 
-    if (news.url) {
-      const a = document.createElement('a');
-      a.href = news.url;
-      a.target = '_blank';
-      a.rel = 'noopener noreferrer';
-      a.className = 'thinkreview-news-banner-link';
-      a.textContent = news.message;
-      textWrap.appendChild(a);
-    } else {
-      textWrap.textContent = news.message;
+    body.appendChild(textWrap);
+
+    const ctaUrl = typeof news.ctaUrl === 'string' && news.ctaUrl.trim() ? news.ctaUrl.trim() : null;
+    const ctaTitle =
+      typeof news.ctaTitle === 'string' && news.ctaTitle.trim() ? news.ctaTitle.trim() : null;
+    if (ctaUrl && ctaTitle) {
+      const cta = document.createElement('a');
+      cta.href = ctaUrl;
+      cta.target = '_blank';
+      cta.rel = 'noopener noreferrer';
+      cta.className = 'thinkreview-news-banner-cta';
+      cta.textContent = ctaTitle;
+      body.appendChild(cta);
     }
 
     const closeBtn = document.createElement('button');
@@ -1667,7 +1674,7 @@ async function refreshThinkReviewNewsBanner() {
       el.classList.add('gl-hidden');
     });
 
-    inner.appendChild(textWrap);
+    inner.appendChild(body);
     inner.appendChild(closeBtn);
     el.appendChild(inner);
     el.classList.remove('gl-hidden');

--- a/content.js
+++ b/content.js
@@ -1475,8 +1475,7 @@ async function fetchAndDisplayCodeReview(forceRegenerate = false, isAutoTriggere
     
 
     // Display the review results (use filtered patch — same string as reviewPatchCode_1_1 for agent checksums).
-    // Await so in-panel work (e.g. news banner fetch via CloudService) completes with this flow.
-    await displayIntegratedReview(
+    displayIntegratedReview(
       data.review,
       filteredCodeContent,
       data.patchSize,

--- a/content.js
+++ b/content.js
@@ -1474,8 +1474,9 @@ async function fetchAndDisplayCodeReview(forceRegenerate = false, isAutoTriggere
     }
     
 
-    // Display the review results (use filtered patch — same string as reviewPatchCode_1_1 for agent checksums)
-    displayIntegratedReview(
+    // Display the review results (use filtered patch — same string as reviewPatchCode_1_1 for agent checksums).
+    // Await so in-panel work (e.g. news banner fetch via CloudService) completes with this flow.
+    await displayIntegratedReview(
       data.review,
       filteredCodeContent,
       data.patchSize,

--- a/content.js
+++ b/content.js
@@ -1472,7 +1472,23 @@ async function fetchAndDisplayCodeReview(forceRegenerate = false, isAutoTriggere
     if (filterSummaryText) {
       data.review.summary = (data.review.summary || '') + '\n\n' + filterSummaryText;
     }
-    
+
+    // Start ThinkReviewGetAgentReviewsForPatch immediately after reviewPatchCode_1_1 returns (runs in parallel with panel render).
+    let agentReviewsResultPromise = null;
+    if (bgResponse.provider === 'cloud') {
+      const hasApiAgents = Array.isArray(data.enabledReviewAgents) && data.enabledReviewAgents.length > 0;
+      const stForAgents = await chrome.storage.local.get(['enabledReviewAgents']);
+      const hasStorageAgents = Array.isArray(stForAgents.enabledReviewAgents) && stForAgents.enabledReviewAgents.length > 0;
+      if (hasApiAgents || hasStorageAgents) {
+        const { startAgentReviewsFetchForPatch } = await import(
+          chrome.runtime.getURL('utils/fetch-agent-reviews-background.js')
+        );
+        agentReviewsResultPromise = startAgentReviewsFetchForPatch(
+          filteredCodeContent,
+          reviewId != null && reviewId !== '' ? reviewId : null
+        );
+      }
+    }
 
     // Display the review results (use filtered patch — same string as reviewPatchCode_1_1 for agent checksums).
     displayIntegratedReview(
@@ -1488,7 +1504,8 @@ async function fetchAndDisplayCodeReview(forceRegenerate = false, isAutoTriggere
         enabledReviewAgents: data.enabledReviewAgents,
         mrId: reviewId,
         provider: bgResponse.provider,
-        platform
+        platform,
+        agentReviewsResultPromise
       }
     );
     

--- a/services/cloud-service.js
+++ b/services/cloud-service.js
@@ -1117,13 +1117,17 @@ export class CloudService {
    */
   static async fetchNewsMessageThinkReview() {
     dbgLog('Fetching ThinkReview news message');
+    const TIMEOUT_MS = 2500;
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS);
     try {
       const response = await fetch(FETCH_NEWS_MESSAGE_THINKREVIEW_URL, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'
         },
-        body: JSON.stringify({})
+        body: JSON.stringify({}),
+        signal: controller.signal
       });
 
       if (!response.ok) {
@@ -1170,6 +1174,8 @@ export class CloudService {
     } catch (error) {
       dbgWarn('Error fetching ThinkReview news message:', error);
       return null;
+    } finally {
+      clearTimeout(timeoutId);
     }
   }
 

--- a/services/cloud-service.js
+++ b/services/cloud-service.js
@@ -1113,7 +1113,7 @@ export class CloudService {
 
   /**
    * News banner for integrated review panel (Remote Config via cloud function).
-   * @returns {Promise<{ message: string, url: string|null, version: string }|null>}
+   * @returns {Promise<{ message: string, version: string, ctaTitle: string|null, ctaUrl: string|null }|null>}
    */
   static async fetchNewsMessageThinkReview() {
     dbgLog('Fetching ThinkReview news message');
@@ -1153,23 +1153,35 @@ export class CloudService {
         return null;
       }
 
-      let url = null;
-      if (typeof news.url === 'string' && news.url.trim()) {
-        const u = news.url.trim();
+      const safeHttpUrl = (u) => {
+        if (typeof u !== 'string' || !u.trim()) return null;
+        const t = u.trim();
         try {
-          const parsed = new URL(u);
-          if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
-            url = u;
-          }
+          const parsed = new URL(t);
+          if (parsed.protocol === 'http:' || parsed.protocol === 'https:') return t;
         } catch (_) {
-          url = null;
+          /* ignore */
         }
+        return null;
+      };
+
+      let ctaUrl = safeHttpUrl(news.ctaUrl);
+      if (!ctaUrl && typeof news.url === 'string') {
+        ctaUrl = safeHttpUrl(news.url);
+      }
+
+      let ctaTitle = typeof news.ctaTitle === 'string' ? news.ctaTitle.trim().slice(0, 120) : '';
+      if (ctaUrl) {
+        if (!ctaTitle) ctaTitle = 'Learn more';
+      } else {
+        ctaTitle = null;
       }
 
       return {
         message,
-        url,
-        version: version.slice(0, 64)
+        version: version.slice(0, 64),
+        ctaTitle,
+        ctaUrl
       };
     } catch (error) {
       dbgWarn('Error fetching ThinkReview news message:', error);

--- a/services/cloud-service.js
+++ b/services/cloud-service.js
@@ -31,6 +31,7 @@ const GET_USER_SUBSCRIPTION_DATA_URL = `${CLOUD_FUNCTIONS_BASE_URL}/getUserSubsc
 const TRACK_REVIEW_PROMPT_INTERACTION_URL = `${CLOUD_FUNCTIONS_BASE_URL}/trackReviewPromptInteractionHTTP`;
 const GET_REVIEW_PROMPT_MESSAGES_URL = `${CLOUD_FUNCTIONS_BASE_URL}/getReviewPromptMessagesThinkReview`;
 const GET_UPGRADE_PROMPT_CONFIG_URL = `${CLOUD_FUNCTIONS_BASE_URL}/getUpgradePromptConfigThinkReview`;
+const FETCH_NEWS_MESSAGE_THINKREVIEW_URL = `${CLOUD_FUNCTIONS_BASE_URL}/fetchNewsMessageThinkReview`;
 const CANCEL_SUBSCRIPTION_URL = `${CLOUD_FUNCTIONS_BASE_URL}/cancelSubscriptionThinkReview`;
 const CONVERSATIONAL_REVIEW_URL = `${CLOUD_FUNCTIONS_BASE_URL}/getConversationalReview`;
 const CONVERSATIONAL_REVIEW_URL_V1_1 = `${CLOUD_FUNCTIONS_BASE_URL}/getConversationalReview_1_1`;
@@ -1108,6 +1109,68 @@ export class CloudService {
       plans: data.plans,
       promotionalMessage: typeof data.promotionalMessage === 'string' ? data.promotionalMessage : ''
     };
+  }
+
+  /**
+   * News banner for integrated review panel (Remote Config via cloud function).
+   * @returns {Promise<{ message: string, url: string|null, version: string }|null>}
+   */
+  static async fetchNewsMessageThinkReview() {
+    dbgLog('Fetching ThinkReview news message');
+    try {
+      const response = await fetch(FETCH_NEWS_MESSAGE_THINKREVIEW_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({})
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`HTTP error ${response.status}: ${errorText}`);
+      }
+
+      const data = await response.json();
+      dbgLog('fetchNewsMessageThinkReview response:', { status: data.status, hasNews: !!data.news });
+
+      if (data.status !== 'success') {
+        return null;
+      }
+
+      const news = data.news;
+      if (!news || typeof news !== 'object') {
+        return null;
+      }
+
+      const message = typeof news.message === 'string' ? news.message.trim() : '';
+      const version = news.version != null ? String(news.version).trim() : '';
+      if (!message || !version) {
+        return null;
+      }
+
+      let url = null;
+      if (typeof news.url === 'string' && news.url.trim()) {
+        const u = news.url.trim();
+        try {
+          const parsed = new URL(u);
+          if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+            url = u;
+          }
+        } catch (_) {
+          url = null;
+        }
+      }
+
+      return {
+        message,
+        url,
+        version: version.slice(0, 64)
+      };
+    } catch (error) {
+      dbgWarn('Error fetching ThinkReview news message:', error);
+      return null;
+    }
   }
 
   /**

--- a/utils/fetch-agent-reviews-background.js
+++ b/utils/fetch-agent-reviews-background.js
@@ -1,0 +1,25 @@
+/**
+ * Fire-and-await ThinkReviewGetAgentReviewsForPatch via the service worker, right after
+ * reviewPatchCode_1_1 returns (use the same patch string and mrId).
+ * @param {string} patchContent
+ * @param {string|null|undefined} mrId
+ * @returns {Promise<{ success: boolean, data?: object, error?: string }>}
+ */
+export function startAgentReviewsFetchForPatch(patchContent, mrId) {
+  return new Promise((resolve) => {
+    chrome.runtime.sendMessage(
+      {
+        type: 'FETCH_AGENT_REVIEWS_FOR_PATCH',
+        patchContent,
+        mrId: mrId != null && mrId !== '' ? mrId : null
+      },
+      (resp) => {
+        if (chrome.runtime.lastError) {
+          resolve({ success: false, error: chrome.runtime.lastError.message });
+        } else {
+          resolve(resp && typeof resp === 'object' ? resp : { success: false, error: 'No response' });
+        }
+      }
+    );
+  });
+}


### PR DESCRIPTION
- Implements a prefetching mechanism (`startAgentReviewsFetchForPatch`) for agent reviews that runs in parallel with the main review panel rendering, improving perceived performance.
- Introduces a remote-configurable "news banner" in the integrated review panel to display announcements to users.
- Adds `fetchNewsMessageThinkReview` in `CloudService` to retrieve the news banner content from the backend with a 2.5-second timeout.
- Implements dismissal persistence for the news banner using `chrome.storage.local` based on the announcement version.
- Safely constructs the news banner DOM elements using `document.createElement` and `textContent` to prevent Cross-Site Scripting (XSS) vulnerabilities.
- Adds URL validation (`safeHttpUrl`) to ensure the Call-To-Action (CTA) link in the news banner uses a secure protocol (`http:` or `https:`).
- Caches the dynamic import of `cloud-service.js` to prevent unnecessary microtask overhead on repeated reviews.