### PR TITLE
feat(azure-devops): revert cloud auth to PAT and harden encoding

### DIFF
--- a/background.js
+++ b/background.js
@@ -594,7 +594,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
           sendResponse({
             success: false,
             isAuthError: true,
-            error: 'Azure DevOps Personal Access Token is required for on-premises Azure DevOps',
+            error: 'Azure DevOps Personal Access Token is required',
             detailMessage: 'Please configure your Personal Access Token in the extension popup to use Azure DevOps.'
           });
           return;

--- a/components/azure-devops-token-error.js
+++ b/components/azure-devops-token-error.js
@@ -8,10 +8,8 @@ import { dbgLog, dbgWarn, dbgError } from '../utils/logger.js';
  * Shows Azure DevOps token configuration error with helpful UI
  * @param {Function} stopEnhancedLoader - Function to stop the enhanced loader if running
  * @param {string|null} extraInfo - Optional detail text from Azure DevOps
- * @param {{ sessionAuth?: boolean }} [options] - If sessionAuth, copy targets Azure DevOps Services sign-in (not PAT)
  */
-export function showAzureDevOpsTokenError(stopEnhancedLoader = null, extraInfo = null, options = {}) {
-  const sessionAuth = options.sessionAuth === true;
+export function showAzureDevOpsTokenError(stopEnhancedLoader = null, extraInfo = null) {
   // Stop the enhanced loader if it's running
   if (typeof stopEnhancedLoader === 'function') {
     stopEnhancedLoader();
@@ -40,66 +38,9 @@ export function showAzureDevOpsTokenError(stopEnhancedLoader = null, extraInfo =
   
   // Update any contextual details
   updateTokenErrorDetails(tokenError, extraInfo);
-
-  applyAzureDevOpsErrorVariant(tokenError, sessionAuth ? 'session' : 'pat');
   
   // Show the token error
   tokenError.classList.remove('gl-hidden');
-}
-
-/**
- * Switches heading, description, and actions between PAT (on-prem) and cloud session messaging.
- * @param {HTMLElement} tokenError - Root error container
- * @param {'pat'|'session'} variant
- */
-function applyAzureDevOpsErrorVariant(tokenError, variant) {
-  const heading = tokenError.querySelector('.azure-devops-token-heading');
-  const description = tokenError.querySelector('.azure-devops-token-description');
-  const settingsBtn = tokenError.querySelector('.azure-devops-token-settings-button');
-  const learnLink = tokenError.querySelector('.azure-devops-token-learn-link');
-  let reloadBtn = tokenError.querySelector('.azure-devops-session-reload-button');
-
-  if (variant === 'session') {
-    if (heading) {
-      heading.textContent = 'Azure DevOps sign-in required';
-    }
-    if (description) {
-      description.textContent =
-        'ThinkReview uses your existing Azure DevOps browser session on dev.azure.com and visualstudio.com. Sign in to Azure DevOps in this tab, refresh the page if needed, and try again.';
-    }
-    if (settingsBtn) settingsBtn.style.display = 'none';
-    if (learnLink) learnLink.style.display = 'none';
-    if (!reloadBtn && tokenError.querySelector('.azure-devops-token-actions')) {
-      reloadBtn = document.createElement('button');
-      reloadBtn.type = 'button';
-      reloadBtn.className = 'azure-devops-session-reload-button';
-      reloadBtn.style.backgroundColor = '#0078D4';
-      reloadBtn.style.color = 'white';
-      reloadBtn.style.border = 'none';
-      reloadBtn.style.padding = '12px 20px';
-      reloadBtn.style.borderRadius = '6px';
-      reloadBtn.style.cursor = 'pointer';
-      reloadBtn.style.fontSize = '14px';
-      reloadBtn.style.fontWeight = '500';
-      reloadBtn.textContent = 'Reload this page';
-      reloadBtn.addEventListener('click', () => {
-        window.location.reload();
-      });
-      tokenError.querySelector('.azure-devops-token-actions').appendChild(reloadBtn);
-    }
-    if (reloadBtn) reloadBtn.style.display = 'inline-flex';
-  } else {
-    if (heading) {
-      heading.textContent = 'Azure DevOps Personal Access Token Issue';
-    }
-    if (description) {
-      description.textContent =
-        'Your Azure DevOps Personal Access Token is incorrect, missing, expired, or does not have access to this organization/project.';
-    }
-    if (settingsBtn) settingsBtn.style.display = 'inline-flex';
-    if (learnLink) learnLink.style.display = 'inline-flex';
-    if (reloadBtn) reloadBtn.style.display = 'none';
-  }
 }
 
 /**

--- a/content.js
+++ b/content.js
@@ -1118,7 +1118,8 @@ async function getAzureDevOpsToken() {
         return;
       }
       const token = result.azureDevOpsToken;
-      resolve(token && String(token).trim() ? token : DUMMY_AZURE_DEVOPS_TOKEN);
+      const trimmed = token ? String(token).trim() : '';
+      resolve(trimmed || DUMMY_AZURE_DEVOPS_TOKEN);
     });
   });
 }
@@ -1235,106 +1236,64 @@ async function fetchAndDisplayCodeReview(forceRegenerate = false, isAutoTriggere
       reviewId = getGitHubPRId();
       
     } else if (platformDetector && platformDetector.isOnAzureDevOpsPRPage()) {
+      // Azure DevOps: fetch via background script using stored PAT (cloud and on-prem)
       dbgLog('Starting Azure DevOps code fetch');
+      const azureToken = await getAzureDevOpsToken();
+      if (!azureToken || azureToken === DUMMY_AZURE_DEVOPS_TOKEN) {
+        if (azureDevOpsTokenError) {
+          azureDevOpsTokenError.showAzureDevOpsTokenError(stopEnhancedLoader);
+        } else {
+          throw new Error(
+            'Azure DevOps token not configured. Please set your Personal Access Token in the extension popup.'
+          );
+        }
+        return;
+      }
+
       const prInfo = platformDetector.detectPlatform().pageInfo;
       dbgLog('PR info retrieved:', {
         hasPrId: !!prInfo?.prId,
         hasPrUrl: !!prInfo?.prUrl
       });
 
-      const hostname = window.location.hostname || '';
-      const isAzureCloud =
-        hostname.includes('dev.azure.com') || hostname.includes('visualstudio.com');
+      try {
+        const azureResponse = await new Promise((resolve) => {
+          chrome.runtime.sendMessage(
+            {
+              type: 'FETCH_AZURE_DEVOPS_PATCH',
+              prInfo,
+              azureToken
+            },
+            resolve
+          );
+        });
 
-      if (isAzureCloud) {
-        // Azure DevOps Services: use the logged-in browser session (cookies). Must run in the content script context.
-        const apiModule = await import(chrome.runtime.getURL('services/azure-devops-api.js'));
-        try {
-          const fetcherModule = await import(chrome.runtime.getURL('services/azure-devops-fetcher.js'));
-          await fetcherModule.azureDevOpsFetcher.init(prInfo, { useSessionCookies: true });
-          const formattedChanges = await fetcherModule.azureDevOpsFetcher.fetchCodeChanges();
-          codeContent = fetcherModule.azureDevOpsFetcher.toPatchString(formattedChanges);
-          reviewId = prInfo.prId;
-          dbgLog('Azure DevOps changes fetched (cloud session):', {
-            fileCount: formattedChanges?.files?.length || 0,
-            totalLines: formattedChanges?.totalLines || 0
-          });
-        } catch (error) {
-          const AuthErr = apiModule.AzureDevOpsAuthError;
-          const isAuth =
-            (AuthErr && error instanceof AuthErr) ||
-            error?.name === 'AzureDevOpsAuthError';
-          if (isAuth) {
-            dbgLog('Azure DevOps session authentication/access failed, showing sign-in UI');
+        if (!azureResponse || !azureResponse.success) {
+          if (azureResponse?.isAuthError) {
+            dbgLog('Azure DevOps token authentication/access failed, showing token error UI');
             if (azureDevOpsTokenError) {
-              const detailMessage =
-                error.details?.userMessage || error.details?.rawMessage || error.message;
-              azureDevOpsTokenError.showAzureDevOpsTokenError(
-                stopEnhancedLoader,
-                detailMessage,
-                { sessionAuth: true }
-              );
+              const detailMessage = azureResponse.detailMessage || azureResponse.error;
+              azureDevOpsTokenError.showAzureDevOpsTokenError(stopEnhancedLoader, detailMessage);
             } else {
-              throw new Error(error.message);
+              throw new Error(
+                'Azure DevOps token is invalid or expired. Please update your Personal Access Token in the extension popup.'
+              );
             }
             return;
           }
-          throw error;
-        }
-      } else {
-        // On-premises / custom domain: PAT from extension storage; fetch in background (no session cookies).
-        const azureToken = await getAzureDevOpsToken();
-        if (!azureToken || azureToken === DUMMY_AZURE_DEVOPS_TOKEN) {
-          if (azureDevOpsTokenError) {
-            azureDevOpsTokenError.showAzureDevOpsTokenError(stopEnhancedLoader);
-          } else {
-            throw new Error(
-              'Azure DevOps token not configured. Please set your Personal Access Token in the extension popup.'
-            );
-          }
-          return;
+
+          throw new Error(azureResponse?.error || 'Failed to fetch Azure DevOps changes');
         }
 
-        dbgLog('Azure PAT found for on-prem, fetching via background');
-        try {
-          const azureResponse = await new Promise((resolve) => {
-            chrome.runtime.sendMessage(
-              {
-                type: 'FETCH_AZURE_DEVOPS_PATCH',
-                prInfo,
-                azureToken
-              },
-              resolve
-            );
-          });
+        codeContent = azureResponse.content;
+        reviewId = prInfo.prId;
 
-          if (!azureResponse || !azureResponse.success) {
-            if (azureResponse?.isAuthError) {
-              dbgLog('Azure DevOps token authentication/access failed, showing token error UI');
-              if (azureDevOpsTokenError) {
-                const detailMessage = azureResponse.detailMessage || azureResponse.error;
-                azureDevOpsTokenError.showAzureDevOpsTokenError(stopEnhancedLoader, detailMessage);
-              } else {
-                throw new Error(
-                  'Azure DevOps token is invalid or expired. Please update your Personal Access Token in the extension popup.'
-                );
-              }
-              return;
-            }
-
-            throw new Error(azureResponse?.error || 'Failed to fetch Azure DevOps changes');
-          }
-
-          codeContent = azureResponse.content;
-          reviewId = prInfo.prId;
-
-          dbgLog('Azure DevOps changes fetched:', {
-            fileCount: azureResponse.fileCount || 0,
-            totalLines: azureResponse.totalLines || 0
-          });
-        } catch (error) {
-          throw error;
-        }
+        dbgLog('Azure DevOps changes fetched:', {
+          fileCount: azureResponse.fileCount || 0,
+          totalLines: azureResponse.totalLines || 0
+        });
+      } catch (error) {
+        throw error;
       }
     } else if (platformDetector && platformDetector.isOnBitbucketPRPage()) {
       // Bitbucket: fetch patch via background script to avoid page CSP blocking connect-src

--- a/popup.html
+++ b/popup.html
@@ -667,22 +667,22 @@
           <h3>Azure DevOps</h3>
         </div>
 
-        <!-- Cloud wizard (ready out of the box) -->
+        <!-- Cloud wizard -->
         <div class="wizard-card wizard-card--ready">
-          <div class="wizard-ready-badge">✓ Cloud works out of the box</div>
-          <p class="wizard-ready-desc">No setup needed for <strong>dev.azure.com</strong> and <strong>*.visualstudio.com</strong></p>
+          <div class="wizard-ready-badge">Azure DevOps Cloud</div>
+          <p class="wizard-ready-desc">Requires a Personal Access Token (save below) for <strong>dev.azure.com</strong> and <strong>*.visualstudio.com</strong></p>
           <div class="wizard-steps">
             <div class="wizard-step" style="--step-delay:0s">
               <div class="wizard-step-num">1</div>
-              <span>Navigate to any pull request on <strong>dev.azure.com</strong> or <strong>*.visualstudio.com</strong></span>
+              <span>Create a PAT in Azure DevOps and save it in the section below</span>
             </div>
             <div class="wizard-step" style="--step-delay:0.15s">
               <div class="wizard-step-num">2</div>
-              <span>ThinkReview button appears automatically</span>
+              <span>Navigate to any pull request on <strong>dev.azure.com</strong> or <strong>*.visualstudio.com</strong></span>
             </div>
             <div class="wizard-step" style="--step-delay:0.3s">
               <div class="wizard-step-num">3</div>
-              <span>Click it to get an instant AI code review</span>
+              <span>Click the ThinkReview button to get an AI code review</span>
             </div>
           </div>
 

--- a/popup.html
+++ b/popup.html
@@ -251,7 +251,7 @@
             <div class="platform-card-info">
               <span class="platform-card-name">Azure DevOps Cloud</span>
               <span class="platform-card-subtitle">dev.azure.com or *.visualstudio.com</span>
-              <span class="platform-badge platform-badge-ready" id="badge-azure-cloud">✓ Ready</span>
+              <span class="platform-badge platform-badge-setup" id="badge-azure-cloud">⚙ Setup needed</span>
             </div>
           </button>
 

--- a/popup.js
+++ b/popup.js
@@ -2972,7 +2972,7 @@ function showPlatformView(platform, scrollTarget = null) {
 async function computePlatformStatuses() {
   try {
     const result = await chrome.storage.local.get([
-      'azureToken',
+      'azureDevOpsToken',
       'customDomains',                  // GitLab custom domains
       'azureCustomDomains',             // Azure on-prem domains
       'githubEnterpriseDomains',
@@ -2983,10 +2983,11 @@ async function computePlatformStatuses() {
       'bitbucketDataCenterToken',
     ]);
 
-    // Cloud variants: always ready, no setup required
+    // Cloud variants
     setBadge('github-com',  'ready');
     setBadge('gitlab-com',  'ready');
-    setBadge('azure-cloud', 'ready');
+    const azureCloudReady = result.azureDevOpsToken && String(result.azureDevOpsToken).trim();
+    setBadge('azure-cloud', azureCloudReady ? 'ready' : 'setup');
 
     // GitHub Enterprise Server: ready once at least one domain is saved
     const ghesdomains = result.githubEnterpriseDomains;

--- a/services/azure-devops-api.js
+++ b/services/azure-devops-api.js
@@ -28,8 +28,6 @@ export class AzureDevOpsAPI {
   constructor() {
     this.baseUrl = null;
     this.token = null;
-    /** When true, REST calls use the browser session (cookies); no PAT Authorization header. */
-    this.useSessionCookies = false;
     this.apiVersion = DEFAULT_API_VERSION;
     this.isInitialized = false;
     /** @type {Promise<void>|null} One-time promise for lazy project resolution (on-prem when project not in URL) */
@@ -45,16 +43,13 @@ export class AzureDevOpsAPI {
    * @param {string} hostname - Hostname (optional, used to determine base URL for visualstudio.com domains)
    * @param {string} protocol - Protocol (optional, e.g. 'http:' or 'https:'; used for custom/on-prem to match page)
    * @param {string|null} apiVersion - API version (optional, e.g. '4.1' for on-prem; default 7.1)
-   * @param {{ useSessionCookies?: boolean }} [options] - If useSessionCookies, token may be omitted (Azure DevOps Services cloud only).
    */
-  async init(token, organization, project, repository, hostname = null, protocol = null, apiVersion = null, options = {}) {
-    const useSessionCookies = options.useSessionCookies === true;
-    if (!useSessionCookies && !token) {
+  async init(token, organization, project, repository, hostname = null, protocol = null, apiVersion = null) {
+    if (!token) {
       throw new Error('Azure DevOps token is required');
     }
 
-    this.useSessionCookies = useSessionCookies;
-    this.token = useSessionCookies ? null : token;
+    this.token = token;
     this.organization = organization;
     this.project = project || null;
     this.repository = repository;
@@ -101,16 +96,12 @@ export class AzureDevOpsAPI {
       ? ''
       : (projectOverride !== undefined ? `/${projectOverride}` : (this.project != null && this.project !== '' ? `/${this.project}` : ''));
     const url = `${this.baseUrl}${pathSegment}/_apis/${endpoint}${separator}api-version=${this.apiVersion}`;
-    const headers = {
-      'Content-Type': 'application/json',
-      'Accept': 'application/json'
-    };
-    if (!this.useSessionCookies && this.token) {
-      headers['Authorization'] = `Basic ${btoa(':' + this.token)}`;
-    }
     const defaultOptions = {
-      credentials: this.useSessionCookies ? 'include' : 'omit',
-      headers
+      headers: {
+        'Authorization': `Basic ${btoa(Array.from(new TextEncoder().encode(':' + this.token), b => String.fromCharCode(b)).join(''))}`,
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+      }
     };
     const requestOptions = {
       ...defaultOptions,
@@ -243,17 +234,13 @@ export class AzureDevOpsAPI {
           // Handle 401 Unauthorized - token is invalid or expired
           if (response.status === 401) {
             dbgWarn('Azure DevOps authentication failed - token is invalid or not set');
-            const msg = this.useSessionCookies
-              ? 'Your Azure DevOps browser session is invalid or expired. Sign in to Azure DevOps in this tab and try again.'
-              : 'Azure DevOps Personal Access Token is invalid, expired, or not set. Please check your token configuration.';
             throw new AzureDevOpsAuthError(
-              msg,
+              'Azure DevOps Personal Access Token is invalid, expired, or not set. Please check your token configuration.',
               401,
               {
                 status: 401,
                 userMessage: null,
-                rawMessage: errorMessage,
-                sessionAuth: this.useSessionCookies
+                rawMessage: errorMessage
               }
             );
           }
@@ -262,24 +249,31 @@ export class AzureDevOpsAPI {
           if (response.status === 403) {
             const userMessage = parsedError?.message || 'Azure DevOps denied access to this pull request.';
             dbgWarn('Azure DevOps access blocked (403):', userMessage);
-            const msg = this.useSessionCookies
-              ? 'Azure DevOps denied access using your browser session. Confirm you are signed in and have access to this organization/project.'
-              : 'Azure DevOps denied access for this token. Please ensure the PAT belongs to a member with access to this organization/project.';
             throw new AzureDevOpsAuthError(
-              msg,
+              'Azure DevOps denied access for this token. Please ensure the PAT belongs to a member with access to this organization/project.',
               403,
               {
                 status: 403,
                 code: parsedError?.typeKey || parsedError?.typeName || null,
                 userMessage,
-                rawMessage: errorMessage,
-                sessionAuth: this.useSessionCookies
+                rawMessage: errorMessage
               }
             );
           }
           
           throw new Error(`Azure DevOps API error: ${response.status} ${response.statusText} - ${errorText}`);
         }
+
+      // If the server followed a redirect to a login/error HTML page the status is 200 but the body
+      // is HTML. Detect this via Content-Type before any caller tries response.json().
+      const contentType = response.headers.get('content-type') || '';
+      if (contentType.includes('text/html')) {
+        throw new AzureDevOpsAuthError(
+          'Azure DevOps returned an HTML page instead of JSON. Your PAT may be invalid, expired, or lacking the required scopes.',
+          response.status,
+          { rawMessage: `HTML response (content-type: ${contentType})` }
+        );
+      }
 
       return response;
     } catch (error) {

--- a/services/azure-devops-fetcher.js
+++ b/services/azure-devops-fetcher.js
@@ -19,36 +19,17 @@ export class AzureDevOpsFetcher {
   /**
    * Initialize the fetcher with PR information
    * @param {Object} prInfo - Pull request information from detector
-   * @param {string|{ useSessionCookies?: boolean, token?: string }} tokenOrOptions - PAT string (on‑prem), or `{ useSessionCookies: true }` for Azure DevOps Services (cloud) using the logged-in browser session
+   * @param {string} token - Azure DevOps Personal Access Token
    */
-  async init(prInfo, tokenOrOptions) {
-    if (!prInfo) {
-      throw new Error('PR info is required');
-    }
-
-    let token = null;
-    let useSessionCookies = false;
-    if (tokenOrOptions != null && typeof tokenOrOptions === 'object' && !Array.isArray(tokenOrOptions)) {
-      useSessionCookies = tokenOrOptions.useSessionCookies === true;
-      token = typeof tokenOrOptions.token === 'string' ? tokenOrOptions.token : null;
-    } else if (typeof tokenOrOptions === 'string') {
-      token = tokenOrOptions;
-    }
-
-    const origin = `${prInfo.protocol}//${prInfo.hostname}`;
-    const isCloud = prInfo.hostname?.includes('dev.azure.com') || prInfo.hostname?.includes('visualstudio.com');
-
-    if (useSessionCookies) {
-      if (!isCloud) {
-        throw new Error('Session-based auth is only supported for Azure DevOps Services (dev.azure.com / *.visualstudio.com)');
-      }
-    } else {
-      if (!token || typeof token !== 'string') {
-        throw new Error('PR info and token are required');
-      }
+  async init(prInfo, token) {
+    if (!prInfo || !token) {
+      throw new Error('PR info and token are required');
     }
 
     this.prInfo = prInfo;
+
+    const origin = `${prInfo.protocol}//${prInfo.hostname}`;
+    const isCloud = prInfo.hostname?.includes('dev.azure.com') || prInfo.hostname?.includes('visualstudio.com');
 
     let apiVersion = DEFAULT_API_VERSION;
     if (!isCloud) {
@@ -59,22 +40,20 @@ export class AzureDevOpsFetcher {
 
     // Initialize the API service
     await azureDevOpsAPI.init(
-      useSessionCookies ? null : token,
+      token,
       prInfo.organization,
       prInfo.project,
       prInfo.repository.name,
       prInfo.hostname,
       prInfo.protocol,
-      apiVersion,
-      { useSessionCookies }
+      apiVersion
     );
 
     this.isInitialized = true;
     dbgLog('Azure DevOps fetcher initialized:', {
       prId: prInfo.prId,
       repository: prInfo.repository.name,
-      organization: prInfo.organization,
-      useSessionCookies
+      organization: prInfo.organization
     });
   }
 


### PR DESCRIPTION
- Remove session-cookie auth path; both dev.azure.com and on-prem now use the stored Personal Access Token via the background script
- Trim the stored token before use to strip invisible Unicode chars
- Use TextEncoder-safe btoa to avoid Latin1 range errors in the worker
- Detect HTML responses in makeRequest and surface them as auth errors instead of crashing with a JSON parse exception
- Align azure-cloud badge to read azureDevOpsToken (was reading the never-written azureToken key)
- Update Cloud wizard copy to reflect PAT requirement