### PR TITLE
Make OpenRouter host permission optional with popup allow flow.

### DIFF
--- a/background.js
+++ b/background.js
@@ -25,6 +25,12 @@ chrome.runtime.setUninstallURL('https://thinkreview.dev/goodbye.html', () => {
 const AUTH_TOKEN_KEY = 'oauth_token';
 const AUTH_USER_KEY = 'oauth_user';
 
+const OPENROUTER_ORIGINS = ['https://openrouter.ai/*'];
+
+async function hasOpenRouterHostPermission() {
+  return chrome.permissions.contains({ origins: OPENROUTER_ORIGINS });
+}
+
 // Rate limiter for OPEN_EXTENSION_PAGE — max 3 opens per 60 seconds
 const OPEN_PAGE_RATE_LIMIT = { max: 3, windowMs: 60 * 1000 };
 const openPageRateLimit = { count: 0, windowStart: 0 };
@@ -337,6 +343,15 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         }
 
         if (provider === 'openrouter') {
+          if (!(await hasOpenRouterHostPermission())) {
+            sendResponse({
+              success: false,
+              error: 'OpenRouter host permission not granted.',
+              provider: 'openrouter',
+              suggestion: 'Open the extension popup, select OpenRouter, and click Allow OpenRouter.'
+            });
+            return;
+          }
           try {
             const data = await OpenRouterService.getConversationalResponse(
               patchContent,
@@ -451,6 +466,15 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         }
 
         if (provider === 'openrouter') {
+          if (!(await hasOpenRouterHostPermission())) {
+            sendResponse({
+              success: false,
+              error: 'OpenRouter host permission not granted.',
+              provider: 'openrouter',
+              suggestion: 'Open the extension popup, select OpenRouter, and click Allow OpenRouter.'
+            });
+            return;
+          }
           try {
             const data = await OpenRouterService.reviewPatchCode(patchContent, language, mrId, mrUrl);
 

--- a/background.js
+++ b/background.js
@@ -14,6 +14,7 @@ import { azureDevOpsFetcher } from './services/azure-devops-fetcher.js';
 import { AzureDevOpsAuthError } from './services/azure-devops-api.js';
 
 import { dbgLog, dbgWarn, dbgError } from './utils/logger.js';
+import { hasOpenRouterHostPermission } from './utils/openrouter-permissions.js';
 import { fetchPatchContent } from './services/bitbucket-api.js';
 // Logger module will automatically initialize Honeybadger
 // Set uninstall URL to redirect users to feedback page
@@ -24,12 +25,6 @@ chrome.runtime.setUninstallURL('https://thinkreview.dev/goodbye.html', () => {
 // OAuth constants
 const AUTH_TOKEN_KEY = 'oauth_token';
 const AUTH_USER_KEY = 'oauth_user';
-
-const OPENROUTER_ORIGINS = ['https://openrouter.ai/*'];
-
-async function hasOpenRouterHostPermission() {
-  return chrome.permissions.contains({ origins: OPENROUTER_ORIGINS });
-}
 
 // Rate limiter for OPEN_EXTENSION_PAGE — max 3 opens per 60 seconds
 const OPEN_PAGE_RATE_LIMIT = { max: 3, windowMs: 60 * 1000 };

--- a/components/integrated-review.css
+++ b/components/integrated-review.css
@@ -2089,8 +2089,9 @@ body[data-theme="high-contrast"] #gitlab-mr-integrated-review .thinkreview-table
   text-decoration: none;
 }
 
-/* Ollama metadata bar: Switch to Cloud button and model dropdown */
-#gitlab-mr-integrated-review .thinkreview-ollama-metadata-banner .thinkreview-ollama-switch-to-cloud-btn {
+/* Ollama / OpenRouter metadata bar: Switch to Cloud button and model dropdown */
+#gitlab-mr-integrated-review .thinkreview-ollama-metadata-banner .thinkreview-ollama-switch-to-cloud-btn,
+#gitlab-mr-integrated-review .thinkreview-openrouter-metadata-banner .thinkreview-openrouter-switch-to-cloud-btn {
   flex-shrink: 0;
   padding: 5px 12px;
   background: linear-gradient(180deg, #7c5ce8 0%, #5b3ead 100%);
@@ -2106,7 +2107,8 @@ body[data-theme="high-contrast"] #gitlab-mr-integrated-review .thinkreview-table
   white-space: nowrap;
 }
 
-#gitlab-mr-integrated-review .thinkreview-ollama-metadata-banner .thinkreview-ollama-switch-to-cloud-btn:hover {
+#gitlab-mr-integrated-review .thinkreview-ollama-metadata-banner .thinkreview-ollama-switch-to-cloud-btn:hover,
+#gitlab-mr-integrated-review .thinkreview-openrouter-metadata-banner .thinkreview-openrouter-switch-to-cloud-btn:hover {
   background: linear-gradient(180deg, #8b6bef 0%, #6b4fbb 100%);
   background-color: #7c5ce8;
   border-color: #b197fc;
@@ -2114,19 +2116,22 @@ body[data-theme="high-contrast"] #gitlab-mr-integrated-review .thinkreview-table
   box-shadow: 0 2px 10px rgba(91, 62, 173, 0.5);
 }
 
-#gitlab-mr-integrated-review .thinkreview-ollama-model-wrap {
+#gitlab-mr-integrated-review .thinkreview-ollama-model-wrap,
+#gitlab-mr-integrated-review .thinkreview-openrouter-model-wrap {
   flex-shrink: 0;
   display: flex;
   align-items: center;
   gap: 6px;
 }
 
-#gitlab-mr-integrated-review .thinkreview-ollama-model-label {
+#gitlab-mr-integrated-review .thinkreview-ollama-model-label,
+#gitlab-mr-integrated-review .thinkreview-openrouter-model-label {
   font-size: 12px;
   color: var(--thinkreview-text-secondary);
 }
 
-#gitlab-mr-integrated-review .thinkreview-ollama-model-select {
+#gitlab-mr-integrated-review .thinkreview-ollama-model-select,
+#gitlab-mr-integrated-review .thinkreview-openrouter-model-select {
   padding: 4px 8px;
   font-size: 12px;
   background-color: rgba(30, 30, 30, 0.8);
@@ -2139,20 +2144,47 @@ body[data-theme="high-contrast"] #gitlab-mr-integrated-review .thinkreview-table
 }
 
 #gitlab-mr-integrated-review .thinkreview-ollama-model-select:hover,
-#gitlab-mr-integrated-review .thinkreview-ollama-model-select:focus {
+#gitlab-mr-integrated-review .thinkreview-ollama-model-select:focus,
+#gitlab-mr-integrated-review .thinkreview-openrouter-model-select:hover,
+#gitlab-mr-integrated-review .thinkreview-openrouter-model-select:focus {
   border-color: rgba(107, 79, 187, 0.8);
   outline: none;
 }
 
-/* Ollama truncated-patch: info button + custom tooltip */
-#gitlab-mr-integrated-review .thinkreview-ollama-truncated-tooltip-wrapper {
+#gitlab-mr-integrated-review .thinkreview-openrouter-metadata-banner .thinkreview-openrouter-switch-to-cloud-btn {
+  background: linear-gradient(180deg, #ff9a4d 0%, #e86a10 100%);
+  background-color: #ff7a18;
+  border-color: #ffb380;
+  box-shadow: 0 1px 6px rgba(232, 106, 16, 0.4);
+}
+
+#gitlab-mr-integrated-review .thinkreview-openrouter-metadata-banner .thinkreview-openrouter-switch-to-cloud-btn:hover {
+  background: linear-gradient(180deg, #ffad66 0%, #ff7a18 100%);
+  background-color: #ff9a4d;
+  border-color: #ffc999;
+  box-shadow: 0 2px 10px rgba(232, 106, 16, 0.5);
+}
+
+#gitlab-mr-integrated-review .thinkreview-openrouter-model-select {
+  border-color: rgba(255, 122, 24, 0.5);
+}
+
+#gitlab-mr-integrated-review .thinkreview-openrouter-model-select:hover,
+#gitlab-mr-integrated-review .thinkreview-openrouter-model-select:focus {
+  border-color: rgba(255, 122, 24, 0.8);
+}
+
+/* Ollama / OpenRouter truncated-patch: info button + custom tooltip */
+#gitlab-mr-integrated-review .thinkreview-ollama-truncated-tooltip-wrapper,
+#gitlab-mr-integrated-review .thinkreview-openrouter-truncated-tooltip-wrapper {
   position: relative;
   display: inline-flex;
   align-items: center;
   gap: 4px;
 }
 
-#gitlab-mr-integrated-review .thinkreview-ollama-truncated-info-btn {
+#gitlab-mr-integrated-review .thinkreview-ollama-truncated-info-btn,
+#gitlab-mr-integrated-review .thinkreview-openrouter-truncated-info-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -2173,14 +2205,30 @@ body[data-theme="high-contrast"] #gitlab-mr-integrated-review .thinkreview-table
 }
 
 #gitlab-mr-integrated-review .thinkreview-ollama-truncated-info-btn:hover,
-#gitlab-mr-integrated-review .thinkreview-ollama-truncated-info-btn:focus {
+#gitlab-mr-integrated-review .thinkreview-ollama-truncated-info-btn:focus,
+#gitlab-mr-integrated-review .thinkreview-openrouter-truncated-info-btn:hover,
+#gitlab-mr-integrated-review .thinkreview-openrouter-truncated-info-btn:focus {
   background: rgba(107, 79, 187, 0.4);
   border-color: rgba(107, 79, 187, 0.8);
   color: #d4c5ff;
   outline: none;
 }
 
-#gitlab-mr-integrated-review .thinkreview-ollama-truncated-tooltip {
+#gitlab-mr-integrated-review .thinkreview-openrouter-truncated-info-btn {
+  border-color: rgba(255, 122, 24, 0.6);
+  background: rgba(255, 122, 24, 0.2);
+  color: #ffc999;
+}
+
+#gitlab-mr-integrated-review .thinkreview-openrouter-truncated-info-btn:hover,
+#gitlab-mr-integrated-review .thinkreview-openrouter-truncated-info-btn:focus {
+  background: rgba(255, 122, 24, 0.35);
+  border-color: rgba(255, 122, 24, 0.85);
+  color: #ffe0c2;
+}
+
+#gitlab-mr-integrated-review .thinkreview-ollama-truncated-tooltip,
+#gitlab-mr-integrated-review .thinkreview-openrouter-truncated-tooltip {
   position: absolute;
   top: 100%;
   left: 0;
@@ -2202,7 +2250,8 @@ body[data-theme="high-contrast"] #gitlab-mr-integrated-review .thinkreview-table
   z-index: var(--thinkreview-z-tooltip);
 }
 
-#gitlab-mr-integrated-review .thinkreview-ollama-truncated-tooltip.thinkreview-tooltip-visible {
+#gitlab-mr-integrated-review .thinkreview-ollama-truncated-tooltip.thinkreview-tooltip-visible,
+#gitlab-mr-integrated-review .thinkreview-openrouter-truncated-tooltip.thinkreview-tooltip-visible {
   opacity: 1;
 }
 

--- a/components/integrated-review.js
+++ b/components/integrated-review.js
@@ -1534,7 +1534,8 @@ async function handleSendMessage(messageText) {
     if (
       chatLog &&
       !chatLog.querySelector('.thinkreview-context-banner') &&
-      aiResponse.provider !== 'ollama'
+      aiResponse.provider !== 'ollama' &&
+      aiResponse.provider !== 'openrouter'
     ) {
       const contextType = aiResponse.contextType || 'patch_only';
       chatLog.appendChild(createContextBanner(contextType));
@@ -1692,6 +1693,7 @@ async function displayIntegratedReview(
   isCached = false,
   provider = null,
   ollamaMeta = null,
+  openrouterMeta = null,
   integrationOpts = null
 ) {
   // Store review data for copy-all functionality
@@ -1815,6 +1817,17 @@ async function displayIntegratedReview(
             },
             onModelChange(modelName) {
               document.dispatchEvent(new CustomEvent('thinkreview-ollama-model-changed', { detail: { model: modelName } }));
+            }
+          },
+          reviewRequestLabel
+        );
+      } else if (provider === 'openrouter' && openrouterMeta) {
+        metadataModule.renderOpenRouterMetadataBar(
+          patchSizeBanner,
+          openrouterMeta,
+          {
+            onSwitchToCloud() {
+              document.dispatchEvent(new CustomEvent('thinkreview-switch-to-cloud'));
             }
           },
           reviewRequestLabel

--- a/components/review-metadata-bar.js
+++ b/components/review-metadata-bar.js
@@ -513,4 +513,100 @@ export function renderOllamaMetadataBar(container, ollamaMeta, callbacks = {}, r
   container.classList.remove('gl-hidden');
 }
 
+/**
+ * Render the OpenRouter-specific metadata bar (patch size, truncation, Switch to Cloud, model name).
+ * @param {HTMLElement} container
+ * @param {Object|null} openrouterMeta - { patchSizeChars, patchSentChars, wasTruncated, model }
+ * @param {Object} callbacks - { onSwitchToCloud() }
+ * @param {string|null} [reviewRequestLabel]
+ */
+export function renderOpenRouterMetadataBar(container, openrouterMeta, callbacks = {}, reviewRequestLabel = null) {
+  if (!container) return;
+
+  container.replaceChildren();
+
+  if (!openrouterMeta || typeof openrouterMeta.patchSizeChars !== 'number') {
+    container.classList.add('gl-hidden');
+    return;
+  }
+
+  const { patchSizeChars, patchSentChars, wasTruncated, model } = openrouterMeta;
+  const onSwitchToCloud = typeof callbacks.onSwitchToCloud === 'function' ? callbacks.onSwitchToCloud : () => {};
+
+  const banner = document.createElement('div');
+  banner.className = 'thinkreview-patch-size-banner thinkreview-openrouter-metadata-banner';
+
+  const topRow = document.createElement('div');
+  topRow.className = 'thinkreview-patch-size-top-row';
+
+  const content = document.createElement('div');
+  content.className = 'thinkreview-patch-size-content';
+  const patchSizeStr = formatCharsAsSize(patchSizeChars);
+  const truncatedSizeStr = formatCharsAsSize(patchSentChars);
+  if (reviewRequestLabel) {
+    content.appendChild(document.createTextNode(reviewRequestLabel));
+    content.appendChild(document.createTextNode(' • '));
+  }
+  content.appendChild(document.createTextNode(`Original patch: ${patchSizeStr}`));
+  if (wasTruncated && truncatedSizeStr) {
+    content.appendChild(document.createTextNode(' • '));
+    const tooltipMsg = "The patch was truncated to respect this model's context length. Switch to ThinkReview Cloud for full repo context.";
+    const truncatedWrapper = document.createElement('span');
+    truncatedWrapper.className = 'thinkreview-openrouter-truncated-tooltip-wrapper';
+    const truncatedSpan = document.createElement('span');
+    truncatedSpan.className = 'thinkreview-openrouter-truncated-label';
+    truncatedSpan.textContent = `Truncated patch: ${truncatedSizeStr}`;
+    const infoBtn = document.createElement('button');
+    infoBtn.type = 'button';
+    infoBtn.className = 'thinkreview-openrouter-truncated-info-btn';
+    infoBtn.textContent = 'i';
+    infoBtn.setAttribute('aria-label', 'Why was the patch truncated?');
+    const tooltipEl = document.createElement('span');
+    tooltipEl.className = 'thinkreview-openrouter-truncated-tooltip';
+    tooltipEl.setAttribute('aria-hidden', 'true');
+    tooltipEl.textContent = tooltipMsg;
+    truncatedWrapper.appendChild(truncatedSpan);
+    truncatedWrapper.appendChild(infoBtn);
+    truncatedWrapper.appendChild(tooltipEl);
+    let tooltipTimeout;
+    const showTooltip = () => {
+      tooltipTimeout = setTimeout(() => tooltipEl.classList.add('thinkreview-tooltip-visible'), 200);
+    };
+    const hideTooltip = () => {
+      clearTimeout(tooltipTimeout);
+      tooltipEl.classList.remove('thinkreview-tooltip-visible');
+    };
+    infoBtn.addEventListener('mouseenter', showTooltip);
+    infoBtn.addEventListener('mouseleave', hideTooltip);
+    infoBtn.addEventListener('focus', showTooltip);
+    infoBtn.addEventListener('blur', hideTooltip);
+    infoBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      tooltipEl.classList.toggle('thinkreview-tooltip-visible');
+    });
+    content.appendChild(truncatedWrapper);
+  }
+  if (model) {
+    content.appendChild(document.createTextNode(' • '));
+    content.appendChild(document.createTextNode(`Model: ${model}`));
+  }
+
+  topRow.appendChild(content);
+
+  const switchToCloudBtn = document.createElement('button');
+  switchToCloudBtn.type = 'button';
+  switchToCloudBtn.className = 'thinkreview-openrouter-switch-to-cloud-btn';
+  switchToCloudBtn.textContent = 'Switch to Cloud AI';
+  switchToCloudBtn.setAttribute('aria-label', 'Switch to Cloud AI and regenerate review');
+  switchToCloudBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    onSwitchToCloud();
+  });
+  topRow.appendChild(switchToCloudBtn);
+
+  banner.appendChild(topRow);
+  container.appendChild(banner);
+  container.classList.remove('gl-hidden');
+}
+
 

--- a/content.js
+++ b/content.js
@@ -1500,6 +1500,7 @@ async function fetchAndDisplayCodeReview(forceRegenerate = false, isAutoTriggere
       data.cached,
       bgResponse.provider,
       data.ollamaMeta,
+      data.openrouterMeta,
       {
         enabledReviewAgents: data.enabledReviewAgents,
         mrId: reviewId,

--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,6 @@
     "https://github.com/*",
     "https://patch-diff.githubusercontent.com/*",
     "https://us-central1-thinkgpt.cloudfunctions.net/*",
-    "https://openrouter.ai/*",
     "https://dev.azure.com/*",
     "https://*.visualstudio.com/*"
   ],

--- a/popup.css
+++ b/popup.css
@@ -1833,7 +1833,8 @@ footer {
   font-size: 17px;
 }
 
-.bitbucket-allow-section {
+.bitbucket-allow-section,
+.openrouter-allow-section {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
@@ -1842,23 +1843,31 @@ footer {
   flex-shrink: 0;
 }
 
-.bitbucket-allow-button-row {
+.bitbucket-allow-button-row,
+.openrouter-allow-button-row {
   display: flex;
   flex-direction: row;
   align-items: center;
   gap: 8px;
 }
 
-.bitbucket-allow-section .add-domain-btn {
+.bitbucket-allow-section .add-domain-btn,
+.openrouter-allow-section .add-domain-btn {
   margin: 3px 0 0 0;
 }
 
-.bitbucket-allow-hint {
+.bitbucket-allow-hint,
+.openrouter-allow-hint {
   margin: 0;
   font-size: 11px;
   color: #666;
   text-align: right;
   max-width: 100%;
+}
+
+.openrouter-permission-status {
+  font-size: 11px;
+  color: #666;
 }
 
 /* Tighter spacing under Bitbucket email/token fields */

--- a/popup.html
+++ b/popup.html
@@ -326,7 +326,7 @@
                       </svg>
                     </div>
                   </div>
-                  <p class="provider-card-desc">Frontier AI models with a free tier. No setup required.</p>
+                  <p class="provider-card-desc">Experience the most powerful code review features: flagship models, repo context, niche agents, zero code retention.</p>
                   <div class="provider-card-tags">
                     <span class="provider-tag provider-tag--cloud">Free Tier Available</span>
                     <span class="provider-tag provider-tag--cloud">15+ flagship models</span>

--- a/popup.html
+++ b/popup.html
@@ -318,7 +318,7 @@
                     </div>
                     <div class="provider-card-title-group">
                       <span class="provider-card-name">ThinkReview Cloud</span>
-                      <span class="provider-card-badge provider-card-badge--cloud">Default</span>
+                      <span class="provider-card-badge provider-card-badge--cloud">Recommended</span>
                     </div>
                     <div class="provider-card-check-icon">
                       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
@@ -328,10 +328,12 @@
                   </div>
                   <p class="provider-card-desc">Frontier AI models with a free tier. No setup required.</p>
                   <div class="provider-card-tags">
-                    <span class="provider-tag provider-tag--cloud">Free tier</span>
+                    <span class="provider-tag provider-tag--cloud">Free Tier Available</span>
                     <span class="provider-tag provider-tag--cloud">15+ flagship models</span>
+                    <span class="provider-tag provider-tag--cloud">Full Repo Context</span>
+                    <span class="provider-tag provider-tag--cloud">Create Custom Agents</span>
                     <span class="provider-tag provider-tag--cloud">Custom rules</span>
-                    <span class="provider-tag provider-tag--cloud">Fast responses</span>
+                    <span class="provider-tag provider-tag--cloud">35% Cheaper than BYOK</span>
                   </div>
                 </div>
               </label>
@@ -360,10 +362,9 @@
                   </div>
                   <p class="provider-card-desc">Run your own LLM locally. Requires Setup.</p>
                   <div class="provider-card-tags">
-                    <span class="provider-tag provider-tag--ollama">Private</span>
-                    <span class="provider-tag provider-tag--ollama">Offline</span>
+                    <span class="provider-tag provider-tag--ollama">Limited Context to Diffs only</span>
                     <span class="provider-tag provider-tag--ollama">Runs locally</span>
-                    <span class="provider-tag provider-tag--ollama">Open source models</span>
+                    <span class="provider-tag provider-tag--ollama">No caching</span>
                   </div>
                 </div>
               </label>
@@ -394,9 +395,8 @@
                   </div>
                   <p class="provider-card-desc">Access models from multiple providers with one OpenAI-compatible API key.</p>
                   <div class="provider-card-tags">
-                    <span class="provider-tag provider-tag--openrouter">Multi-provider</span>
-                    <span class="provider-tag provider-tag--openrouter">OpenAI-compatible</span>
-                    <span class="provider-tag provider-tag--openrouter">Dynamic routing</span>
+                    <span class="provider-tag provider-tag--openrouter">Multiple Models</span>
+                    <span class="provider-tag provider-tag--openrouter">Limited Context to Diffs only</span>
                     <span class="provider-tag provider-tag--openrouter">Single API key</span>
                   </div>
                 </div>
@@ -441,6 +441,19 @@
               </div>
             </div>
             <div id="openrouter-config" class="openrouter-config" style="display: none;">
+              <div id="openrouter-allow-section" class="openrouter-allow-section">
+                <div class="openrouter-allow-button-row">
+                  <button id="allow-openrouter-btn" class="add-domain-btn">Allow OpenRouter</button>
+                  <span id="openrouter-permission-status" class="openrouter-permission-status"></span>
+                </div>
+                <p class="help-text openrouter-allow-hint">Grant permission to connect to openrouter.ai for API requests.</p>
+              </div>
+              <div id="openrouter-enabled-message" class="github-info" style="display: none;">
+                <div class="github-info-icon thinkreview-tick-green">✓</div>
+                <div class="github-info-content">
+                  <p class="github-info-text"><strong>OpenRouter enabled.</strong> You can test your API key and save settings below.</p>
+                </div>
+              </div>
               <div class="openrouter-config-row">
                 <label for="openrouter-api-key" class="config-label">OpenRouter API Key:</label>
                 <input type="password" id="openrouter-api-key" class="config-input" placeholder="sk-or-...">
@@ -461,7 +474,7 @@
               <div class="openrouter-help">
                 <p class="help-text">
                   <strong>📖 <a href="https://openrouter.ai/docs" target="_blank">OpenRouter Docs</a></strong>
-                  — use any OpenRouter model id such as <code>openai/gpt-5.2</code> or <code>anthropic/claude-sonnet-4</code>
+                  — use any OpenRouter model id such as <code>openai/gpt-5.3</code> or <code>anthropic/claude-sonnet-4.6</code>
                 </p>
               </div>
             </div>

--- a/popup.html
+++ b/popup.html
@@ -397,7 +397,7 @@
                   <div class="provider-card-tags">
                     <span class="provider-tag provider-tag--openrouter">Multiple Models</span>
                     <span class="provider-tag provider-tag--openrouter">Limited Context to Diffs only</span>
-                    <span class="provider-tag provider-tag--openrouter">Single API key</span>
+                    <span class="provider-tag provider-tag--openrouter">BYOK</span>
                   </div>
                 </div>
               </label>

--- a/popup.js
+++ b/popup.js
@@ -6,6 +6,7 @@ import { subscriptionStatus } from './components/popup-modules/subscription-stat
 import { reviewCount } from './components/popup-modules/review-count.js';
 import { dbgLog, dbgWarn, dbgError } from './utils/logger.js';
 import { clampTemperature, clampTopP, clampTopK } from './utils/ollama-options.js';
+import { OPENROUTER_ORIGINS, hasOpenRouterHostPermission } from './utils/openrouter-permissions.js';
 
 // Timing constants (in milliseconds)
 const TIMEOUT_AUTO_SIGNIN_WAIT = 500;
@@ -1988,12 +1989,6 @@ function clearTokenStatus() {
 // Subscription upgrade functionality has been moved to content.js and removed from popup
 
 // OpenRouter: optional host permission (request openrouter.ai access from popup)
-const OPENROUTER_ORIGINS = ['https://openrouter.ai/*'];
-
-async function hasOpenRouterHostPermission() {
-  return chrome.permissions.contains({ origins: OPENROUTER_ORIGINS });
-}
-
 function initializeOpenRouterPermissionSettings() {
   loadOpenRouterPermissionState();
   const allowBtn = document.getElementById('allow-openrouter-btn');

--- a/popup.js
+++ b/popup.js
@@ -2000,12 +2000,15 @@ function initializeOpenRouterPermissionSettings() {
 async function loadOpenRouterPermissionState() {
   try {
     const hasPermission = await hasOpenRouterHostPermission();
-    const result = await chrome.storage.local.get(['openrouterAllowed']);
-    const allowed = result.openrouterAllowed === true || hasPermission;
 
-    if (allowed) {
+    // Use actual permission as the single source of truth
+    if (!hasPermission) {
+      await chrome.storage.local.set({ openrouterAllowed: false });
+    } else {
       await chrome.storage.local.set({ openrouterAllowed: true });
     }
+
+    const allowed = hasPermission;
 
     const allowSection = document.getElementById('openrouter-allow-section');
     const enabledMessage = document.getElementById('openrouter-enabled-message');

--- a/popup.js
+++ b/popup.js
@@ -1987,8 +1987,102 @@ function clearTokenStatus() {
 
 // Subscription upgrade functionality has been moved to content.js and removed from popup
 
+// OpenRouter: optional host permission (request openrouter.ai access from popup)
+const OPENROUTER_ORIGINS = ['https://openrouter.ai/*'];
+
+async function hasOpenRouterHostPermission() {
+  return chrome.permissions.contains({ origins: OPENROUTER_ORIGINS });
+}
+
+function initializeOpenRouterPermissionSettings() {
+  loadOpenRouterPermissionState();
+  const allowBtn = document.getElementById('allow-openrouter-btn');
+  if (allowBtn) {
+    allowBtn.addEventListener('click', allowOpenRouter);
+  }
+}
+
+async function loadOpenRouterPermissionState() {
+  try {
+    const hasPermission = await hasOpenRouterHostPermission();
+    const result = await chrome.storage.local.get(['openrouterAllowed']);
+    const allowed = result.openrouterAllowed === true || hasPermission;
+
+    if (allowed) {
+      await chrome.storage.local.set({ openrouterAllowed: true });
+    }
+
+    const allowSection = document.getElementById('openrouter-allow-section');
+    const enabledMessage = document.getElementById('openrouter-enabled-message');
+    const statusEl = document.getElementById('openrouter-permission-status');
+    const allowBtn = document.getElementById('allow-openrouter-btn');
+
+    if (allowed) {
+      if (allowSection) allowSection.style.display = 'none';
+      if (enabledMessage) enabledMessage.style.display = 'flex';
+      if (statusEl) statusEl.textContent = '';
+    } else {
+      if (allowSection) allowSection.style.display = 'flex';
+      if (enabledMessage) enabledMessage.style.display = 'none';
+      if (statusEl) statusEl.textContent = '';
+      if (allowBtn) allowBtn.textContent = 'Allow OpenRouter';
+    }
+  } catch (error) {
+    dbgWarn('Error loading OpenRouter permission state:', error);
+  }
+}
+
+let isAllowingOpenRouter = false;
+
+async function allowOpenRouter() {
+  if (isAllowingOpenRouter) return;
+  const allowBtn = document.getElementById('allow-openrouter-btn');
+  const statusEl = document.getElementById('openrouter-permission-status');
+  const originalButtonText = allowBtn?.textContent ?? 'Allow OpenRouter';
+
+  try {
+    isAllowingOpenRouter = true;
+    if (allowBtn) {
+      allowBtn.textContent = 'Adding...';
+      allowBtn.disabled = true;
+    }
+    if (statusEl) statusEl.textContent = '';
+
+    const granted = await chrome.permissions.request({ origins: OPENROUTER_ORIGINS });
+
+    if (!granted) {
+      if (statusEl) statusEl.textContent = 'Permission not granted.';
+      return;
+    }
+
+    await chrome.storage.local.set({ openrouterAllowed: true });
+    loadOpenRouterPermissionState();
+    showOpenRouterStatus('OpenRouter access enabled. You can test and save your settings.', 'success');
+  } catch (error) {
+    dbgWarn('Error allowing OpenRouter:', error);
+    if (statusEl) statusEl.textContent = 'Error: ' + (error.message || 'Failed');
+  } finally {
+    isAllowingOpenRouter = false;
+    if (allowBtn) {
+      allowBtn.textContent = originalButtonText;
+      allowBtn.disabled = false;
+    }
+  }
+}
+
+async function ensureOpenRouterHostPermission() {
+  const allowed = await hasOpenRouterHostPermission();
+  if (!allowed) {
+    showOpenRouterStatus('❌ Allow OpenRouter access first using the button above', 'error');
+    loadOpenRouterPermissionState();
+    return false;
+  }
+  return true;
+}
+
 // AI Provider Management Functionality
 function initializeAIProviderSettings() {
+  initializeOpenRouterPermissionSettings();
   loadAIProviderSettings();
   setupAIProviderEventListeners();
 }
@@ -2090,8 +2184,11 @@ async function loadAIProviderSettings() {
       dbgLog('Ollama is selected provider, fetching available models...');
       await fetchAndPopulateModels(config.url, config.model);
     } else if (provider === 'openrouter') {
+      await loadOpenRouterPermissionState();
       dbgLog('OpenRouter is selected provider, fetching available models...');
-      await fetchAndPopulateOpenRouterModels(openrouterConfig.apiKey, openrouterConfig.model, openrouterConfig.contextLength);
+      if (openrouterConfig.apiKey && (await hasOpenRouterHostPermission())) {
+        await fetchAndPopulateOpenRouterModels(openrouterConfig.apiKey, openrouterConfig.model, openrouterConfig.contextLength);
+      }
     }
     
     dbgLog('AI Provider settings loaded:', { provider, config });
@@ -2145,13 +2242,17 @@ function handleProviderChange(event) {
     }
 
     if (provider === 'openrouter') {
+      loadOpenRouterPermissionState();
       const apiKeyInput = document.getElementById('openrouter-api-key');
       const apiKey = apiKeyInput ? apiKeyInput.value.trim() : '';
 
       if (apiKey) {
-        dbgLog('OpenRouter selected, fetching available models...');
-        fetchAndPopulateOpenRouterModels(apiKey).catch(err => {
-          dbgWarn('Error auto-fetching OpenRouter models (non-critical):', err);
+        hasOpenRouterHostPermission().then((allowed) => {
+          if (!allowed) return;
+          dbgLog('OpenRouter selected, fetching available models...');
+          fetchAndPopulateOpenRouterModels(apiKey).catch(err => {
+            dbgWarn('Error auto-fetching OpenRouter models (non-critical):', err);
+          });
         });
       }
     }
@@ -2387,6 +2488,8 @@ async function refreshOllamaModels() {
 }
 
 async function fetchAndPopulateOpenRouterModels(apiKey, savedModel = null, savedContextLength = null) {
+  if (!(await ensureOpenRouterHostPermission())) return;
+
   const modelInput = document.getElementById('openrouter-model');
   const modelList = document.getElementById('openrouter-model-list');
   if (!modelInput || !modelList) return;
@@ -2444,6 +2547,8 @@ async function fetchAndPopulateOpenRouterModels(apiKey, savedModel = null, saved
 }
 
 async function refreshOpenRouterModels() {
+  if (!(await ensureOpenRouterHostPermission())) return;
+
   const apiKeyInput = document.getElementById('openrouter-api-key');
   const refreshButton = document.getElementById('refresh-openrouter-models-btn');
   const apiKey = apiKeyInput ? apiKeyInput.value.trim() : '';
@@ -2470,6 +2575,8 @@ async function refreshOpenRouterModels() {
 }
 
 async function testOpenRouterConnection() {
+  if (!(await ensureOpenRouterHostPermission())) return;
+
   const apiKeyInput = document.getElementById('openrouter-api-key');
   const modelInput = document.getElementById('openrouter-model');
   const apiKey = apiKeyInput ? apiKeyInput.value.trim() : '';
@@ -2498,6 +2605,8 @@ async function testOpenRouterConnection() {
 }
 
 async function saveOpenRouterSettings() {
+  if (!(await ensureOpenRouterHostPermission())) return;
+
   const apiKeyInput = document.getElementById('openrouter-api-key');
   const modelInput = document.getElementById('openrouter-model');
   const apiKey = apiKeyInput ? apiKeyInput.value.trim() : '';

--- a/services/openrouter-service.js
+++ b/services/openrouter-service.js
@@ -76,35 +76,20 @@ Important: Respond ONLY with valid JSON. Do not include any explanatory text bef
 }
 
 function buildConversationMessages(patchContent, conversationHistory, language) {
-  const truncatedPatch = patchContent.length > 40000
-    ? patchContent.substring(0, 20000) + '\n... (truncated for brevity)'
-    : patchContent;
-
-  const systemContext = `You are an expert code reviewer. The following code patch is being discussed:\n\nCODE PATCH (Git Diff Format):\n\`\`\`\n${truncatedPatch}\n\`\`\`\n\nYour role is to answer questions about this code review in a helpful, concise manner using Markdown formatting.`;
+  const systemContext = `You are an expert code reviewer. The following code patch is being discussed:\n\nCODE PATCH (Git Diff Format):\n\`\`\`\n${patchContent}\n\`\`\`\n\nYour role is to answer questions about this code review in a helpful, concise manner using Markdown formatting.`;
 
   const languageInstruction = language && language !== 'English'
     ? `\n\nIMPORTANT: You MUST respond entirely in ${language}. Your entire response must be written in ${language}.`
     : '';
 
-  const MAX_HISTORY_MESSAGES = 11;
-  let truncatedHistory = conversationHistory;
-
-  if (conversationHistory.length > MAX_HISTORY_MESSAGES) {
-    truncatedHistory = [
-      conversationHistory[0],
-      ...conversationHistory.slice(-(MAX_HISTORY_MESSAGES - 1))
-    ];
-    dbgLog(`Truncated conversation history from ${conversationHistory.length} to ${truncatedHistory.length} messages`);
-  }
-
-  const lastUserMessage = truncatedHistory[truncatedHistory.length - 1];
+  const lastUserMessage = conversationHistory[conversationHistory.length - 1];
   if (!lastUserMessage || lastUserMessage.role !== 'user') {
     throw new Error('The last message in the history must be from the user');
   }
 
   return [
     { role: 'system', content: systemContext },
-    ...truncatedHistory.slice(0, -1).map((message) => ({
+    ...conversationHistory.slice(0, -1).map((message) => ({
       role: message.role === 'user' ? 'user' : 'assistant',
       content: message.content
     })),
@@ -288,18 +273,13 @@ export class OpenRouterService {
 
     const { promptBeforePatch, promptAfterPatch } = buildReviewPrompt(patchContent, language);
 
-    let patchToUse = patchContent;
-    if (contextLength != null && contextLength > 0) {
-      const CHARS_PER_TOKEN = 2;
-      const RESERVED_RESPONSE_TOKENS = 1024;
-      const promptTokens = Math.ceil((promptBeforePatch.length + promptAfterPatch.length) / CHARS_PER_TOKEN);
-      const maxPatchTokens = Math.max(0, contextLength - RESERVED_RESPONSE_TOKENS - promptTokens);
-      const maxPatchChars = maxPatchTokens * CHARS_PER_TOKEN;
-      if (patchContent.length > maxPatchChars) {
-        patchToUse = patchContent.substring(0, maxPatchChars) + '\n\n... (truncated for context limit)';
-        dbgLog('OpenRouter patch truncated to fit context:', { contextLength, maxPatchChars, originalLength: patchContent.length });
-      }
-    }
+    const patchSizeChars = patchContent.length;
+    const openrouterMeta = {
+      patchSizeChars,
+      patchSentChars: patchSizeChars,
+      wasTruncated: false,
+      model
+    };
 
     const reviewMessages = [
       {
@@ -308,7 +288,7 @@ export class OpenRouterService {
       },
       {
         role: 'user',
-        content: `${promptBeforePatch}${patchToUse}${promptAfterPatch}`
+        content: `${promptBeforePatch}${patchContent}${promptAfterPatch}`
       }
     ];
     const maxTokens = resolveOpenRouterMaxTokens(
@@ -344,7 +324,8 @@ export class OpenRouterService {
           status: 'success',
           review: normalizeReview(parsedReview, model),
           raw: parsedReview,
-          provider: 'openrouter'
+          provider: 'openrouter',
+          openrouterMeta
         };
       } catch (parseError) {
         dbgWarn('Failed to parse OpenRouter JSON response, using fallback structure:', parseError);
@@ -370,7 +351,8 @@ export class OpenRouterService {
             model,
             note: 'Model did not return structured JSON. See raw response below.'
           },
-          rawResponse: reviewText
+          rawResponse: reviewText,
+          openrouterMeta
         };
       }
     } catch (error) {

--- a/utils/openrouter-permissions.js
+++ b/utils/openrouter-permissions.js
@@ -1,0 +1,8 @@
+// openrouter-permissions.js
+// Shared OpenRouter optional host permission helpers for popup and background.
+
+export const OPENROUTER_ORIGINS = ['https://openrouter.ai/*'];
+
+export async function hasOpenRouterHostPermission() {
+  return chrome.permissions.contains({ origins: OPENROUTER_ORIGINS });
+}


### PR DESCRIPTION
- Added optional OpenRouter host permission gating across execution paths: background handlers now fail fast with a clear user-facing error/suggestion when permission is missing, and manifest permissions were tightened by removing always-on "https://openrouter.ai/*" access.
- Introduced a shared permission utility (utils/openrouter-permissions.js) and integrated it into popup flows, including a new "Allow OpenRouter" UI section, permission status messaging, and guard checks before model fetch, test, refresh, and save actions.
- Expanded integrated review UI to support OpenRouter metadata parity with Ollama: added openrouterMeta plumbing from content -> integrated-review display, rendered a provider-specific metadata bar, and updated chat context-banner behavior to avoid showing generic context banner for OpenRouter responses.
- Added substantial OpenRouter-specific styling in integrated-review.css and popup.css, including switch-to-cloud button variants, model selector styles, and truncated-patch tooltip controls for a consistent provider-specific visual treatment.
- Added renderOpenRouterMetadataBar in review-metadata-bar.js with patch size, truncation tooltip UX, model display, and a "Switch to Cloud AI" action callback, closely mirroring existing Ollama metadata functionality.
- Updated popup provider marketing/content copy (ThinkReview Cloud, Ollama, OpenRouter cards) and OpenRouter docs examples; this is non-functional but affects user guidance and expectation-setting.
- OpenRouter request construction in services/openrouter-service.js removed prior truncation/history limits and now sends full patch + full conversation history, while returning openrouterMeta with patch size and model details; this improves transparency but increases risk of context overflow, latency, and token/cost spikes.