### PR TITLE
Feature/ُThinkReview enterprise Self hosted gateway option

### DIFF
--- a/background.js
+++ b/background.js
@@ -16,6 +16,7 @@ import { AzureDevOpsAuthError } from './services/azure-devops-api.js';
 import { dbgLog, dbgWarn, dbgError } from './utils/logger.js';
 import { getThinkReviewAuthHeaders, EXTENSION_AUTH_TOKEN_KEY, isAuthExpiredError, handleUnauthorizedResponse, AuthExpiredError } from './utils/extension-auth.js';
 import { hasOpenRouterHostPermission } from './utils/openrouter-permissions.js';
+import { assertSelfHostedGatewayReady } from './utils/enterprise-gateway.js';
 import { fetchPatchContent } from './services/bitbucket-api.js';
 // Logger module will automatically initialize Honeybadger
 // Set uninstall URL to redirect users to feedback page
@@ -310,7 +311,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       try {
         // Get AI provider setting
         const settings = await chrome.storage.local.get(['aiProvider', 'ollamaConfig', 'openrouterConfig']);
-        const provider = settings.aiProvider || 'cloud';
+        let provider = settings.aiProvider || 'cloud';
         
         dbgLog('Using AI provider for conversation:', provider);
         
@@ -380,8 +381,17 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
             return;
           }
         }
+
+        const latestSettings = await chrome.storage.local.get(['aiProvider']);
+        provider = latestSettings.aiProvider || provider || 'cloud';
+
+        const selfHostedGate = await assertSelfHostedGatewayReady(provider);
+        if (!selfHostedGate.ok) {
+          sendResponse({ success: false, ...selfHostedGate });
+          return;
+        }
         
-        // Default: Use cloud service (Gemini)
+        // ThinkReview Cloud or self-hosted gateway (via CloudService routing)
         const data = await CloudService.getConversationalResponse(patchContent, conversationHistory, mrId, mrUrl, language || 'English');
         // Log only metadata, not the actual response content
         dbgLog('Conversational response received:', {
@@ -393,7 +403,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         sendResponse({ 
           success: true, 
           data: data, 
-          provider: 'cloud' 
+          provider: provider === 'self-hosted' ? 'self-hosted' : 'cloud'
         });
       } catch (err) {
         // Log error details for debugging
@@ -503,8 +513,17 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
             return;
           }
         }
+
+        const latestSettings = await chrome.storage.local.get(['aiProvider']);
+        provider = latestSettings.aiProvider || provider || 'cloud';
+
+        const selfHostedGate = await assertSelfHostedGatewayReady(provider);
+        if (!selfHostedGate.ok) {
+          sendResponse({ success: false, ...selfHostedGate });
+          return;
+        }
         
-        // Default: Use cloud service (Gemini)
+        // ThinkReview Cloud or self-hosted gateway (via CloudService routing)
         // Validate patchContent before sending
         if (!patchContent || patchContent.trim().length === 0) {
           throw new Error('There are no code changes yet in this merge request. If you think this is a bug, please report it here: https://thinkreview.dev/bug-report');
@@ -545,7 +564,11 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
           }
         })();
         
-        sendResponse({ success: true, data, provider: 'cloud' });
+        sendResponse({
+          success: true,
+          data,
+          provider: provider === 'self-hosted' ? 'self-hosted' : 'cloud',
+        });
       } catch (err) {
         dbgWarn('Review fetch error:', err);
         sendResponse({ 

--- a/content-webapp-auth.js
+++ b/content-webapp-auth.js
@@ -17,11 +17,34 @@
   var dbgLog = (...args) => { if (DEBUG) console.log('[ThinkReview Extension]', ...args); };
   var dbgWarn = (...args) => { if (DEBUG) console.warn('[ThinkReview Extension]', ...args); };
   var dbgError = (...args) => { if (DEBUG) console.error('[ThinkReview Extension]', ...args); };
+
+  /** True when this content script can still talk to the extension (false after reload/update). */
+  function canMessageExtension() {
+    try {
+      return typeof chrome !== 'undefined'
+        && !!chrome.runtime
+        && typeof chrome.runtime.sendMessage === 'function'
+        && !!chrome.runtime.id;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  function getExtensionResourceUrl(path) {
+    if (!canMessageExtension()) return null;
+    try {
+      return chrome.runtime.getURL(path);
+    } catch (_) {
+      return null;
+    }
+  }
   
   // Initialize logger functions with dynamic import
   (async () => {
     try {
-      const loggerModule = await import(chrome.runtime.getURL('utils/logger.js'));
+      const loggerUrl = getExtensionResourceUrl('utils/logger.js');
+      if (!loggerUrl) return;
+      const loggerModule = await import(loggerUrl);
       dbgLog = loggerModule.dbgLog;
       dbgWarn = loggerModule.dbgWarn;
       dbgError = loggerModule.dbgError;
@@ -38,7 +61,12 @@
   // Load the origin validator utility
   (async () => {
     try {
-      const module = await import(chrome.runtime.getURL('utils/origin-validator.js'));
+      const validatorUrl = getExtensionResourceUrl('utils/origin-validator.js');
+      if (!validatorUrl) {
+        dbgWarn('Extension context unavailable; refresh the portal page after updating ThinkReview.');
+        return;
+      }
+      const module = await import(validatorUrl);
       isValidOrigin = module.isValidOrigin;
       originValidatorLoaded = true;
       initializeContentScript();
@@ -56,6 +84,10 @@
     // so the button works in dev environments too. Low-risk: only opens a new tab.
     window.addEventListener('thinkreview-open-extension', () => {
       dbgLog('Received open-extension event from webapp');
+      if (!canMessageExtension()) {
+        dbgWarn('Extension context unavailable; refresh the page after updating ThinkReview.');
+        return;
+      }
       try {
         chrome.runtime.sendMessage({ type: 'OPEN_EXTENSION_PAGE' }, (response) => {
           if (chrome.runtime.lastError) {
@@ -107,6 +139,11 @@
         dbgWarn('Auth data is stale, ignoring');
         return;
       }
+
+      if (!canMessageExtension()) {
+        dbgWarn('Extension context unavailable; refresh the portal page to sync sign-in with ThinkReview.');
+        return;
+      }
       
       try {
         chrome.runtime.sendMessage({
@@ -122,7 +159,7 @@
           }
         });
       } catch (error) {
-        console.error('Error sending auth message:', error);
+        dbgWarn('Error sending auth message:', error);
       }
     }
   

--- a/popup.css
+++ b/popup.css
@@ -1105,6 +1105,11 @@ footer {
   color: #475569;
 }
 
+.provider-card-icon--self-hosted {
+  background: linear-gradient(135deg, #e8f4fc 0%, #cfe8f7 100%);
+  color: #1565c0;
+}
+
 .provider-card-title-group {
   display: flex;
   flex-direction: column;
@@ -1145,6 +1150,12 @@ footer {
   background: #f1f5f9;
   color: #334155;
   border: 1px solid #cbd5e1;
+}
+
+.provider-card-badge--self-hosted {
+  background: #e3f2fd;
+  color: #1565c0;
+  border: 1px solid #90caf9;
 }
 
 .provider-card-check-icon {
@@ -1198,6 +1209,12 @@ footer {
   background: #f8fafc;
   color: #475569;
   border: 1px solid #d7e0ea;
+}
+
+.provider-tag--self-hosted {
+  background: #e8f4fc;
+  color: #1565c0;
+  border: 1px solid #bbdefb;
 }
 
 /* Selected state */

--- a/popup.html
+++ b/popup.html
@@ -355,8 +355,8 @@
                 </div>
               </label>
 
-              <!-- ThinkReview Self-Hosted Gateway -->
-              <label class="provider-card" id="provider-card-self-hosted">
+              <!-- ThinkReview Self-Hosted Gateway (Teams only) -->
+              <label class="provider-card" id="provider-card-self-hosted" style="display:none;">
                 <input type="radio" name="ai-provider" value="self-hosted" id="provider-self-hosted" class="provider-card-radio">
                 <div class="provider-card-inner">
                   <div class="provider-card-top">
@@ -370,7 +370,7 @@
                     </div>
                     <div class="provider-card-title-group">
                       <span class="provider-card-name">ThinkReview Self-Hosted Gateway</span>
-                      <span class="provider-card-badge provider-card-badge--self-hosted">On-prem</span>
+                      <span class="provider-card-badge provider-card-badge--self-hosted">Teams</span>
                     </div>
                     <div class="provider-card-check-icon">
                       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
@@ -453,7 +453,7 @@
 
             </div>
             <div id="self-hosted-config" class="ollama-config" style="display: none;">
-              <p class="help-text">Reviews route to your gateway; sign-in, agents, and billing still use ThinkReview cloud.</p>
+              <p class="help-text">Teams plan only. Reviews route to your gateway; sign-in, agents, and billing still use ThinkReview cloud.</p>
               <div class="ollama-config-row">
                 <label for="gateway-base-url" class="config-label">Gateway Base URL:</label>
                 <input type="url" id="gateway-base-url" class="config-input" placeholder="http://localhost:8443" autocomplete="off" spellcheck="false">

--- a/popup.html
+++ b/popup.html
@@ -355,6 +355,38 @@
                 </div>
               </label>
 
+              <!-- ThinkReview Self-Hosted Gateway -->
+              <label class="provider-card" id="provider-card-self-hosted">
+                <input type="radio" name="ai-provider" value="self-hosted" id="provider-self-hosted" class="provider-card-radio">
+                <div class="provider-card-inner">
+                  <div class="provider-card-top">
+                    <div class="provider-card-icon provider-card-icon--self-hosted">
+                      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect>
+                        <path d="M8 21h8"></path>
+                        <path d="M12 17v4"></path>
+                        <path d="M7 7h.01M7 11h.01"></path>
+                      </svg>
+                    </div>
+                    <div class="provider-card-title-group">
+                      <span class="provider-card-name">ThinkReview Self-Hosted Gateway</span>
+                      <span class="provider-card-badge provider-card-badge--self-hosted">On-prem</span>
+                    </div>
+                    <div class="provider-card-check-icon">
+                      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+                        <polyline points="20 6 9 17 4 12"></polyline>
+                      </svg>
+                    </div>
+                  </div>
+                  <p class="provider-card-desc">Run reviews on your on-prem ThinkReview gateway with your own LLM. Code stays in your network.</p>
+                  <div class="provider-card-tags">
+                    <span class="provider-tag provider-tag--self-hosted">Your LLM</span>
+                    <span class="provider-tag provider-tag--self-hosted">On-prem</span>
+                    <span class="provider-tag provider-tag--self-hosted">Full repo context</span>
+                  </div>
+                </div>
+              </label>
+
               <!-- Ollama Card -->
               <label class="provider-card" id="provider-card-ollama">
                 <input type="radio" name="ai-provider" value="ollama" id="provider-ollama" class="provider-card-radio">
@@ -419,6 +451,18 @@
                 </div>
               </label>
 
+            </div>
+            <div id="self-hosted-config" class="ollama-config" style="display: none;">
+              <p class="help-text">Reviews route to your gateway; sign-in, agents, and billing still use ThinkReview cloud.</p>
+              <div class="ollama-config-row">
+                <label for="gateway-base-url" class="config-label">Gateway Base URL:</label>
+                <input type="url" id="gateway-base-url" class="config-input" placeholder="http://localhost:8443" autocomplete="off" spellcheck="false">
+              </div>
+              <div class="ollama-actions">
+                <button id="test-gateway-btn" class="test-ollama-btn" type="button">Test Connection</button>
+                <button id="save-gateway-btn" class="save-ollama-btn" type="button">Save Settings</button>
+              </div>
+              <div id="gateway-status" class="ollama-status"></div>
             </div>
             <div id="ollama-config" class="ollama-config" style="display: none;">
               <div class="ollama-config-row">
@@ -508,32 +552,6 @@
                   <span class="auto-start-info-icon" data-tooltip="Review only starts when you click the ThinkReview button." aria-label="Info">ⓘ</span>
                 </div>
               </div>
-            </div>
-          </div>
-        </div>
-
-        <!-- Enterprise Gateway Settings (collapsed by default) -->
-        <div id="gateway-settings" class="ai-provider-settings-section">
-          <button class="collapsible-header" id="gateway-toggle" aria-expanded="false">
-            <h3 class="settings-title">Enterprise Gateway</h3>
-            <svg class="collapsible-chevron" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <polyline points="6 9 12 15 18 9"></polyline>
-            </svg>
-          </button>
-          <div id="gateway-body" class="collapsible-body" style="display:none;">
-            <p class="settings-description">Route patch review and conversational API calls to your on-prem ThinkReview gateway. Sign-in, agents, and billing still use ThinkReview cloud.</p>
-            <div class="ollama-config">
-              <div class="ollama-config-row">
-                <label for="gateway-base-url" class="config-label">Gateway Base URL:</label>
-                <input type="url" id="gateway-base-url" class="config-input" placeholder="https://thinkreview-gateway.yourcompany.internal:8443" autocomplete="off" spellcheck="false">
-              </div>
-              <div class="ollama-actions">
-                <button id="test-gateway-btn" class="test-ollama-btn" type="button">Test Connection</button>
-                <button id="save-gateway-btn" class="save-ollama-btn" type="button">Save</button>
-                <button id="clear-gateway-btn" class="test-ollama-btn" type="button">Use ThinkReview Cloud</button>
-              </div>
-              <div id="gateway-status" class="ollama-status"></div>
-              <p class="help-text">Leave empty and save to use the default ThinkReview cloud API. Only review endpoints are routed to your gateway.</p>
             </div>
           </div>
         </div>

--- a/popup.html
+++ b/popup.html
@@ -512,6 +512,32 @@
           </div>
         </div>
 
+        <!-- Enterprise Gateway Settings (collapsed by default) -->
+        <div id="gateway-settings" class="ai-provider-settings-section">
+          <button class="collapsible-header" id="gateway-toggle" aria-expanded="false">
+            <h3 class="settings-title">Enterprise Gateway</h3>
+            <svg class="collapsible-chevron" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="6 9 12 15 18 9"></polyline>
+            </svg>
+          </button>
+          <div id="gateway-body" class="collapsible-body" style="display:none;">
+            <p class="settings-description">Route patch review and conversational API calls to your on-prem ThinkReview gateway. Sign-in, agents, and billing still use ThinkReview cloud.</p>
+            <div class="ollama-config">
+              <div class="ollama-config-row">
+                <label for="gateway-base-url" class="config-label">Gateway Base URL:</label>
+                <input type="url" id="gateway-base-url" class="config-input" placeholder="https://thinkreview-gateway.yourcompany.internal:8443" autocomplete="off" spellcheck="false">
+              </div>
+              <div class="ollama-actions">
+                <button id="test-gateway-btn" class="test-ollama-btn" type="button">Test Connection</button>
+                <button id="save-gateway-btn" class="save-ollama-btn" type="button">Save</button>
+                <button id="clear-gateway-btn" class="test-ollama-btn" type="button">Use ThinkReview Cloud</button>
+              </div>
+              <div id="gateway-status" class="ollama-status"></div>
+              <p class="help-text">Leave empty and save to use the default ThinkReview cloud API. Only review endpoints are routed to your gateway.</p>
+            </div>
+          </div>
+        </div>
+
       </div><!-- /platform-home -->
 
 

--- a/popup.js
+++ b/popup.js
@@ -7,7 +7,7 @@ import { reviewCount } from './components/popup-modules/review-count.js';
 import { dbgLog, dbgWarn, dbgError } from './utils/logger.js';
 import { clampTemperature, clampTopP, clampTopK } from './utils/ollama-options.js';
 import { OPENROUTER_ORIGINS, hasOpenRouterHostPermission } from './utils/openrouter-permissions.js';
-import { normalizeGatewayBaseUrl } from './utils/enterprise-gateway.js';
+import { normalizeGatewayBaseUrl, canUseEnterpriseGatewayFromStorage } from './utils/enterprise-gateway.js';
 
 // Timing constants (in milliseconds)
 const TIMEOUT_AUTO_SIGNIN_WAIT = 500;
@@ -267,6 +267,7 @@ async function fetchAndDisplayUserData() {
         showErrorState('Unable to load user data');
         updateReviewCount('error');
         await updateSubscriptionStatus('Free', null, false, null);
+        await updateSelfHostedProviderVisibility(null);
         return;
       }
       const backoffTime = Math.pow(2, cloudRetry) * 500;
@@ -296,6 +297,11 @@ async function fetchAndDisplayUserData() {
           userData.stripeCanceledDate,
           initialTrialEndDate
         );
+        await chrome.storage.local.set({
+          subscriptionType,
+          userSubscriptionData: userData.userSubscriptionData || null,
+        });
+        await updateSelfHostedProviderVisibility(userData);
         dbgLog('User data updated:', userData);
         return;
       } catch (error) {
@@ -304,6 +310,7 @@ async function fetchAndDisplayUserData() {
           showErrorState('Failed to load user data');
           updateReviewCount('error');
           await updateSubscriptionStatus('Free', null, false, null);
+          await updateSelfHostedProviderVisibility(null);
           return;
         }
         const backoffTime = Math.pow(2, fetchAttempt) * 500;
@@ -2202,10 +2209,21 @@ function setupAIProviderEventListeners() {
 
 async function loadAIProviderSettings() {
   try {
-    const result = await chrome.storage.local.get(['aiProvider', 'ollamaConfig', 'openrouterConfig', 'gatewayBaseUrl']);
+    const result = await chrome.storage.local.get([
+      'aiProvider',
+      'ollamaConfig',
+      'openrouterConfig',
+      'gatewayBaseUrl',
+      'userSubscriptionData',
+      'subscriptionType',
+    ]);
     let provider = result.aiProvider || 'cloud';
-    // Migrate: if gateway URL was saved before self-hosted provider existed
-    if (provider === 'cloud' && result.gatewayBaseUrl) {
+    const canUseGateway = canUseEnterpriseGatewayFromStorage(result);
+
+    if (provider === 'self-hosted' && !canUseGateway) {
+      provider = 'cloud';
+      await chrome.storage.local.set({ aiProvider: 'cloud' });
+    } else if (provider === 'cloud' && result.gatewayBaseUrl && canUseGateway) {
       provider = 'self-hosted';
       await chrome.storage.local.set({ aiProvider: 'self-hosted' });
     }
@@ -2266,6 +2284,10 @@ async function loadAIProviderSettings() {
     }
     
     dbgLog('AI Provider settings loaded:', { provider, config });
+    await updateSelfHostedProviderVisibility({
+      userSubscriptionData: result.userSubscriptionData,
+      subscriptionType: result.subscriptionType,
+    });
   } catch (error) {
     dbgWarn('Error loading AI Provider settings:', error);
   }
@@ -2293,6 +2315,20 @@ function showProviderConfigPanels(provider) {
 
 async function handleProviderChange(event) {
   const provider = event.target.value;
+
+  if (provider === 'self-hosted') {
+    const stored = await chrome.storage.local.get(['userSubscriptionData', 'subscriptionType']);
+    if (!canUseEnterpriseGatewayFromStorage(stored)) {
+      showGatewayStatus('ThinkReview Self-Hosted Gateway is available on the Teams plan only', 'error');
+      const cloudRadio = document.getElementById('provider-cloud');
+      if (cloudRadio) cloudRadio.checked = true;
+      updateProviderCardSelection('cloud');
+      showProviderConfigPanels('cloud');
+      await chrome.storage.local.set({ aiProvider: 'cloud' });
+      return;
+    }
+  }
+
   updateProviderCardSelection(provider);
   showProviderConfigPanels(provider);
 
@@ -3131,8 +3167,43 @@ function initializeAIProviderCollapsible() {
 }
 
 // =====================================================================
-// THINKREVIEW SELF-HOSTED GATEWAY (aiProvider: self-hosted)
+// THINKREVIEW SELF-HOSTED GATEWAY (Teams plan only — aiProvider: self-hosted)
 // =====================================================================
+
+async function updateSelfHostedProviderVisibility(userData) {
+  const card = document.getElementById('provider-card-self-hosted');
+  const canUse = canUseEnterpriseGatewayFromStorage({
+    userSubscriptionData: userData?.userSubscriptionData,
+    subscriptionType: userData?.subscriptionType,
+  });
+
+  if (card) {
+    card.style.display = canUse ? 'block' : 'none';
+  }
+
+  if (!canUse) {
+    const stored = await chrome.storage.local.get(['aiProvider']);
+    if (stored.aiProvider === 'self-hosted') {
+      await chrome.storage.local.set({ aiProvider: 'cloud' });
+      const cloudRadio = document.getElementById('provider-cloud');
+      if (cloudRadio) cloudRadio.checked = true;
+      updateProviderCardSelection('cloud');
+      showProviderConfigPanels('cloud');
+    }
+  }
+}
+
+async function ensureTeamsPlanForGateway() {
+  const stored = await chrome.storage.local.get([
+    'userSubscriptionData',
+    'subscriptionType',
+  ]);
+  if (canUseEnterpriseGatewayFromStorage(stored)) {
+    return true;
+  }
+  showGatewayStatus('ThinkReview Self-Hosted Gateway is available on the Teams plan only', 'error');
+  return false;
+}
 
 function getGatewayOriginPattern(baseUrl) {
   const url = new URL(baseUrl);
@@ -3162,6 +3233,9 @@ function showGatewayStatus(message, type = 'info') {
 }
 
 async function testGatewayConnection() {
+  if (!(await ensureTeamsPlanForGateway())) {
+    return;
+  }
   const urlInput = document.getElementById('gateway-base-url');
   const testButton = document.getElementById('test-gateway-btn');
   const raw = urlInput ? urlInput.value : '';
@@ -3212,6 +3286,9 @@ async function testGatewayConnection() {
 }
 
 async function saveGatewaySettings() {
+  if (!(await ensureTeamsPlanForGateway())) {
+    return;
+  }
   const urlInput = document.getElementById('gateway-base-url');
   const saveButton = document.getElementById('save-gateway-btn');
   const raw = urlInput ? urlInput.value : '';

--- a/popup.js
+++ b/popup.js
@@ -7,6 +7,7 @@ import { reviewCount } from './components/popup-modules/review-count.js';
 import { dbgLog, dbgWarn, dbgError } from './utils/logger.js';
 import { clampTemperature, clampTopP, clampTopK } from './utils/ollama-options.js';
 import { OPENROUTER_ORIGINS, hasOpenRouterHostPermission } from './utils/openrouter-permissions.js';
+import { normalizeGatewayBaseUrl } from './utils/enterprise-gateway.js';
 
 // Timing constants (in milliseconds)
 const TIMEOUT_AUTO_SIGNIN_WAIT = 500;
@@ -855,10 +856,6 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   // Initialize collapsible AI Provider header
   initializeAIProviderCollapsible();
-
-  // Initialize enterprise gateway settings
-  initializeGatewaySettings();
-  initializeGatewayCollapsible();
 
 });
 
@@ -2152,6 +2149,9 @@ function setupAIProviderEventListeners() {
   const testOpenRouterButton = document.getElementById('test-openrouter-btn');
   const saveOpenRouterButton = document.getElementById('save-openrouter-btn');
   const refreshOpenRouterModelsButton = document.getElementById('refresh-openrouter-models-btn');
+  const testGatewayButton = document.getElementById('test-gateway-btn');
+  const saveGatewayButton = document.getElementById('save-gateway-btn');
+  const gatewayUrlInput = document.getElementById('gateway-base-url');
   
   // Provider selection change
   providerRadios.forEach(radio => {
@@ -2184,12 +2184,31 @@ function setupAIProviderEventListeners() {
   if (refreshOpenRouterModelsButton) {
     refreshOpenRouterModelsButton.addEventListener('click', refreshOpenRouterModels);
   }
+
+  if (testGatewayButton) {
+    testGatewayButton.addEventListener('click', testGatewayConnection);
+  }
+  if (saveGatewayButton) {
+    saveGatewayButton.addEventListener('click', saveGatewaySettings);
+  }
+  if (gatewayUrlInput) {
+    gatewayUrlInput.addEventListener('keypress', (event) => {
+      if (event.key === 'Enter') {
+        saveGatewaySettings();
+      }
+    });
+  }
 }
 
 async function loadAIProviderSettings() {
   try {
-    const result = await chrome.storage.local.get(['aiProvider', 'ollamaConfig', 'openrouterConfig']);
-    const provider = result.aiProvider || 'cloud';
+    const result = await chrome.storage.local.get(['aiProvider', 'ollamaConfig', 'openrouterConfig', 'gatewayBaseUrl']);
+    let provider = result.aiProvider || 'cloud';
+    // Migrate: if gateway URL was saved before self-hosted provider existed
+    if (provider === 'cloud' && result.gatewayBaseUrl) {
+      provider = 'self-hosted';
+      await chrome.storage.local.set({ aiProvider: 'self-hosted' });
+    }
     const config = result.ollamaConfig || {
       url: 'http://localhost:11434',
       model: 'gemma4',
@@ -2204,21 +2223,19 @@ async function loadAIProviderSettings() {
     };
     
     // Set the selected provider
-    const providerRadio = document.getElementById(`provider-${provider}`);
+    const providerRadioId = provider === 'self-hosted' ? 'provider-self-hosted' : `provider-${provider}`;
+    const providerRadio = document.getElementById(providerRadioId);
     if (providerRadio) {
       providerRadio.checked = true;
     }
     updateProviderCardSelection(provider);
+    showProviderConfigPanels(provider);
+
+    const gatewayUrlInput = document.getElementById('gateway-base-url');
+    if (gatewayUrlInput) {
+      gatewayUrlInput.value = result.gatewayBaseUrl || '';
+    }
     
-    // Show/hide Ollama config based on provider
-    const ollamaConfig = document.getElementById('ollama-config');
-    if (ollamaConfig) {
-      ollamaConfig.style.display = provider === 'ollama' ? 'block' : 'none';
-    }
-    const openrouterConfigEl = document.getElementById('openrouter-config');
-    if (openrouterConfigEl) {
-      openrouterConfigEl.style.display = provider === 'openrouter' ? 'block' : 'none';
-    }
     // Load Ollama config values
     const urlInput = document.getElementById('ollama-url');
     const modelInput = document.getElementById('ollama-model');
@@ -2256,80 +2273,87 @@ async function loadAIProviderSettings() {
 
 function updateProviderCardSelection(provider) {
   const cloudCard = document.getElementById('provider-card-cloud');
+  const selfHostedCard = document.getElementById('provider-card-self-hosted');
   const ollamaCard = document.getElementById('provider-card-ollama');
   const openrouterCard = document.getElementById('provider-card-openrouter');
   if (cloudCard) cloudCard.classList.toggle('is-selected', provider === 'cloud');
+  if (selfHostedCard) selfHostedCard.classList.toggle('is-selected', provider === 'self-hosted');
   if (ollamaCard) ollamaCard.classList.toggle('is-selected', provider === 'ollama');
   if (openrouterCard) openrouterCard.classList.toggle('is-selected', provider === 'openrouter');
 }
 
-function handleProviderChange(event) {
-  const provider = event.target.value;
-  updateProviderCardSelection(provider);
+function showProviderConfigPanels(provider) {
   const ollamaConfig = document.getElementById('ollama-config');
   const openrouterConfig = document.getElementById('openrouter-config');
-  
-  if (ollamaConfig) {
-    ollamaConfig.style.display = provider === 'ollama' ? 'block' : 'none';
-  }
-  if (openrouterConfig) {
-    openrouterConfig.style.display = provider === 'openrouter' ? 'block' : 'none';
-  }
-  // Auto-save provider selection
-  chrome.storage.local.set({ aiProvider: provider }, () => {
+  const selfHostedConfig = document.getElementById('self-hosted-config');
+  if (ollamaConfig) ollamaConfig.style.display = provider === 'ollama' ? 'block' : 'none';
+  if (openrouterConfig) openrouterConfig.style.display = provider === 'openrouter' ? 'block' : 'none';
+  if (selfHostedConfig) selfHostedConfig.style.display = provider === 'self-hosted' ? 'block' : 'none';
+}
+
+async function handleProviderChange(event) {
+  const provider = event.target.value;
+  updateProviderCardSelection(provider);
+  showProviderConfigPanels(provider);
+
+  try {
+    await chrome.storage.local.set({ aiProvider: provider });
     dbgLog('AI Provider changed to:', provider);
+  } catch (error) {
+    dbgWarn('Error saving AI provider selection:', error);
+  }
+
+  if (provider === 'self-hosted') {
+    showGatewayStatus('ThinkReview Self-Hosted Gateway selected — enter your gateway URL below', 'info');
+  } else {
     showOllamaStatus(
-      provider === 'cloud' 
-        ? '☁️ Using Cloud AI (Advanced Models)' 
+      provider === 'cloud'
+        ? '☁️ Using ThinkReview Cloud'
         : provider === 'ollama'
           ? '🖥️ Local Ollama selected - configure and test below'
           : '🌐 OpenRouter selected - enter your API key and choose a model',
       provider === 'cloud' ? 'success' : 'info'
     );
-    
-    // Automatically fetch models when Ollama is selected
-    if (provider === 'ollama') {
-      const urlInput = document.getElementById('ollama-url');
-      const url = urlInput ? urlInput.value.trim() : 'http://localhost:11434';
-      
-      dbgLog('Ollama selected, fetching available models...');
-      fetchAndPopulateModels(url).catch(err => {
-        dbgWarn('Error auto-fetching models (non-critical):', err);
+  }
+
+  if (provider === 'ollama') {
+    const urlInput = document.getElementById('ollama-url');
+    const url = urlInput ? urlInput.value.trim() : 'http://localhost:11434';
+
+    dbgLog('Ollama selected, fetching available models...');
+    fetchAndPopulateModels(url).catch(err => {
+      dbgWarn('Error auto-fetching models (non-critical):', err);
+    });
+  }
+
+  if (provider === 'openrouter') {
+    loadOpenRouterPermissionState();
+    const apiKeyInput = document.getElementById('openrouter-api-key');
+    const apiKey = apiKeyInput ? apiKeyInput.value.trim() : '';
+
+    if (apiKey) {
+      hasOpenRouterHostPermission().then((allowed) => {
+        if (!allowed) return;
+        dbgLog('OpenRouter selected, fetching available models...');
+        fetchAndPopulateOpenRouterModels(apiKey).catch(err => {
+          dbgWarn('Error auto-fetching OpenRouter models (non-critical):', err);
+        });
       });
     }
+  }
 
-    if (provider === 'openrouter') {
-      loadOpenRouterPermissionState();
-      const apiKeyInput = document.getElementById('openrouter-api-key');
-      const apiKey = apiKeyInput ? apiKeyInput.value.trim() : '';
-
-      if (apiKey) {
-        hasOpenRouterHostPermission().then((allowed) => {
-          if (!allowed) return;
-          dbgLog('OpenRouter selected, fetching available models...');
-          fetchAndPopulateOpenRouterModels(apiKey).catch(err => {
-            dbgWarn('Error auto-fetching OpenRouter models (non-critical):', err);
-          });
-        });
+  isUserLoggedIn().then(isLoggedIn => {
+    if (isLoggedIn && window.CloudService) {
+      dbgLog('User logged in, tracking AI provider change in cloud (async)');
+      if (provider === 'cloud') {
+        window.CloudService.trackOllamaConfig(false, null)
+          .then(() => dbgLog('Ollama disabled tracked successfully in cloud'))
+          .catch(trackError => dbgWarn('Error tracking provider change in cloud (non-critical):', trackError));
       }
+    } else {
+      dbgLog('User not logged in or CloudService not available, skipping cloud tracking');
     }
-    
-    // Track provider change in cloud asynchronously (fire-and-forget)
-    isUserLoggedIn().then(isLoggedIn => {
-      if (isLoggedIn && window.CloudService) {
-        dbgLog('User logged in, tracking AI provider change in cloud (async)');
-        // If switching to cloud, track Ollama as disabled
-        if (provider === 'cloud') {
-          window.CloudService.trackOllamaConfig(false, null)
-            .then(() => dbgLog('Ollama disabled tracked successfully in cloud'))
-            .catch(trackError => dbgWarn('Error tracking provider change in cloud (non-critical):', trackError));
-        }
-        // If switching to Ollama, it will be tracked when user saves the config
-      } else {
-        dbgLog('User not logged in or CloudService not available, skipping cloud tracking');
-      }
-    }).catch(err => dbgWarn('Error checking login status for cloud tracking:', err));
-  });
+  }).catch(err => dbgWarn('Error checking login status for cloud tracking:', err));
 }
 
 async function fetchAndPopulateModels(url, savedModel = null) {
@@ -3107,58 +3131,8 @@ function initializeAIProviderCollapsible() {
 }
 
 // =====================================================================
-// ENTERPRISE GATEWAY SETTINGS
+// THINKREVIEW SELF-HOSTED GATEWAY (aiProvider: self-hosted)
 // =====================================================================
-
-function initializeGatewaySettings() {
-  loadGatewaySettings();
-  setupGatewayEventListeners();
-}
-
-function setupGatewayEventListeners() {
-  const saveButton = document.getElementById('save-gateway-btn');
-  const testButton = document.getElementById('test-gateway-btn');
-  const clearButton = document.getElementById('clear-gateway-btn');
-  const urlInput = document.getElementById('gateway-base-url');
-
-  if (saveButton) {
-    saveButton.addEventListener('click', saveGatewaySettings);
-  }
-  if (testButton) {
-    testButton.addEventListener('click', testGatewayConnection);
-  }
-  if (clearButton) {
-    clearButton.addEventListener('click', clearGatewaySettings);
-  }
-  if (urlInput) {
-    urlInput.addEventListener('keypress', (event) => {
-      if (event.key === 'Enter') {
-        saveGatewaySettings();
-      }
-    });
-  }
-}
-
-function normalizeGatewayBaseUrl(raw) {
-  const trimmed = String(raw || '').trim();
-  if (!trimmed) return '';
-
-  let candidate = trimmed;
-  if (!/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(candidate)) {
-    candidate = `https://${candidate}`;
-  }
-
-  try {
-    const url = new URL(candidate);
-    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-      return null;
-    }
-    const pathname = url.pathname.replace(/\/$/, '');
-    return `${url.origin}${pathname === '' ? '' : pathname}`.replace(/\/$/, '');
-  } catch (_) {
-    return null;
-  }
-}
 
 function getGatewayOriginPattern(baseUrl) {
   const url = new URL(baseUrl);
@@ -3171,18 +3145,6 @@ async function requestGatewayHostPermission(baseUrl) {
   if (existing) return true;
 
   return chrome.permissions.request({ origins: [originPattern] });
-}
-
-async function loadGatewaySettings() {
-  try {
-    const result = await chrome.storage.local.get(['gatewayBaseUrl']);
-    const urlInput = document.getElementById('gateway-base-url');
-    if (urlInput) {
-      urlInput.value = result.gatewayBaseUrl || '';
-    }
-  } catch (error) {
-    dbgWarn('Error loading gateway settings:', error);
-  }
 }
 
 function showGatewayStatus(message, type = 'info') {
@@ -3255,8 +3217,14 @@ async function saveGatewaySettings() {
   const raw = urlInput ? urlInput.value : '';
   const baseUrl = normalizeGatewayBaseUrl(raw);
 
-  if (raw.trim() && !baseUrl) {
+  if (!baseUrl) {
     showGatewayStatus('Please enter a valid gateway URL (http or https)', 'error');
+    return;
+  }
+
+  const selectedProvider = document.querySelector('input[name="ai-provider"]:checked')?.value;
+  if (selectedProvider !== 'self-hosted') {
+    showGatewayStatus('Select ThinkReview Self-Hosted Gateway before saving the URL', 'error');
     return;
   }
 
@@ -3265,49 +3233,18 @@ async function saveGatewaySettings() {
   if (saveButton) saveButton.disabled = true;
 
   try {
-    if (baseUrl) {
-      const granted = await requestGatewayHostPermission(baseUrl);
-      if (!granted) {
-        showGatewayStatus('Permission not granted. Allow access to your gateway host to save this URL.', 'error');
-        return;
-      }
-      await chrome.storage.local.set({ gatewayBaseUrl: baseUrl });
-      showGatewayStatus('Enterprise gateway URL saved', 'success');
-    } else {
-      await chrome.storage.local.remove(['gatewayBaseUrl']);
-      showGatewayStatus('Using ThinkReview cloud for reviews', 'success');
+    const granted = await requestGatewayHostPermission(baseUrl);
+    if (!granted) {
+      showGatewayStatus('Permission not granted. Allow access to your gateway host to save this URL.', 'error');
+      return;
     }
-    dbgLog('Gateway settings saved:', { gatewayBaseUrl: baseUrl || null });
+    await chrome.storage.local.set({ gatewayBaseUrl: baseUrl });
+    showGatewayStatus('Self-hosted gateway URL saved', 'success');
+    dbgLog('Gateway settings saved:', { gatewayBaseUrl: baseUrl });
   } catch (error) {
     dbgWarn('Error saving gateway settings:', error);
     showGatewayStatus('Failed to save gateway settings', 'error');
   } finally {
     if (saveButton) saveButton.disabled = false;
   }
-}
-
-async function clearGatewaySettings() {
-  const urlInput = document.getElementById('gateway-base-url');
-  if (urlInput) urlInput.value = '';
-
-  try {
-    await chrome.storage.local.remove(['gatewayBaseUrl']);
-    showGatewayStatus('Using ThinkReview cloud for reviews', 'success');
-    dbgLog('Gateway settings cleared');
-  } catch (error) {
-    dbgWarn('Error clearing gateway settings:', error);
-    showGatewayStatus('Failed to clear gateway settings', 'error');
-  }
-}
-
-function initializeGatewayCollapsible() {
-  const toggle = document.getElementById('gateway-toggle');
-  const body = document.getElementById('gateway-body');
-  if (!toggle || !body) return;
-
-  toggle.addEventListener('click', () => {
-    const expanded = toggle.getAttribute('aria-expanded') === 'true';
-    toggle.setAttribute('aria-expanded', String(!expanded));
-    body.style.display = expanded ? 'none' : 'block';
-  });
 }

--- a/popup.js
+++ b/popup.js
@@ -856,6 +856,10 @@ document.addEventListener('DOMContentLoaded', async () => {
   // Initialize collapsible AI Provider header
   initializeAIProviderCollapsible();
 
+  // Initialize enterprise gateway settings
+  initializeGatewaySettings();
+  initializeGatewayCollapsible();
+
 });
 
 // Domain Management Functionality
@@ -3093,6 +3097,212 @@ function setBadge(platform, status) {
 function initializeAIProviderCollapsible() {
   const toggle = document.getElementById('ai-provider-toggle');
   const body = document.getElementById('ai-provider-body');
+  if (!toggle || !body) return;
+
+  toggle.addEventListener('click', () => {
+    const expanded = toggle.getAttribute('aria-expanded') === 'true';
+    toggle.setAttribute('aria-expanded', String(!expanded));
+    body.style.display = expanded ? 'none' : 'block';
+  });
+}
+
+// =====================================================================
+// ENTERPRISE GATEWAY SETTINGS
+// =====================================================================
+
+function initializeGatewaySettings() {
+  loadGatewaySettings();
+  setupGatewayEventListeners();
+}
+
+function setupGatewayEventListeners() {
+  const saveButton = document.getElementById('save-gateway-btn');
+  const testButton = document.getElementById('test-gateway-btn');
+  const clearButton = document.getElementById('clear-gateway-btn');
+  const urlInput = document.getElementById('gateway-base-url');
+
+  if (saveButton) {
+    saveButton.addEventListener('click', saveGatewaySettings);
+  }
+  if (testButton) {
+    testButton.addEventListener('click', testGatewayConnection);
+  }
+  if (clearButton) {
+    clearButton.addEventListener('click', clearGatewaySettings);
+  }
+  if (urlInput) {
+    urlInput.addEventListener('keypress', (event) => {
+      if (event.key === 'Enter') {
+        saveGatewaySettings();
+      }
+    });
+  }
+}
+
+function normalizeGatewayBaseUrl(raw) {
+  const trimmed = String(raw || '').trim();
+  if (!trimmed) return '';
+
+  let candidate = trimmed;
+  if (!/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(candidate)) {
+    candidate = `https://${candidate}`;
+  }
+
+  try {
+    const url = new URL(candidate);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return null;
+    }
+    const pathname = url.pathname.replace(/\/$/, '');
+    return `${url.origin}${pathname === '' ? '' : pathname}`.replace(/\/$/, '');
+  } catch (_) {
+    return null;
+  }
+}
+
+function getGatewayOriginPattern(baseUrl) {
+  const url = new URL(baseUrl);
+  return `${url.origin}/*`;
+}
+
+async function requestGatewayHostPermission(baseUrl) {
+  const originPattern = getGatewayOriginPattern(baseUrl);
+  const existing = await chrome.permissions.contains({ origins: [originPattern] });
+  if (existing) return true;
+
+  return chrome.permissions.request({ origins: [originPattern] });
+}
+
+async function loadGatewaySettings() {
+  try {
+    const result = await chrome.storage.local.get(['gatewayBaseUrl']);
+    const urlInput = document.getElementById('gateway-base-url');
+    if (urlInput) {
+      urlInput.value = result.gatewayBaseUrl || '';
+    }
+  } catch (error) {
+    dbgWarn('Error loading gateway settings:', error);
+  }
+}
+
+function showGatewayStatus(message, type = 'info') {
+  const statusDiv = document.getElementById('gateway-status');
+  if (!statusDiv) return;
+
+  statusDiv.textContent = message;
+  statusDiv.className = `ollama-status show ${type}`;
+
+  if (type === 'success') {
+    setTimeout(() => {
+      statusDiv.classList.remove('show');
+    }, 5000);
+  }
+}
+
+async function testGatewayConnection() {
+  const urlInput = document.getElementById('gateway-base-url');
+  const testButton = document.getElementById('test-gateway-btn');
+  const raw = urlInput ? urlInput.value : '';
+  const baseUrl = normalizeGatewayBaseUrl(raw);
+
+  if (!baseUrl) {
+    showGatewayStatus('Please enter a valid gateway URL (http or https)', 'error');
+    return;
+  }
+
+  if (urlInput) urlInput.value = baseUrl;
+
+  if (testButton) testButton.disabled = true;
+  showGatewayStatus('Testing gateway connection...', 'info');
+
+  try {
+    const granted = await requestGatewayHostPermission(baseUrl);
+    if (!granted) {
+      showGatewayStatus('Permission not granted. Allow access to your gateway host to test the connection.', 'error');
+      return;
+    }
+
+    const response = await fetch(`${baseUrl}/health`);
+    if (!response.ok) {
+      showGatewayStatus(`Gateway returned HTTP ${response.status}`, 'error');
+      return;
+    }
+
+    let payload = null;
+    try {
+      payload = await response.json();
+    } catch (_) {
+      // non-JSON health response is still a successful connection
+    }
+
+    if (payload && payload.engineReady === false) {
+      showGatewayStatus('Gateway reachable, but review engine is not ready yet', 'error');
+      return;
+    }
+
+    showGatewayStatus('Gateway connection successful', 'success');
+  } catch (error) {
+    dbgWarn('Gateway connection test failed:', error);
+    showGatewayStatus(`Connection failed: ${error.message}`, 'error');
+  } finally {
+    if (testButton) testButton.disabled = false;
+  }
+}
+
+async function saveGatewaySettings() {
+  const urlInput = document.getElementById('gateway-base-url');
+  const saveButton = document.getElementById('save-gateway-btn');
+  const raw = urlInput ? urlInput.value : '';
+  const baseUrl = normalizeGatewayBaseUrl(raw);
+
+  if (raw.trim() && !baseUrl) {
+    showGatewayStatus('Please enter a valid gateway URL (http or https)', 'error');
+    return;
+  }
+
+  if (urlInput) urlInput.value = baseUrl;
+
+  if (saveButton) saveButton.disabled = true;
+
+  try {
+    if (baseUrl) {
+      const granted = await requestGatewayHostPermission(baseUrl);
+      if (!granted) {
+        showGatewayStatus('Permission not granted. Allow access to your gateway host to save this URL.', 'error');
+        return;
+      }
+      await chrome.storage.local.set({ gatewayBaseUrl: baseUrl });
+      showGatewayStatus('Enterprise gateway URL saved', 'success');
+    } else {
+      await chrome.storage.local.remove(['gatewayBaseUrl']);
+      showGatewayStatus('Using ThinkReview cloud for reviews', 'success');
+    }
+    dbgLog('Gateway settings saved:', { gatewayBaseUrl: baseUrl || null });
+  } catch (error) {
+    dbgWarn('Error saving gateway settings:', error);
+    showGatewayStatus('Failed to save gateway settings', 'error');
+  } finally {
+    if (saveButton) saveButton.disabled = false;
+  }
+}
+
+async function clearGatewaySettings() {
+  const urlInput = document.getElementById('gateway-base-url');
+  if (urlInput) urlInput.value = '';
+
+  try {
+    await chrome.storage.local.remove(['gatewayBaseUrl']);
+    showGatewayStatus('Using ThinkReview cloud for reviews', 'success');
+    dbgLog('Gateway settings cleared');
+  } catch (error) {
+    dbgWarn('Error clearing gateway settings:', error);
+    showGatewayStatus('Failed to clear gateway settings', 'error');
+  }
+}
+
+function initializeGatewayCollapsible() {
+  const toggle = document.getElementById('gateway-toggle');
+  const body = document.getElementById('gateway-body');
   if (!toggle || !body) return;
 
   toggle.addEventListener('click', () => {

--- a/services/cloud-service.js
+++ b/services/cloud-service.js
@@ -24,7 +24,6 @@ const EXTENSION_VERSION_PAYLOAD = _extensionVersion ? { extensionVersion: _exten
 const CLOUD_FUNCTIONS_BASE_URL = 'https://us-central1-thinkgpt.cloudfunctions.net';
 const SYNC_USER_URL = `${CLOUD_FUNCTIONS_BASE_URL}/syncUserByEmailReviews`;
 const REVIEW_CODE_URL = `${CLOUD_FUNCTIONS_BASE_URL}/reviewPatchCode`;
-const REVIEW_CODE_URL_V1_1 = `${CLOUD_FUNCTIONS_BASE_URL}/reviewPatchCode_1_1`;
 const SYNC_REVIEWS_URL = `${CLOUD_FUNCTIONS_BASE_URL}/syncCodeReviews`;
 const GET_REVIEW_COUNT_URL = `${CLOUD_FUNCTIONS_BASE_URL}/getReviewCount`;
 const GET_USER_DATA_URL = `${CLOUD_FUNCTIONS_BASE_URL}/ThinkReviewGetUserData`;
@@ -36,7 +35,6 @@ const GET_UPGRADE_PROMPT_CONFIG_URL = `${CLOUD_FUNCTIONS_BASE_URL}/getUpgradePro
 const FETCH_NEWS_MESSAGE_THINKREVIEW_URL = `${CLOUD_FUNCTIONS_BASE_URL}/fetchNewsMessageThinkReview`;
 const CANCEL_SUBSCRIPTION_URL = `${CLOUD_FUNCTIONS_BASE_URL}/cancelSubscriptionThinkReview`;
 const CONVERSATIONAL_REVIEW_URL = `${CLOUD_FUNCTIONS_BASE_URL}/getConversationalReview`;
-const CONVERSATIONAL_REVIEW_URL_V1_1 = `${CLOUD_FUNCTIONS_BASE_URL}/getConversationalReview_1_1`;
 const TRACK_CUSTOM_DOMAINS_URL = `${CLOUD_FUNCTIONS_BASE_URL}/trackCustomDomainsThinkReview`;
 const STORE_LAYOUT_SETTINGS_URL = `${CLOUD_FUNCTIONS_BASE_URL}/storeLayoutSettingsThinkReview`;
 const LOG_AZURE_DEVOPS_VERSION_URL = `${CLOUD_FUNCTIONS_BASE_URL}/logAzureDevOpsVersionThinkReview`;
@@ -70,6 +68,36 @@ export class CloudService {
     }
 
     return response;
+  }
+
+  /**
+   * Enterprise on-prem gateway base URL (optional). When set, patch review and
+   * conversational endpoints use the gateway instead of ThinkReview cloud.
+   * @returns {Promise<string>}
+   */
+  static async getReviewApiBaseUrl() {
+    try {
+      const stored = await new Promise((resolve) => {
+        chrome.storage.local.get(['gatewayBaseUrl'], resolve);
+      });
+      const raw = stored?.gatewayBaseUrl;
+      if (typeof raw === 'string' && raw.trim()) {
+        return raw.trim().replace(/\/$/, '');
+      }
+    } catch (_) {
+      // ignore
+    }
+    return CLOUD_FUNCTIONS_BASE_URL;
+  }
+
+  static async getReviewCodeUrlV11() {
+    const base = await CloudService.getReviewApiBaseUrl();
+    return `${base}/reviewPatchCode_1_1`;
+  }
+
+  static async getConversationalReviewUrlV11() {
+    const base = await CloudService.getReviewApiBaseUrl();
+    return `${base}/getConversationalReview_1_1`;
   }
 
   /**
@@ -323,7 +351,7 @@ export class CloudService {
         requestBody.platform = platform;
       }
       
-      const response = await CloudService.thinkReviewFetch(REVIEW_CODE_URL_V1_1, requestBody);
+      const response = await CloudService.thinkReviewFetch(await CloudService.getReviewCodeUrlV11(), requestBody);
       
       if (!response.ok) {
         const errorText = await response.text();
@@ -490,7 +518,7 @@ export class CloudService {
         language: language
       });
       
-      const response = await CloudService.thinkReviewFetch(CONVERSATIONAL_REVIEW_URL_V1_1, requestBody);
+      const response = await CloudService.thinkReviewFetch(await CloudService.getConversationalReviewUrlV11(), requestBody);
       
       if (!response.ok) {
         const errorText = await response.text();

--- a/services/cloud-service.js
+++ b/services/cloud-service.js
@@ -78,8 +78,12 @@ export class CloudService {
   static async getReviewApiBaseUrl() {
     try {
       const stored = await new Promise((resolve) => {
-        chrome.storage.local.get(['gatewayBaseUrl'], resolve);
+        chrome.storage.local.get(['aiProvider', 'gatewayBaseUrl'], resolve);
       });
+      const provider = stored?.aiProvider || 'cloud';
+      if (provider !== 'self-hosted') {
+        return CLOUD_FUNCTIONS_BASE_URL;
+      }
       const raw = stored?.gatewayBaseUrl;
       if (typeof raw === 'string' && raw.trim()) {
         return raw.trim().replace(/\/$/, '');

--- a/services/cloud-service.js
+++ b/services/cloud-service.js
@@ -1,6 +1,7 @@
 import { dbgLog, dbgWarn, dbgError } from '../utils/logger.js';
 import { getThinkReviewAuthHeaders, handleUnauthorizedResponse, AuthExpiredError } from '../utils/extension-auth.js';
 import { filterValidCreditPacks } from '../utils/credit-pack-validation.js';
+import { canUseEnterpriseGatewayFromStorage } from '../utils/enterprise-gateway.js';
 
 // Cached once at module load; chrome.runtime.getManifest() is synchronous and
 // returns the same static value for the lifetime of the extension page.
@@ -78,10 +79,19 @@ export class CloudService {
   static async getReviewApiBaseUrl() {
     try {
       const stored = await new Promise((resolve) => {
-        chrome.storage.local.get(['aiProvider', 'gatewayBaseUrl'], resolve);
+        chrome.storage.local.get([
+          'aiProvider',
+          'gatewayBaseUrl',
+          'userSubscriptionData',
+          'userData',
+          'subscriptionType',
+        ], resolve);
       });
       const provider = stored?.aiProvider || 'cloud';
       if (provider !== 'self-hosted') {
+        return CLOUD_FUNCTIONS_BASE_URL;
+      }
+      if (!canUseEnterpriseGatewayFromStorage(stored)) {
         return CLOUD_FUNCTIONS_BASE_URL;
       }
       const raw = stored?.gatewayBaseUrl;

--- a/utils/enterprise-gateway.js
+++ b/utils/enterprise-gateway.js
@@ -1,6 +1,36 @@
 /**
- * ThinkReview self-hosted gateway helpers.
+ * ThinkReview self-hosted gateway helpers (Teams plan only).
  */
+
+export function isTeamsSubscriptionType(subscriptionType) {
+  return String(subscriptionType ?? '').trim().toLowerCase() === 'teams';
+}
+
+/**
+ * @param {object} stored - chrome.storage.local snapshot or user payload
+ * @returns {boolean}
+ */
+export function canUseEnterpriseGatewayFromStorage(stored) {
+  const sub = stored?.userSubscriptionData;
+  if (sub && typeof sub === 'object') {
+    const type = sub.userSubscriptionType || stored?.subscriptionType;
+    if (sub.userSubscriptionStatus && sub.userSubscriptionStatus !== 'active') {
+      return false;
+    }
+    return isTeamsSubscriptionType(type);
+  }
+  const fallbackType = stored?.subscriptionType || stored?.userData?.subscriptionType;
+  return isTeamsSubscriptionType(fallbackType);
+}
+
+export async function readCanUseEnterpriseGateway() {
+  const stored = await chrome.storage.local.get([
+    'userSubscriptionData',
+    'userData',
+    'subscriptionType',
+  ]);
+  return canUseEnterpriseGatewayFromStorage(stored);
+}
 
 export function normalizeGatewayBaseUrl(raw) {
   const trimmed = String(raw || '').trim();
@@ -33,7 +63,22 @@ export async function assertSelfHostedGatewayReady(aiProvider) {
     return { ok: true };
   }
 
-  const stored = await chrome.storage.local.get(['gatewayBaseUrl']);
+  const stored = await chrome.storage.local.get([
+    'gatewayBaseUrl',
+    'userSubscriptionData',
+    'userData',
+    'subscriptionType',
+  ]);
+
+  if (!canUseEnterpriseGatewayFromStorage(stored)) {
+    return {
+      ok: false,
+      error: 'ThinkReview Self-Hosted Gateway requires a Teams subscription.',
+      provider: 'self-hosted',
+      suggestion: 'Switch to ThinkReview Cloud or upgrade to Teams.',
+    };
+  }
+
   const baseUrl = normalizeGatewayBaseUrl(stored?.gatewayBaseUrl);
   if (!baseUrl) {
     return {

--- a/utils/enterprise-gateway.js
+++ b/utils/enterprise-gateway.js
@@ -1,0 +1,48 @@
+/**
+ * ThinkReview self-hosted gateway helpers.
+ */
+
+export function normalizeGatewayBaseUrl(raw) {
+  const trimmed = String(raw || '').trim();
+  if (!trimmed) return '';
+
+  let candidate = trimmed;
+  if (!/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(candidate)) {
+    candidate = `https://${candidate}`;
+  }
+
+  try {
+    const url = new URL(candidate);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return null;
+    }
+    const pathname = url.pathname.replace(/\/$/, '');
+    return `${url.origin}${pathname === '' ? '' : pathname}`.replace(/\/$/, '');
+  } catch (_) {
+    return null;
+  }
+}
+
+/**
+ * Validate self-hosted gateway is configured before routing review traffic.
+ * @param {string} aiProvider
+ * @returns {Promise<{ ok: boolean, error?: string, provider?: string, suggestion?: string }>}
+ */
+export async function assertSelfHostedGatewayReady(aiProvider) {
+  if (aiProvider !== 'self-hosted') {
+    return { ok: true };
+  }
+
+  const stored = await chrome.storage.local.get(['gatewayBaseUrl']);
+  const baseUrl = normalizeGatewayBaseUrl(stored?.gatewayBaseUrl);
+  if (!baseUrl) {
+    return {
+      ok: false,
+      error: 'Configure your ThinkReview Self-Hosted Gateway URL in extension settings.',
+      provider: 'self-hosted',
+      suggestion: 'Open the popup, select ThinkReview Self-Hosted Gateway, and save your gateway URL.',
+    };
+  }
+
+  return { ok: true };
+}


### PR DESCRIPTION
- Added enterprise gateway support across background routing and cloud service URL resolution, including a new `utils/enterprise-gateway.js` helper module that validates Teams eligibility, normalizes gateway URLs, and enforces readiness checks before self-hosted review traffic is sent.
- Updated `background.js` review/conversation flows to re-read latest `aiProvider`, gate self-hosted usage via `assertSelfHostedGatewayReady`, and return the effective provider (`cloud` vs `self-hosted`) in responses.
- Extended popup UI (`popup.html` + `popup.css`) with a new hidden-by-default "ThinkReview Self-Hosted Gateway" provider card and configuration panel (gateway URL, test/save actions, status messaging).
- Refactored popup provider logic (`popup.js`) to support three config panels consistently, enforce Teams-plan access for self-hosted mode, persist/reconcile provider selection in storage, request runtime host permissions for gateway origins, and add connection testing against `/health`.
- Improved subscription-aware behavior by storing subscription metadata locally and using it to dynamically show/hide the self-hosted provider option, including automatic fallback to cloud when entitlement is missing.
- Hardened content script resilience in `content-webapp-auth.js` by adding extension-context availability checks before dynamic imports and runtime messaging, preventing errors after extension reload/update and replacing raw console error logging with internal debug warnings.
- Simplified cloud service constants by removing unused fixed v1.1 URL constants and replacing them with dynamic endpoint builders that route review/conversation traffic to either ThinkReview cloud or configured self-hosted gateway.