### PR TITLE
Feature/severity review layout

### DIFF
--- a/background.js
+++ b/background.js
@@ -439,7 +439,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   
   // Handle code review request from content script to avoid CSP issues
   if (message.type === 'REVIEW_PATCH_CODE') {
-    const { patchContent, mrId, mrUrl, language, platform, forceRegenerate } = message;
+    const { patchContent, mrId, mrUrl, language, platform, forceRegenerate, reviewFormat } = message;
     
     (async () => {
       // Get AI provider setting (declare outside try block so it's accessible in catch)
@@ -530,7 +530,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         }
 
         // Use CloudService to review the patch code
-        const data = await CloudService.reviewPatchCode(patchContent, language, mrId, mrUrl, forceRegenerate, platform);
+        const data = await CloudService.reviewPatchCode(patchContent, language, mrId, mrUrl, forceRegenerate, platform, reviewFormat);
         
         // Track the review if mrId is provided
         if (mrId) {

--- a/components/integrated-review.css
+++ b/components/integrated-review.css
@@ -841,66 +841,6 @@ body[data-theme="high-contrast"] #gitlab-mr-integrated-review .thinkreview-table
   transition: color 0.2s ease;
 }
 
-/* Wrapper for bug report button + fast tooltip */
-#gitlab-mr-integrated-review .thinkreview-bug-report-btn-wrapper {
-  position: relative;
-  display: inline-flex;
-  margin-right: 0;
-}
-
-#gitlab-mr-integrated-review .thinkreview-bug-report-tooltip {
-  position: absolute;
-  top: 100%;
-  left: 50%;
-  transform: translateX(-50%) translateY(2px);
-  margin-top: 4px;
-  padding: 4px 8px;
-  background: #fff;
-  color: #333;
-  font-size: 12px;
-  white-space: nowrap;
-  border-radius: 4px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-  border: 1px solid #e1e4e8;
-  pointer-events: none;
-  opacity: 0;
-  transition: opacity 0.1s ease;
-  z-index: var(--thinkreview-z-tooltip);
-}
-
-#gitlab-mr-integrated-review .thinkreview-bug-report-tooltip.thinkreview-tooltip-visible {
-  opacity: 1;
-}
-
-#gitlab-mr-integrated-review .thinkreview-bug-report-btn {
-  background: none;
-  border: none;
-  color: white;
-  cursor: pointer;
-  padding: 6px;
-  border-radius: 4px;
-  transition: all 0.2s ease;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 14px;
-  line-height: 1;
-  opacity: 0.7;
-  width: 28px;
-  height: 28px;
-}
-
-#gitlab-mr-integrated-review .thinkreview-bug-report-btn:hover {
-  background-color: rgba(107, 79, 187, 0.2);
-  opacity: 1;
-  transform: scale(1.1);
-}
-
-#gitlab-mr-integrated-review .thinkreview-bug-report-btn:active {
-  transform: scale(0.95);
-  background-color: rgba(107, 79, 187, 0.3);
-}
-
 /* Wrapper for copy-all button + fast tooltip */
 #gitlab-mr-integrated-review .thinkreview-copy-all-btn-wrapper {
   position: relative;
@@ -4264,48 +4204,209 @@ body[data-theme="dark"] #gitlab-mr-integrated-review .thinkreview-progress-bar,
   max-width: 180px;
 }
 
+/* PR Description section */
+.thinkreview-severity-pr-section {
+  background-color: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  padding: 16px;
+  margin-bottom: 20px !important;
+}
+
+.thinkreview-severity-pr-section .thinkreview-section-title {
+  font-size: 16px;
+  margin-bottom: 12px;
+  color: #ffffff;
+}
+
 .thinkreview-severity-pr-description {
   white-space: normal;
+  line-height: 1.6;
+  color: rgba(255, 255, 255, 0.9);
 }
 
-.thinkreview-severity-issue-title {
+.thinkreview-severity-pr-description h3,
+.thinkreview-severity-pr-description h4 {
+  margin-top: 16px;
+  margin-bottom: 8px;
   font-weight: 600;
-  margin-bottom: 4px;
+  color: #ffffff;
 }
 
-.thinkreview-severity-issue-location {
-  font-size: 0.85em;
-  opacity: 0.75;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  margin-bottom: 6px;
+.thinkreview-severity-pr-description p {
+  margin-bottom: 16px;
 }
 
-.thinkreview-severity-issue-description {
-  margin-top: 2px;
+.thinkreview-severity-pr-description br {
+  display: block;
+  margin-bottom: 10px;
+  content: '';
 }
 
-.thinkreview-severity-empty {
-  opacity: 0.7;
-  font-style: italic;
-  margin: 0;
+.thinkreview-severity-pr-description ul,
+.thinkreview-severity-pr-description ol {
+  margin-left: 20px;
+  margin-bottom: 12px;
+}
+
+.thinkreview-severity-pr-description code {
+  background-color: rgba(255, 255, 255, 0.1);
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 0.9em;
+}
+
+/* Issue sections */
+.thinkreview-severity-section {
+  background-color: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  padding: 16px;
+  margin-bottom: 16px !important;
+  transition: all 0.2s ease;
+}
+
+.thinkreview-severity-section:hover {
+  background-color: rgba(255, 255, 255, 0.04);
+  border-color: rgba(255, 255, 255, 0.12);
+}
+
+.thinkreview-severity-section .thinkreview-section-title {
+  font-size: 16px;
+  margin-bottom: 12px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* Severity-specific colors with icon indicators */
+.thinkreview-severity-critical {
+  border-left: 4px solid #ef4444;
 }
 
 .thinkreview-severity-critical .thinkreview-section-title {
   color: #ef4444;
 }
 
+.thinkreview-severity-critical .thinkreview-section-title::before {
+  content: '●';
+  font-size: 20px;
+  line-height: 1;
+}
+
+.thinkreview-severity-high {
+  border-left: 4px solid #f59e0b;
+}
+
 .thinkreview-severity-high .thinkreview-section-title {
   color: #f59e0b;
+}
+
+.thinkreview-severity-high .thinkreview-section-title::before {
+  content: '●';
+  font-size: 20px;
+  line-height: 1;
+}
+
+.thinkreview-severity-low {
+  border-left: 4px solid #3b82f6;
 }
 
 .thinkreview-severity-low .thinkreview-section-title {
   color: #3b82f6;
 }
 
+.thinkreview-severity-low .thinkreview-section-title::before {
+  content: '●';
+  font-size: 20px;
+  line-height: 1;
+}
+
+/* Issue list */
+.thinkreview-severity-list {
+  list-style: none;
+  padding-left: 0 !important;
+  margin: 0;
+}
+
+.thinkreview-severity-issue-item {
+  margin-bottom: 12px;
+}
+
+.thinkreview-severity-issue-item:last-child {
+  margin-bottom: 0;
+}
+
+.thinkreview-severity-issue-wrapper {
+  background-color: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 6px;
+  padding: 12px;
+  transition: all 0.2s ease;
+}
+
 .thinkreview-severity-issue-wrapper.thinkreview-clickable-item {
   cursor: pointer;
 }
 
+.thinkreview-severity-issue-wrapper.thinkreview-clickable-item:hover {
+  background-color: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.15);
+  transform: translateX(4px);
+}
+
+.thinkreview-severity-issue-title {
+  font-weight: 600;
+  font-size: 14px;
+  margin-bottom: 6px;
+  color: #ffffff;
+  line-height: 1.4;
+}
+
+.thinkreview-severity-issue-location {
+  font-size: 12px;
+  opacity: 0.65;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  margin-bottom: 8px;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: rgba(255, 255, 255, 0.05);
+  padding: 4px 8px;
+  border-radius: 4px;
+  display: inline-block;
+}
+
+.thinkreview-severity-issue-description {
+  margin-top: 8px;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 13px;
+}
+
+.thinkreview-severity-issue-description p {
+  margin-bottom: 8px;
+}
+
+.thinkreview-severity-issue-description code {
+  background-color: rgba(255, 255, 255, 0.1);
+  padding: 2px 4px;
+  border-radius: 3px;
+  font-size: 0.9em;
+}
+
+/* Empty state */
+.thinkreview-severity-empty {
+  opacity: 0.5;
+  font-style: italic;
+  margin: 0;
+  padding: 12px;
+  text-align: center;
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.6);
+  background-color: rgba(255, 255, 255, 0.02);
+  border-radius: 4px;
+}
+
+/* Copy button */
 .thinkreview-copy-pr-desc-btn {
   margin-left: auto;
 }

--- a/components/integrated-review.css
+++ b/components/integrated-review.css
@@ -4200,9 +4200,6 @@ body[data-theme="dark"] #gitlab-mr-integrated-review .thinkreview-progress-bar,
 
 
 /* ===== Severity review layout ===== */
-.thinkreview-format-dropdown {
-  max-width: 180px;
-}
 
 /* PR Description section */
 .thinkreview-severity-pr-section {

--- a/components/integrated-review.css
+++ b/components/integrated-review.css
@@ -4009,14 +4009,33 @@ body[data-theme="dark"] #gitlab-mr-integrated-review .thinkreview-progress-bar,
   padding-top: 12px;
   border-top: 1px solid #404040;
   opacity: 1;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+#initial-review-feedback-container.thinkreview-feedback-container--split {
+  width: 100%;
+  max-width: 100%;
+  justify-content: space-between;
+}
+
+#initial-review-feedback-container .thinkreview-feedback-helpful {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+#initial-review-feedback-container.thinkreview-feedback-container--split .thinkreview-feedback-helpful {
+  margin-left: auto;
 }
 
 #initial-review-feedback-container .thinkreview-feedback-label {
   display: block;
   font-size: 11px;
   color: #999999;
-  margin-bottom: 6px;
+  margin-bottom: 0;
   font-weight: 400;
+  white-space: nowrap;
 }
 
 #initial-review-feedback-container .thinkreview-feedback-btn {
@@ -4401,6 +4420,37 @@ body[data-theme="dark"] #gitlab-mr-integrated-review .thinkreview-progress-bar,
   color: rgba(255, 255, 255, 0.6);
   background-color: rgba(255, 255, 255, 0.02);
   border-radius: 4px;
+}
+
+/* Custom Rules button — left side; helpful feedback stays on the right */
+.thinkreview-severity-custom-rules-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-right: 0;
+  padding: 5px 10px;
+  background: rgba(107, 79, 187, 0.18);
+  border: 1px solid rgba(155, 126, 240, 0.45);
+  border-radius: 16px;
+  color: #e8dffc;
+  text-decoration: none;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.thinkreview-severity-custom-rules-btn:hover {
+  background: rgba(107, 79, 187, 0.32);
+  border-color: rgba(155, 126, 240, 0.7);
+  color: #ffffff;
+}
+
+.thinkreview-severity-custom-rules-btn svg {
+  flex-shrink: 0;
+  display: block;
 }
 
 /* Copy button */

--- a/components/integrated-review.css
+++ b/components/integrated-review.css
@@ -4422,12 +4422,18 @@ body[data-theme="dark"] #gitlab-mr-integrated-review .thinkreview-progress-bar,
   border-radius: 4px;
 }
 
-/* Custom Rules button — left side; helpful feedback stays on the right */
-.thinkreview-severity-custom-rules-btn {
+/* Left action buttons — Custom Rules + Add an Agent; helpful feedback stays on the right */
+.thinkreview-severity-feedback-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.thinkreview-severity-action-btn {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  margin-right: 0;
   padding: 5px 10px;
   background: rgba(107, 79, 187, 0.18);
   border: 1px solid rgba(155, 126, 240, 0.45);
@@ -4442,13 +4448,13 @@ body[data-theme="dark"] #gitlab-mr-integrated-review .thinkreview-progress-bar,
   transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
 }
 
-.thinkreview-severity-custom-rules-btn:hover {
+.thinkreview-severity-action-btn:hover {
   background: rgba(107, 79, 187, 0.32);
   border-color: rgba(155, 126, 240, 0.7);
   color: #ffffff;
 }
 
-.thinkreview-severity-custom-rules-btn svg {
+.thinkreview-severity-action-btn svg {
   flex-shrink: 0;
   display: block;
 }

--- a/components/integrated-review.css
+++ b/components/integrated-review.css
@@ -4458,8 +4458,3 @@ body[data-theme="dark"] #gitlab-mr-integrated-review .thinkreview-progress-bar,
   flex-shrink: 0;
   display: block;
 }
-
-/* Copy button */
-.thinkreview-copy-pr-desc-btn {
-  margin-left: auto;
-}

--- a/components/integrated-review.css
+++ b/components/integrated-review.css
@@ -4258,3 +4258,54 @@ body[data-theme="dark"] #gitlab-mr-integrated-review .thinkreview-progress-bar,
   transform: translateY(0);
 }
 
+
+/* ===== Severity review layout ===== */
+.thinkreview-format-dropdown {
+  max-width: 180px;
+}
+
+.thinkreview-severity-pr-description {
+  white-space: normal;
+}
+
+.thinkreview-severity-issue-title {
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.thinkreview-severity-issue-location {
+  font-size: 0.85em;
+  opacity: 0.75;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  margin-bottom: 6px;
+}
+
+.thinkreview-severity-issue-description {
+  margin-top: 2px;
+}
+
+.thinkreview-severity-empty {
+  opacity: 0.7;
+  font-style: italic;
+  margin: 0;
+}
+
+.thinkreview-severity-critical .thinkreview-section-title {
+  color: #ef4444;
+}
+
+.thinkreview-severity-high .thinkreview-section-title {
+  color: #f59e0b;
+}
+
+.thinkreview-severity-low .thinkreview-section-title {
+  color: #3b82f6;
+}
+
+.thinkreview-severity-issue-wrapper.thinkreview-clickable-item {
+  cursor: pointer;
+}
+
+.thinkreview-copy-pr-desc-btn {
+  margin-left: auto;
+}

--- a/components/integrated-review.js
+++ b/components/integrated-review.js
@@ -459,18 +459,31 @@ async function createIntegratedReviewPanel(patchUrl) {
               <div id="suggested-questions" class="thinkreview-suggested-questions-list"></div>
             </div>
             <div id="initial-review-feedback-container" class="thinkreview-feedback-container gl-mb-4 gl-hidden">
-              <div class="thinkreview-feedback-label">Was this review helpful?</div>
-              <div class="thinkreview-feedback-buttons">
-                <button class="thinkreview-feedback-btn thinkreview-thumbs-up-btn" data-rating="thumbs_up" title="Helpful">
-                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M1 21h4V9H1v12zm22-11c0-1.1-.9-2-2-2h-6.31l.95-4.57.03-.32c0-.41-.17-.79-.44-1.06L14.17 1 7.59 7.59C7.22 7.95 7 8.45 7 9v10c0 1.1.9 2 2 2h9c.83 0 1.54-.5 1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73v-2z" fill="currentColor"/>
-                  </svg>
-                </button>
-                <button class="thinkreview-feedback-btn thinkreview-thumbs-down-btn" data-rating="thumbs_down" title="Not helpful">
-                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M15 3H6c-.83 0-1.54.5-1.84 1.22l-3.02 7.05c-.09.23-.14.47-.14.73v2c0 1.1.9 2 2 2h6.31l-.95 4.57-.03.32c0 .41.17.79.44 1.06L9.83 23l6.59-6.59c.36-.36.58-.86.58-1.41V5c0-1.1-.9-2-2-2zm4 0v12h4V3h-4z" fill="currentColor"/>
-                  </svg>
-                </button>
+              <a id="severity-custom-rules-btn"
+                 href="https://portal.thinkreview.dev/scoring-metrics"
+                 target="_blank"
+                 rel="noopener noreferrer"
+                 class="thinkreview-severity-custom-rules-btn gl-hidden"
+                 aria-label="Open Custom Rules">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path>
+                </svg>
+                <span>Custom Rules</span>
+              </a>
+              <div class="thinkreview-feedback-helpful">
+                <div class="thinkreview-feedback-label">Was this review helpful?</div>
+                <div class="thinkreview-feedback-buttons">
+                  <button class="thinkreview-feedback-btn thinkreview-thumbs-up-btn" data-rating="thumbs_up" title="Helpful">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path d="M1 21h4V9H1v12zm22-11c0-1.1-.9-2-2-2h-6.31l.95-4.57.03-.32c0-.41-.17-.79-.44-1.06L14.17 1 7.59 7.59C7.22 7.95 7 8.45 7 9v10c0 1.1.9 2 2 2h9c.83 0 1.54-.5 1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73v-2z" fill="currentColor"/>
+                    </svg>
+                  </button>
+                  <button class="thinkreview-feedback-btn thinkreview-thumbs-down-btn" data-rating="thumbs_down" title="Not helpful">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path d="M15 3H6c-.83 0-1.54.5-1.84 1.22l-3.02 7.05c-.09.23-.14.47-.14.73v2c0 1.1.9 2 2 2h6.31l-.95 4.57-.03.32c0 .41.17.79.44 1.06L9.83 23l6.59-6.59c.36-.36.58-.86.58-1.41V5c0-1.1-.9-2-2-2zm4 0v12h4V3h-4z" fill="currentColor"/>
+                    </svg>
+                  </button>
+                </div>
               </div>
             </div>
             <div id="chat-log" class="thinkreview-chat-log"></div>
@@ -2294,6 +2307,7 @@ async function displayIntegratedReview(
   // Show initial review feedback buttons
   // Use mrUrl to query the review document
   const initialFeedbackContainer = document.getElementById('initial-review-feedback-container');
+  const severityCustomRulesBtn = document.getElementById('severity-custom-rules-btn');
   if (initialFeedbackContainer) {
     // Get the full MR/PR URL
     const mrUrl = window.location.href;
@@ -2305,6 +2319,29 @@ async function displayIntegratedReview(
     } else {
       dbgWarn('Cannot get mrUrl');
       initialFeedbackContainer.classList.add('gl-hidden');
+    }
+  }
+
+  // Custom Rules sits left of "Was this review helpful?" for severity layout only
+  if (severityCustomRulesBtn) {
+    if (isSeverityFormat) {
+      severityCustomRulesBtn.classList.remove('gl-hidden');
+      initialFeedbackContainer?.classList.add('thinkreview-feedback-container--split');
+      if (!severityCustomRulesBtn.dataset.analyticsBound) {
+        severityCustomRulesBtn.dataset.analyticsBound = '1';
+        severityCustomRulesBtn.addEventListener('click', async () => {
+          try {
+            const analyticsModule = await import(chrome.runtime.getURL('utils/analytics-service.js'));
+            analyticsModule.trackUserAction('custom_rules_opened', {
+              context: 'severity_review_layout',
+              location: 'feedback_row'
+            }).catch(() => {});
+          } catch (_) { /* silent */ }
+        });
+      }
+    } else {
+      severityCustomRulesBtn.classList.add('gl-hidden');
+      initialFeedbackContainer?.classList.remove('thinkreview-feedback-container--split');
     }
   }
 

--- a/components/integrated-review.js
+++ b/components/integrated-review.js
@@ -1728,228 +1728,101 @@ async function refreshThinkReviewNewsBanner() {
   }
 }
 
-async function displayIntegratedReview(
-  review,
-  patchContent,
-  patchSize = null,
-  subscriptionType = null,
-  modelUsed = null,
-  isCached = false,
-  provider = null,
-  ollamaMeta = null,
-  openrouterMeta = null,
-  integrationOpts = null
-) {
-  // Store review data for copy-all functionality
-  currentReviewData = review;
+/**
+ * Render severity-layout review sections (PR description + issues).
+ * Hides scoring-layout containers.
+ * @param {Object} review
+ * @param {Object} containers
+ * @param {HTMLElement|null} containers.reviewMetricsContainer
+ * @param {HTMLElement|null} containers.severityContainer
+ * @param {HTMLElement|null} containers.summaryContainer
+ * @param {HTMLElement|null} containers.suggestionsContainer
+ * @param {HTMLElement|null} containers.securityContainer
+ * @param {HTMLElement|null} containers.practicesContainer
+ * @param {HTMLElement|null} containers.suggestedQuestionsOuter
+ */
+async function renderSeverityReviewSections(review, containers) {
+  const {
+    reviewMetricsContainer,
+    severityContainer,
+    summaryContainer,
+    suggestionsContainer,
+    securityContainer,
+    practicesContainer,
+    suggestedQuestionsOuter
+  } = containers;
 
-  const integratedPanelEl = document.getElementById('gitlab-mr-integrated-review');
-  if (integratedPanelEl) {
-    integratedPanelEl.thinkreviewIntegrationOpts = integrationOpts;
-  }
-
-  // Ensure copy button utils are loaded
-  if (!attachCopyButtonToItem) {
-    await initCopyButtonUtils();
-  }
-
-  // Check if there was a JSON parsing error (safety check)
-  if (review.parsingError === true) {
-    dbgWarn('JSON parsing error detected in review object');
-    const errorMessage = review.errorMessage 
-      ? `Unable to parse AI response: ${review.errorMessage}. Please try regenerating the review.`
-      : 'The AI generated a response that could not be parsed. Please try regenerating the review or report this issue at https://thinkreview.dev/bug-report';
-    await showIntegratedReviewError(errorMessage);
-    return;
-  }
-  
-  // Stop the enhanced loader
-  stopEnhancedLoader();
-
-  // Ensure the Review tab is active (panel may have been on a different tab when the loader started)
-  switchToReviewTab();
-  
-  // Hide loading indicator on button when review completes
-  try {
-    const loadingModule = await import(chrome.runtime.getURL('components/popup-modules/button-loading-indicator.js'));
-    loadingModule.hideButtonLoadingIndicator();
-  } catch (error) {
-    // Silently fail if module not available
-    dbgWarn('Failed to hide loading indicator:', error);
-  }
-
-  const reviewLoading = document.getElementById('review-loading');
-  const reviewContent = document.getElementById('review-content');
-  const reviewError = document.getElementById('review-error');
-  const tokenError = document.getElementById('review-azure-token-error');
-  const loginPrompt = document.getElementById('review-login-prompt');
-
-  if (!reviewLoading || !reviewContent || !reviewError) {
-    dbgWarn('Review panel elements not found (panel may have been closed or navigated away)');
-    showPanelRecoveryMessage();
-    return;
-  }
-
-  // Static review elements
-  const reviewSummary = document.getElementById('review-summary');
-  const reviewSuggestions = document.getElementById('review-suggestions');
-  const reviewSecurity = document.getElementById('review-security');
-  const reviewPractices = document.getElementById('review-practices');
-  const reviewMetricsContainer = document.getElementById('review-metrics-container');
-  const patchSizeBanner = document.getElementById('review-patch-size-banner');
-
-  // Hide loading indicator and other states, show the main content area
-  reviewLoading.classList.add('gl-hidden');
-  reviewError.classList.add('gl-hidden');
-  const reviewScrollMain = document.getElementById('review-scroll-main');
-  if (reviewScrollMain) reviewScrollMain.classList.remove('gl-hidden');
-  if (tokenError) tokenError.classList.add('gl-hidden');
-  if (loginPrompt) loginPrompt.classList.add('gl-hidden');
-  reviewContent.classList.remove('gl-hidden');
-
-  // Clean up any previously shown upgrade/limit message so the review UI is
-  // fully restored when the API returns a success (e.g. after daily count resets).
-  clearUpgradeMessage(reviewContent);
-
-  // Update subscription type in header (Free, Lite, Premium, Teams)
-  // Always read from storage (getUserSubscriptionDataThinkReview) - stored by background via REFRESH_USER_DATA_STORAGE / GET_USER_DATA_WITH_SUBSCRIPTION
-  const storage = await chrome.storage.local.get(['userSubscriptionData']);
-  const subscriptionTypeForDisplay = storage.userSubscriptionData?.userSubscriptionType || 'Free';
-
-  const subscriptionLabel = document.getElementById('review-subscription-label');
-  if (subscriptionLabel) {
-    const raw = (subscriptionTypeForDisplay ?? '').toString().trim().toLowerCase();
-    let displayName = 'Free';
-    if (raw && !raw.includes('free')) {
-      if (raw === 'lite') displayName = 'Lite';
-      else if (raw === 'teams') displayName = 'Teams';
-      else if (raw === 'professional') displayName = 'Professional';
+  // Hide scoring-layout sections
+  if (reviewMetricsContainer) {
+    const previousScorecard = reviewMetricsContainer.querySelector('.thinkreview-quality-scorecard');
+    if (previousScorecard && typeof previousScorecard._cleanupMetricListeners === 'function') {
+      previousScorecard._cleanupMetricListeners();
     }
-    subscriptionLabel.textContent = displayName;
-    const slug = displayName.toLowerCase();
-    subscriptionLabel.className = 'thinkreview-header-subscription thinkreview-header-subscription-' + slug;
+    reviewMetricsContainer.replaceChildren();
+    reviewMetricsContainer.classList.add('gl-hidden');
   }
+  if (summaryContainer) summaryContainer.classList.add('gl-hidden');
+  if (suggestionsContainer) suggestionsContainer.classList.add('gl-hidden');
+  if (securityContainer) securityContainer.classList.add('gl-hidden');
+  if (practicesContainer) practicesContainer.classList.add('gl-hidden');
+  if (suggestedQuestionsOuter) suggestedQuestionsOuter.classList.add('gl-hidden');
 
-  void refreshThinkReviewNewsBanner();
-
-  // Render patch size / metadata banner (Ollama-specific bar vs cloud bar)
-  if (patchSizeBanner) {
+  // Render severity layout
+  if (severityContainer) {
     try {
-      const metadataModule = await import(chrome.runtime.getURL('components/review-metadata-bar.js'));
-      const reviewRequestLabel = metadataModule.formatReviewRequestLabel(
-        integrationOpts?.platform ?? null,
-        integrationOpts?.mrId ?? null
-      );
-      if (provider === 'ollama' && ollamaMeta) {
-        metadataModule.renderOllamaMetadataBar(
-          patchSizeBanner,
-          ollamaMeta,
-          {
-            onSwitchToCloud() {
-              document.dispatchEvent(new CustomEvent('thinkreview-switch-to-cloud'));
-            },
-            getModels() {
-              return new Promise((resolve) => {
-                chrome.runtime.sendMessage({ type: 'GET_OLLAMA_MODELS' }, (response) => {
-                  if (chrome.runtime.lastError || !response) {
-                    resolve([]);
-                    return;
-                  }
-                  resolve(response.models || []);
-                });
-              });
-            },
-            onModelChange(modelName) {
-              document.dispatchEvent(new CustomEvent('thinkreview-ollama-model-changed', { detail: { model: modelName } }));
-            }
-          },
-          reviewRequestLabel
-        );
-      } else if (provider === 'openrouter' && openrouterMeta) {
-        metadataModule.renderOpenRouterMetadataBar(
-          patchSizeBanner,
-          openrouterMeta,
-          {
-            onSwitchToCloud() {
-              document.dispatchEvent(new CustomEvent('thinkreview-switch-to-cloud'));
-            }
-          },
-          reviewRequestLabel
-        );
-      } else {
-        metadataModule.renderReviewMetadataBar(
-          patchSizeBanner,
-          patchSize,
-          subscriptionTypeForDisplay,
-          modelUsed,
-          isCached,
-          reviewRequestLabel,
-          { isGateway: provider === 'self-hosted' }
-        );
-      }
+      const severityModule = await import(chrome.runtime.getURL('components/severity-review-layout.js'));
+      severityModule.renderSeverityLayout(severityContainer, review, {
+        markdownToHtml,
+        preprocessAIResponse,
+        attachCopyButtonToItem,
+        applySimpleSyntaxHighlighting,
+        onIssueClick: (plainText, severity) => {
+          const severityLabel = severity === 'critical' ? 'critical issue'
+            : severity === 'high' ? 'high issue'
+            : 'low issue';
+          const query = `Can you provide more details about this ${severityLabel}? ${plainText}`;
+          handleSendMessage(query);
+        }
+      });
     } catch (error) {
-      dbgWarn('Failed to load review metadata bar:', error);
-      patchSizeBanner.classList.add('gl-hidden');
-    }
-  }
-
-  // Determine if the patch was forcibly truncated due to free-tier limits
-  const wasForcedTruncated = !!(patchSize && patchSize.wasForcedTruncated);
-
-  const isSeverityFormat = review.reviewFormat === 'severity';
-  const severityContainer = document.getElementById('review-severity-container');
-  const summaryContainer = document.getElementById('review-summary-container');
-  const suggestionsContainer = document.getElementById('review-suggestions-container');
-  const securityContainer = document.getElementById('review-security-container');
-  const practicesContainer = document.getElementById('review-practices-container');
-  const suggestedQuestionsOuter = document.getElementById('suggested-questions-container');
-
-  if (isSeverityFormat) {
-    // Hide scoring-layout sections
-    if (reviewMetricsContainer) {
-      const previousScorecard = reviewMetricsContainer.querySelector('.thinkreview-quality-scorecard');
-      if (previousScorecard && typeof previousScorecard._cleanupMetricListeners === 'function') {
-        previousScorecard._cleanupMetricListeners();
-      }
-      reviewMetricsContainer.replaceChildren();
-      reviewMetricsContainer.classList.add('gl-hidden');
-    }
-    if (summaryContainer) summaryContainer.classList.add('gl-hidden');
-    if (suggestionsContainer) suggestionsContainer.classList.add('gl-hidden');
-    if (securityContainer) securityContainer.classList.add('gl-hidden');
-    if (practicesContainer) practicesContainer.classList.add('gl-hidden');
-    if (suggestedQuestionsOuter) suggestedQuestionsOuter.classList.add('gl-hidden');
-
-    // Render severity layout
-    if (severityContainer) {
-      try {
-        const severityModule = await import(chrome.runtime.getURL('components/severity-review-layout.js'));
-        severityModule.renderSeverityLayout(severityContainer, review, {
-          markdownToHtml,
-          preprocessAIResponse,
-          attachCopyButtonToItem,
-          applySimpleSyntaxHighlighting,
-          onIssueClick: (plainText, severity) => {
-            const severityLabel = severity === 'critical' ? 'critical issue'
-              : severity === 'high' ? 'high issue'
-              : 'low issue';
-            const query = `Can you provide more details about this ${severityLabel}? ${plainText}`;
-            handleSendMessage(query);
-          }
-        });
-      } catch (error) {
-        dbgWarn('Failed to load severity review layout:', error);
-        severityContainer.classList.add('gl-hidden');
-      }
-    }
-  } else {
-    // Scoring layout — hide severity container and show scoring sections
-    if (severityContainer) {
-      severityContainer.replaceChildren();
+      dbgWarn('Failed to load severity review layout:', error);
       severityContainer.classList.add('gl-hidden');
     }
-    if (summaryContainer) summaryContainer.classList.remove('gl-hidden');
-    // suggestions/security/practices visibility is controlled by populateList below
+  }
+}
+
+/**
+ * Render scoring-layout review sections (metrics, summary, lists, suggested questions).
+ * Hides severity-layout containers.
+ * @param {Object} review
+ * @param {Object} containers
+ * @param {HTMLElement|null} containers.reviewMetricsContainer
+ * @param {HTMLElement|null} containers.severityContainer
+ * @param {HTMLElement|null} containers.summaryContainer
+ * @param {HTMLElement|null} containers.reviewSummary
+ * @param {HTMLElement|null} containers.reviewSuggestions
+ * @param {HTMLElement|null} containers.reviewSecurity
+ * @param {HTMLElement|null} containers.reviewPractices
+ * @param {Object|null} integrationOpts
+ */
+async function renderScoringReviewLayout(review, containers, integrationOpts = null) {
+  const {
+    reviewMetricsContainer,
+    severityContainer,
+    summaryContainer,
+    reviewSummary,
+    reviewSuggestions,
+    reviewSecurity,
+    reviewPractices
+  } = containers;
+
+  // Scoring layout — hide severity container and show scoring sections
+  if (severityContainer) {
+    severityContainer.replaceChildren();
+    severityContainer.classList.add('gl-hidden');
+  }
+  if (summaryContainer) summaryContainer.classList.remove('gl-hidden');
+  // suggestions/security/practices visibility is controlled by populateList below
 
   // Render quality scorecard if metrics are available
   if (reviewMetricsContainer) {
@@ -2315,7 +2188,206 @@ async function displayIntegratedReview(
     document.getElementById('suggested-questions-container').classList.remove('gl-hidden');
   }
 
-  } // end scoring-format branch (else of isSeverityFormat)
+}
+
+async function displayIntegratedReview(
+  review,
+  patchContent,
+  patchSize = null,
+  subscriptionType = null,
+  modelUsed = null,
+  isCached = false,
+  provider = null,
+  ollamaMeta = null,
+  openrouterMeta = null,
+  integrationOpts = null
+) {
+  // Store review data for copy-all functionality
+  currentReviewData = review;
+
+  const integratedPanelEl = document.getElementById('gitlab-mr-integrated-review');
+  if (integratedPanelEl) {
+    integratedPanelEl.thinkreviewIntegrationOpts = integrationOpts;
+  }
+
+  // Ensure copy button utils are loaded
+  if (!attachCopyButtonToItem) {
+    await initCopyButtonUtils();
+  }
+
+  // Check if there was a JSON parsing error (safety check)
+  if (review.parsingError === true) {
+    dbgWarn('JSON parsing error detected in review object');
+    const errorMessage = review.errorMessage 
+      ? `Unable to parse AI response: ${review.errorMessage}. Please try regenerating the review.`
+      : 'The AI generated a response that could not be parsed. Please try regenerating the review or report this issue at https://thinkreview.dev/bug-report';
+    await showIntegratedReviewError(errorMessage);
+    return;
+  }
+  
+  // Stop the enhanced loader
+  stopEnhancedLoader();
+
+  // Ensure the Review tab is active (panel may have been on a different tab when the loader started)
+  switchToReviewTab();
+  
+  // Hide loading indicator on button when review completes
+  try {
+    const loadingModule = await import(chrome.runtime.getURL('components/popup-modules/button-loading-indicator.js'));
+    loadingModule.hideButtonLoadingIndicator();
+  } catch (error) {
+    // Silently fail if module not available
+    dbgWarn('Failed to hide loading indicator:', error);
+  }
+
+  const reviewLoading = document.getElementById('review-loading');
+  const reviewContent = document.getElementById('review-content');
+  const reviewError = document.getElementById('review-error');
+  const tokenError = document.getElementById('review-azure-token-error');
+  const loginPrompt = document.getElementById('review-login-prompt');
+
+  if (!reviewLoading || !reviewContent || !reviewError) {
+    dbgWarn('Review panel elements not found (panel may have been closed or navigated away)');
+    showPanelRecoveryMessage();
+    return;
+  }
+
+  // Static review elements
+  const reviewSummary = document.getElementById('review-summary');
+  const reviewSuggestions = document.getElementById('review-suggestions');
+  const reviewSecurity = document.getElementById('review-security');
+  const reviewPractices = document.getElementById('review-practices');
+  const reviewMetricsContainer = document.getElementById('review-metrics-container');
+  const patchSizeBanner = document.getElementById('review-patch-size-banner');
+
+  // Hide loading indicator and other states, show the main content area
+  reviewLoading.classList.add('gl-hidden');
+  reviewError.classList.add('gl-hidden');
+  const reviewScrollMain = document.getElementById('review-scroll-main');
+  if (reviewScrollMain) reviewScrollMain.classList.remove('gl-hidden');
+  if (tokenError) tokenError.classList.add('gl-hidden');
+  if (loginPrompt) loginPrompt.classList.add('gl-hidden');
+  reviewContent.classList.remove('gl-hidden');
+
+  // Clean up any previously shown upgrade/limit message so the review UI is
+  // fully restored when the API returns a success (e.g. after daily count resets).
+  clearUpgradeMessage(reviewContent);
+
+  // Update subscription type in header (Free, Lite, Premium, Teams)
+  // Always read from storage (getUserSubscriptionDataThinkReview) - stored by background via REFRESH_USER_DATA_STORAGE / GET_USER_DATA_WITH_SUBSCRIPTION
+  const storage = await chrome.storage.local.get(['userSubscriptionData']);
+  const subscriptionTypeForDisplay = storage.userSubscriptionData?.userSubscriptionType || 'Free';
+
+  const subscriptionLabel = document.getElementById('review-subscription-label');
+  if (subscriptionLabel) {
+    const raw = (subscriptionTypeForDisplay ?? '').toString().trim().toLowerCase();
+    let displayName = 'Free';
+    if (raw && !raw.includes('free')) {
+      if (raw === 'lite') displayName = 'Lite';
+      else if (raw === 'teams') displayName = 'Teams';
+      else if (raw === 'professional') displayName = 'Professional';
+    }
+    subscriptionLabel.textContent = displayName;
+    const slug = displayName.toLowerCase();
+    subscriptionLabel.className = 'thinkreview-header-subscription thinkreview-header-subscription-' + slug;
+  }
+
+  void refreshThinkReviewNewsBanner();
+
+  // Render patch size / metadata banner (Ollama-specific bar vs cloud bar)
+  if (patchSizeBanner) {
+    try {
+      const metadataModule = await import(chrome.runtime.getURL('components/review-metadata-bar.js'));
+      const reviewRequestLabel = metadataModule.formatReviewRequestLabel(
+        integrationOpts?.platform ?? null,
+        integrationOpts?.mrId ?? null
+      );
+      if (provider === 'ollama' && ollamaMeta) {
+        metadataModule.renderOllamaMetadataBar(
+          patchSizeBanner,
+          ollamaMeta,
+          {
+            onSwitchToCloud() {
+              document.dispatchEvent(new CustomEvent('thinkreview-switch-to-cloud'));
+            },
+            getModels() {
+              return new Promise((resolve) => {
+                chrome.runtime.sendMessage({ type: 'GET_OLLAMA_MODELS' }, (response) => {
+                  if (chrome.runtime.lastError || !response) {
+                    resolve([]);
+                    return;
+                  }
+                  resolve(response.models || []);
+                });
+              });
+            },
+            onModelChange(modelName) {
+              document.dispatchEvent(new CustomEvent('thinkreview-ollama-model-changed', { detail: { model: modelName } }));
+            }
+          },
+          reviewRequestLabel
+        );
+      } else if (provider === 'openrouter' && openrouterMeta) {
+        metadataModule.renderOpenRouterMetadataBar(
+          patchSizeBanner,
+          openrouterMeta,
+          {
+            onSwitchToCloud() {
+              document.dispatchEvent(new CustomEvent('thinkreview-switch-to-cloud'));
+            }
+          },
+          reviewRequestLabel
+        );
+      } else {
+        metadataModule.renderReviewMetadataBar(
+          patchSizeBanner,
+          patchSize,
+          subscriptionTypeForDisplay,
+          modelUsed,
+          isCached,
+          reviewRequestLabel,
+          { isGateway: provider === 'self-hosted' }
+        );
+      }
+    } catch (error) {
+      dbgWarn('Failed to load review metadata bar:', error);
+      patchSizeBanner.classList.add('gl-hidden');
+    }
+  }
+
+  // Determine if the patch was forcibly truncated due to free-tier limits
+  const wasForcedTruncated = !!(patchSize && patchSize.wasForcedTruncated);
+
+  const isSeverityFormat = review.reviewFormat === 'severity';
+  const severityContainer = document.getElementById('review-severity-container');
+  const summaryContainer = document.getElementById('review-summary-container');
+  const suggestionsContainer = document.getElementById('review-suggestions-container');
+  const securityContainer = document.getElementById('review-security-container');
+  const practicesContainer = document.getElementById('review-practices-container');
+  const suggestedQuestionsOuter = document.getElementById('suggested-questions-container');
+
+  if (isSeverityFormat) {
+    await renderSeverityReviewSections(review, {
+      reviewMetricsContainer,
+      severityContainer,
+      summaryContainer,
+      suggestionsContainer,
+      securityContainer,
+      practicesContainer,
+      suggestedQuestionsOuter
+    });
+  } else {
+    await renderScoringReviewLayout(review, {
+      reviewMetricsContainer,
+      severityContainer,
+      summaryContainer,
+      reviewSummary,
+      reviewSuggestions,
+      reviewSecurity,
+      reviewPractices
+    }, integrationOpts);
+  }
+
 
   // Show initial review feedback buttons
   // Use mrUrl to query the review document

--- a/components/integrated-review.js
+++ b/components/integrated-review.js
@@ -357,10 +357,6 @@ async function createIntegratedReviewPanel(patchUrl) {
             <option value="Romanian">Română</option>
             <option value="Italian">Italiano</option>
           </select>
-          <select id="review-format-selector" class="thinkreview-language-dropdown thinkreview-format-dropdown" title="Select review format">
-            <option value="scoring">scoring</option>
-            <option value="severity">severity</option>
-          </select>
           <span class="thinkreview-settings-btn-wrapper">
             <button id="thinkreview-settings-btn" class="thinkreview-settings-btn" aria-label="Open extension settings" title="Settings">
               ${settingsIconSvg}
@@ -829,8 +825,9 @@ async function createIntegratedReviewPanel(patchUrl) {
           e.target.closest('#copy-all-review-btn') ||
           e.target.id === 'language-selector' ||
           e.target.closest('#language-selector') ||
-          e.target.id === 'review-format-selector' ||
-          e.target.closest('#review-format-selector') ||
+          e.target.id === 'thinkreview-review-format-btn' ||
+          e.target.closest('#thinkreview-review-format-btn') ||
+          e.target.closest('#thinkreview-review-format-dropdown') ||
           e.target.id === 'thinkreview-layout-btn' ||
           e.target.closest('#thinkreview-layout-btn') ||
           e.target.id === 'thinkreview-ide-assist-btn' ||
@@ -890,65 +887,44 @@ async function createIntegratedReviewPanel(patchUrl) {
     });
   }
 
-  // Add event listener for the review format selector
-  const formatSelector = container.querySelector('#review-format-selector');
-  if (formatSelector) {
-    const savedFormat = await getReviewFormatPreference();
-    formatSelector.value = savedFormat;
+  // Mount visual review-format picker (scoring | severity) — cloud-only for now
+  try {
+    const providerSettings = await chrome.storage.local.get(['aiProvider']);
+    const aiProvider = providerSettings.aiProvider || 'cloud';
+    const isLocalProvider = aiProvider === 'ollama' || aiProvider === 'openrouter';
 
-    // Hide format selector for local providers (cloud-only feature for now)
-    try {
-      const providerSettings = await chrome.storage.local.get(['aiProvider']);
-      const aiProvider = providerSettings.aiProvider || 'cloud';
-      if (aiProvider === 'ollama' || aiProvider === 'openrouter') {
-        formatSelector.classList.add('gl-hidden');
-        formatSelector.disabled = true;
-      }
-    } catch (error) { /* silent */ }
+    if (!isLocalProvider) {
+      const formatWidgetUrl = chrome.runtime.getURL('components/popup-modules/review-format-preference-widget.js');
+      const { mountReviewFormatPreferenceWidget } = await import(formatWidgetUrl);
+      const headerActionsEl = container.querySelector('.thinkreview-header-actions');
+      const settingsWrapper = headerActionsEl?.querySelector('.thinkreview-settings-btn-wrapper');
 
-    const blockFormatEvent = (e) => {
-      e.stopPropagation();
-      e.stopImmediatePropagation();
-    };
-    formatSelector.addEventListener('click', blockFormatEvent, true);
-    formatSelector.addEventListener('mousedown', blockFormatEvent, true);
-    formatSelector.addEventListener('mouseup', blockFormatEvent, true);
-    formatSelector.addEventListener('pointerdown', blockFormatEvent, true);
-    formatSelector.addEventListener('pointerup', blockFormatEvent, true);
-    formatSelector.addEventListener('touchstart', blockFormatEvent, true);
-    formatSelector.addEventListener('touchend', blockFormatEvent, true);
+      await mountReviewFormatPreferenceWidget(headerActionsEl, {
+        insertBeforeEl: settingsWrapper || null,
+        onFormatChange: async (selectedFormat) => {
+          dbgLog('Review format preference updated to:', selectedFormat);
 
-    formatSelector.addEventListener('change', async (e) => {
-      e.stopPropagation();
-      const selectedFormat = e.target.value === 'severity' ? 'severity' : 'scoring';
-      setReviewFormatPreference(selectedFormat);
-      dbgLog('Review format preference updated to:', selectedFormat);
+          // Fetch review for the new format (cache is segmented server-side by format)
+          const reviewLoading = document.getElementById('review-loading');
+          const reviewContent = document.getElementById('review-content');
+          const reviewError = document.getElementById('review-error');
+          currentReviewData = null;
+          if (reviewLoading) reviewLoading.classList.remove('gl-hidden');
+          if (reviewContent) reviewContent.classList.add('gl-hidden');
+          if (reviewError) reviewError.classList.add('gl-hidden');
+          startEnhancedLoader();
 
-      try {
-        const analyticsModule = await import(chrome.runtime.getURL('utils/analytics-service.js'));
-        analyticsModule.trackUserAction('review_format_changed', {
-          context: 'integrated_review_panel',
-          reviewFormat: selectedFormat
-        }).catch(() => {});
-      } catch (error) { /* silent */ }
-
-      // Fetch review for the new format (cache is segmented server-side by format)
-      const reviewLoading = document.getElementById('review-loading');
-      const reviewContent = document.getElementById('review-content');
-      const reviewError = document.getElementById('review-error');
-      currentReviewData = null;
-      if (reviewLoading) reviewLoading.classList.remove('gl-hidden');
-      if (reviewContent) reviewContent.classList.add('gl-hidden');
-      if (reviewError) reviewError.classList.add('gl-hidden');
-      startEnhancedLoader();
-
-      if (typeof fetchAndDisplayCodeReview === 'function') {
-        // forceRegenerate=false so a previously cached review for this format can be reused
-        await fetchAndDisplayCodeReview(false);
-      } else {
-        console.error('fetchAndDisplayCodeReview function not found');
-      }
-    });
+          if (typeof fetchAndDisplayCodeReview === 'function') {
+            // forceRegenerate=false so a previously cached review for this format can be reused
+            await fetchAndDisplayCodeReview(false);
+          } else {
+            console.error('fetchAndDisplayCodeReview function not found');
+          }
+        }
+      });
+    }
+  } catch (error) {
+    dbgWarn('Failed to mount review format preference widget:', error);
   }
 
   getOllamaBrowserExtensionCorsMessageModule().catch(() => {});
@@ -2696,20 +2672,3 @@ function setLanguagePreference(language) {
   chrome.storage.local.set({ 'code-review-language': language });
 }
 
-/**
- * Get the user's review format preference from extension storage
- * @returns {Promise<string>} - 'scoring' (default) or 'severity'
- */
-async function getReviewFormatPreference() {
-  const result = await chrome.storage.local.get(['code-review-format']);
-  return result['code-review-format'] === 'severity' ? 'severity' : 'scoring';
-}
-
-/**
- * Set the user's review format preference in extension storage
- * @param {string} format - 'scoring' or 'severity'
- */
-function setReviewFormatPreference(format) {
-  const normalized = format === 'severity' ? 'severity' : 'scoring';
-  chrome.storage.local.set({ 'code-review-format': normalized });
-}

--- a/components/integrated-review.js
+++ b/components/integrated-review.js
@@ -353,20 +353,14 @@ async function createIntegratedReviewPanel(patchUrl) {
             <option value="Czech">Čeština</option>
             <option value="Dutch">Dutch</option>
             <option value="Vietnamese">Tiếng Việt</option>
-            <option value="Indonesian">Bahasa Indonesia</option>
+            <option value="Indonesian">Indonesia</option>
             <option value="Romanian">Română</option>
             <option value="Italian">Italiano</option>
           </select>
           <select id="review-format-selector" class="thinkreview-language-dropdown thinkreview-format-dropdown" title="Select review format">
-            <option value="scoring">Scoring</option>
-            <option value="severity">PR Description &amp; Issues</option>
+            <option value="scoring">scoring</option>
+            <option value="severity">severity</option>
           </select>
-          <span class="thinkreview-bug-report-btn-wrapper">
-            <button id="bug-report-btn" class="thinkreview-bug-report-btn" aria-label="Report a Bug">
-              🐞
-            </button>
-            <span class="thinkreview-bug-report-tooltip" aria-hidden="true">Report a Bug</span>
-          </span>
           <span class="thinkreview-settings-btn-wrapper">
             <button id="thinkreview-settings-btn" class="thinkreview-settings-btn" aria-label="Open extension settings" title="Settings">
               ${settingsIconSvg}
@@ -765,36 +759,6 @@ async function createIntegratedReviewPanel(patchUrl) {
     });
   }
 
-  // Add event listener for the bug report button first
-  const bugReportButton = document.getElementById('bug-report-btn');
-  if (bugReportButton) {
-    const bugWrapper = container.querySelector('.thinkreview-bug-report-btn-wrapper');
-    const bugTooltipEl = bugWrapper?.querySelector('.thinkreview-bug-report-tooltip');
-    if (bugWrapper && bugTooltipEl) {
-      let bugTooltipTimeout;
-      bugWrapper.addEventListener('mouseenter', () => {
-        bugTooltipTimeout = setTimeout(() => bugTooltipEl.classList.add('thinkreview-tooltip-visible'), 200);
-      });
-      bugWrapper.addEventListener('mouseleave', () => {
-        clearTimeout(bugTooltipTimeout);
-        bugTooltipEl.classList.remove('thinkreview-tooltip-visible');
-      });
-    }
-    bugReportButton.addEventListener('click', async (e) => {
-      e.stopPropagation(); // Prevent triggering the header click event
-      dbgLog('Bug report button clicked');
-      // Track bug report button click
-      try {
-        const analyticsModule = await import(chrome.runtime.getURL('utils/analytics-service.js'));
-        analyticsModule.trackUserAction('bug_report_clicked', {
-          context: 'integrated_review_panel',
-          location: 'header'
-        }).catch(() => {});
-      } catch (error) { /* silent */ }
-      window.open('https://thinkreview.dev/bug-report', '_blank');
-    });
-  }
-  
   // Fast tooltip for regenerate button (short delay vs native title)
   const regenerateWrapper = container.querySelector('.thinkreview-regenerate-btn-wrapper');
   if (regenerateWrapper) {
@@ -854,14 +818,12 @@ async function createIntegratedReviewPanel(patchUrl) {
   }
 
   // Block events from header-actions to prevent panel minimization
-  // But allow clicks on the bug report button, regenerate button, and language selector to pass through
+  // But allow clicks on the regenerate button and language selector to pass through
   const headerActions = container.querySelector('.thinkreview-header-actions');
   if (headerActions) {
     const blockEvent = (e) => {
-      // Allow clicks on bug report button, regenerate button, copy-all button, language selector, and layout button
-      if (e.target.id === 'bug-report-btn' ||
-          e.target.closest('#bug-report-btn') ||
-          e.target.id === 'regenerate-review-btn' ||
+      // Allow clicks on regenerate button, copy-all button, language selector, and layout button
+      if (e.target.id === 'regenerate-review-btn' ||
           e.target.closest('#regenerate-review-btn') ||
           e.target.id === 'copy-all-review-btn' ||
           e.target.closest('#copy-all-review-btn') ||

--- a/components/integrated-review.js
+++ b/components/integrated-review.js
@@ -459,17 +459,30 @@ async function createIntegratedReviewPanel(patchUrl) {
               <div id="suggested-questions" class="thinkreview-suggested-questions-list"></div>
             </div>
             <div id="initial-review-feedback-container" class="thinkreview-feedback-container gl-mb-4 gl-hidden">
-              <a id="severity-custom-rules-btn"
-                 href="https://portal.thinkreview.dev/scoring-metrics"
-                 target="_blank"
-                 rel="noopener noreferrer"
-                 class="thinkreview-severity-custom-rules-btn gl-hidden"
-                 aria-label="Open Custom Rules">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                  <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path>
-                </svg>
-                <span>Custom Rules</span>
-              </a>
+              <div id="severity-feedback-actions" class="thinkreview-severity-feedback-actions gl-hidden">
+                <a id="severity-custom-rules-btn"
+                   href="https://portal.thinkreview.dev/scoring-metrics"
+                   target="_blank"
+                   rel="noopener noreferrer"
+                   class="thinkreview-severity-action-btn"
+                   aria-label="Open Custom Rules">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path>
+                  </svg>
+                  <span>Custom Rules</span>
+                </a>
+                <a id="severity-add-agent-btn"
+                   href="https://portal.thinkreview.dev/agents"
+                   target="_blank"
+                   rel="noopener noreferrer"
+                   class="thinkreview-severity-action-btn"
+                   aria-label="Add an Agent">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                    <path d="M8.4 18.2c.38.5.6 1.12.6 1.8 0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3c.44 0 .85.09 1.23.26l1.41-1.77c-.92-1.03-1.29-2.39-1.09-3.69l-2.03-.68c-.54.83-1.46 1.38-2.52 1.38-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3c0 .07 0 .14-.01.21l2.03.68c.64-1.21 1.82-2.09 3.22-2.32V5.91C9.96 5.57 9 4.4 9 3c0-1.66 1.34-3 3-3s3 1.34 3 3c0 1.4-.96 2.57-2.25 2.91v2.16c1.4.23 2.58 1.11 3.22 2.32L18 9.71V9.5c0-1.66 1.34-3 3-3s3 1.34 3 3-1.34 3-3 3c-1.06 0-1.98-.55-2.52-1.37l-2.03.68c.2 1.29-.16 2.65-1.09 3.69l1.41 1.77Q17.34 17 18 17c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3c0-.68.22-1.3.6-1.8l-1.41-1.77c-1.35.75-3.01.76-4.37 0z"/>
+                  </svg>
+                  <span>Add an Agent</span>
+                </a>
+              </div>
               <div class="thinkreview-feedback-helpful">
                 <div class="thinkreview-feedback-label">Was this review helpful?</div>
                 <div class="thinkreview-feedback-buttons">
@@ -2307,7 +2320,6 @@ async function displayIntegratedReview(
   // Show initial review feedback buttons
   // Use mrUrl to query the review document
   const initialFeedbackContainer = document.getElementById('initial-review-feedback-container');
-  const severityCustomRulesBtn = document.getElementById('severity-custom-rules-btn');
   if (initialFeedbackContainer) {
     // Get the full MR/PR URL
     const mrUrl = window.location.href;
@@ -2322,26 +2334,38 @@ async function displayIntegratedReview(
     }
   }
 
-  // Custom Rules sits left of "Was this review helpful?" for severity layout only
-  if (severityCustomRulesBtn) {
-    if (isSeverityFormat) {
-      severityCustomRulesBtn.classList.remove('gl-hidden');
-      initialFeedbackContainer?.classList.add('thinkreview-feedback-container--split');
-      if (!severityCustomRulesBtn.dataset.analyticsBound) {
-        severityCustomRulesBtn.dataset.analyticsBound = '1';
-        severityCustomRulesBtn.addEventListener('click', async () => {
-          try {
-            const analyticsModule = await import(chrome.runtime.getURL('utils/analytics-service.js'));
-            analyticsModule.trackUserAction('custom_rules_opened', {
-              context: 'severity_review_layout',
-              location: 'feedback_row'
-            }).catch(() => {});
-          } catch (_) { /* silent */ }
-        });
-      }
-    } else {
-      severityCustomRulesBtn.classList.add('gl-hidden');
-      initialFeedbackContainer?.classList.remove('thinkreview-feedback-container--split');
+  // Left actions (Custom Rules + Add an Agent) for both scoring and severity layouts
+  const severityFeedbackActions = document.getElementById('severity-feedback-actions');
+  const severityCustomRulesBtn = document.getElementById('severity-custom-rules-btn');
+  const severityAddAgentBtn = document.getElementById('severity-add-agent-btn');
+  if (severityFeedbackActions) {
+    severityFeedbackActions.classList.remove('gl-hidden');
+    initialFeedbackContainer?.classList.add('thinkreview-feedback-container--split');
+
+    if (severityCustomRulesBtn && !severityCustomRulesBtn.dataset.analyticsBound) {
+      severityCustomRulesBtn.dataset.analyticsBound = '1';
+      severityCustomRulesBtn.addEventListener('click', async () => {
+        try {
+          const analyticsModule = await import(chrome.runtime.getURL('utils/analytics-service.js'));
+          analyticsModule.trackUserAction('custom_rules_opened', {
+            context: isSeverityFormat ? 'severity_review_layout' : 'scoring_review_layout',
+            location: 'feedback_row'
+          }).catch(() => {});
+        } catch (_) { /* silent */ }
+      });
+    }
+
+    if (severityAddAgentBtn && !severityAddAgentBtn.dataset.analyticsBound) {
+      severityAddAgentBtn.dataset.analyticsBound = '1';
+      severityAddAgentBtn.addEventListener('click', async () => {
+        try {
+          const analyticsModule = await import(chrome.runtime.getURL('utils/analytics-service.js'));
+          analyticsModule.trackUserAction('add_agent_opened', {
+            context: isSeverityFormat ? 'severity_review_layout' : 'scoring_review_layout',
+            location: 'feedback_row'
+          }).catch(() => {});
+        } catch (_) { /* silent */ }
+      });
     }
   }
 

--- a/components/integrated-review.js
+++ b/components/integrated-review.js
@@ -357,6 +357,10 @@ async function createIntegratedReviewPanel(patchUrl) {
             <option value="Romanian">Română</option>
             <option value="Italian">Italiano</option>
           </select>
+          <select id="review-format-selector" class="thinkreview-language-dropdown thinkreview-format-dropdown" title="Select review format">
+            <option value="scoring">Scoring</option>
+            <option value="severity">PR Description &amp; Issues</option>
+          </select>
           <span class="thinkreview-bug-report-btn-wrapper">
             <button id="bug-report-btn" class="thinkreview-bug-report-btn" aria-label="Report a Bug">
               🐞
@@ -438,6 +442,7 @@ async function createIntegratedReviewPanel(patchUrl) {
             <div id="review-news-banner" class="thinkreview-news-banner gl-hidden gl-mb-4" role="region" aria-label="ThinkReview announcement"></div>
             <div id="review-patch-size-banner" class="gl-mb-4 gl-hidden"></div>
             <div id="review-metrics-container" class="gl-mb-4"></div>
+            <div id="review-severity-container" class="gl-mb-4 gl-hidden"></div>
             <div id="review-summary-container" class="gl-mb-4">
               <div class="thinkreview-section-header-row">
                 <h5 class="gl-font-weight-bold thinkreview-section-title">Summary</h5>
@@ -862,6 +867,8 @@ async function createIntegratedReviewPanel(patchUrl) {
           e.target.closest('#copy-all-review-btn') ||
           e.target.id === 'language-selector' ||
           e.target.closest('#language-selector') ||
+          e.target.id === 'review-format-selector' ||
+          e.target.closest('#review-format-selector') ||
           e.target.id === 'thinkreview-layout-btn' ||
           e.target.closest('#thinkreview-layout-btn') ||
           e.target.id === 'thinkreview-ide-assist-btn' ||
@@ -918,6 +925,67 @@ async function createIntegratedReviewPanel(patchUrl) {
       
       setLanguagePreference(selectedLanguage);
       dbgLog('Language preference updated to:', selectedLanguage);
+    });
+  }
+
+  // Add event listener for the review format selector
+  const formatSelector = container.querySelector('#review-format-selector');
+  if (formatSelector) {
+    const savedFormat = await getReviewFormatPreference();
+    formatSelector.value = savedFormat;
+
+    // Hide format selector for local providers (cloud-only feature for now)
+    try {
+      const providerSettings = await chrome.storage.local.get(['aiProvider']);
+      const aiProvider = providerSettings.aiProvider || 'cloud';
+      if (aiProvider === 'ollama' || aiProvider === 'openrouter') {
+        formatSelector.classList.add('gl-hidden');
+        formatSelector.disabled = true;
+      }
+    } catch (error) { /* silent */ }
+
+    const blockFormatEvent = (e) => {
+      e.stopPropagation();
+      e.stopImmediatePropagation();
+    };
+    formatSelector.addEventListener('click', blockFormatEvent, true);
+    formatSelector.addEventListener('mousedown', blockFormatEvent, true);
+    formatSelector.addEventListener('mouseup', blockFormatEvent, true);
+    formatSelector.addEventListener('pointerdown', blockFormatEvent, true);
+    formatSelector.addEventListener('pointerup', blockFormatEvent, true);
+    formatSelector.addEventListener('touchstart', blockFormatEvent, true);
+    formatSelector.addEventListener('touchend', blockFormatEvent, true);
+
+    formatSelector.addEventListener('change', async (e) => {
+      e.stopPropagation();
+      const selectedFormat = e.target.value === 'severity' ? 'severity' : 'scoring';
+      setReviewFormatPreference(selectedFormat);
+      dbgLog('Review format preference updated to:', selectedFormat);
+
+      try {
+        const analyticsModule = await import(chrome.runtime.getURL('utils/analytics-service.js'));
+        analyticsModule.trackUserAction('review_format_changed', {
+          context: 'integrated_review_panel',
+          reviewFormat: selectedFormat
+        }).catch(() => {});
+      } catch (error) { /* silent */ }
+
+      // Fetch review for the new format (cache is segmented server-side by format)
+      const reviewLoading = document.getElementById('review-loading');
+      const reviewContent = document.getElementById('review-content');
+      const reviewError = document.getElementById('review-error');
+      currentReviewData = null;
+      if (reviewLoading) reviewLoading.classList.remove('gl-hidden');
+      if (reviewContent) reviewContent.classList.add('gl-hidden');
+      if (reviewError) reviewError.classList.add('gl-hidden');
+      startEnhancedLoader();
+
+      if (typeof fetchAndDisplayCodeReview === 'function') {
+        // forceRegenerate=false so a previously cached review for this format can be reused
+        await fetchAndDisplayCodeReview(false);
+      } else {
+        console.error('fetchAndDisplayCodeReview function not found');
+      }
     });
   }
 
@@ -1864,6 +1932,61 @@ async function displayIntegratedReview(
   // Determine if the patch was forcibly truncated due to free-tier limits
   const wasForcedTruncated = !!(patchSize && patchSize.wasForcedTruncated);
 
+  const isSeverityFormat = review.reviewFormat === 'severity';
+  const severityContainer = document.getElementById('review-severity-container');
+  const summaryContainer = document.getElementById('review-summary-container');
+  const suggestionsContainer = document.getElementById('review-suggestions-container');
+  const securityContainer = document.getElementById('review-security-container');
+  const practicesContainer = document.getElementById('review-practices-container');
+  const suggestedQuestionsOuter = document.getElementById('suggested-questions-container');
+
+  if (isSeverityFormat) {
+    // Hide scoring-layout sections
+    if (reviewMetricsContainer) {
+      const previousScorecard = reviewMetricsContainer.querySelector('.thinkreview-quality-scorecard');
+      if (previousScorecard && typeof previousScorecard._cleanupMetricListeners === 'function') {
+        previousScorecard._cleanupMetricListeners();
+      }
+      reviewMetricsContainer.replaceChildren();
+      reviewMetricsContainer.classList.add('gl-hidden');
+    }
+    if (summaryContainer) summaryContainer.classList.add('gl-hidden');
+    if (suggestionsContainer) suggestionsContainer.classList.add('gl-hidden');
+    if (securityContainer) securityContainer.classList.add('gl-hidden');
+    if (practicesContainer) practicesContainer.classList.add('gl-hidden');
+    if (suggestedQuestionsOuter) suggestedQuestionsOuter.classList.add('gl-hidden');
+
+    // Render severity layout
+    if (severityContainer) {
+      try {
+        const severityModule = await import(chrome.runtime.getURL('components/severity-review-layout.js'));
+        severityModule.renderSeverityLayout(severityContainer, review, {
+          markdownToHtml,
+          preprocessAIResponse,
+          attachCopyButtonToItem,
+          applySimpleSyntaxHighlighting,
+          onIssueClick: (plainText, severity) => {
+            const severityLabel = severity === 'critical' ? 'critical issue'
+              : severity === 'high' ? 'high issue'
+              : 'low issue';
+            const query = `Can you provide more details about this ${severityLabel}? ${plainText}`;
+            handleSendMessage(query);
+          }
+        });
+      } catch (error) {
+        dbgWarn('Failed to load severity review layout:', error);
+        severityContainer.classList.add('gl-hidden');
+      }
+    }
+  } else {
+    // Scoring layout — hide severity container and show scoring sections
+    if (severityContainer) {
+      severityContainer.replaceChildren();
+      severityContainer.classList.add('gl-hidden');
+    }
+    if (summaryContainer) summaryContainer.classList.remove('gl-hidden');
+    // suggestions/security/practices visibility is controlled by populateList below
+
   // Render quality scorecard if metrics are available
   if (reviewMetricsContainer) {
     // Clean up previous scorecard event listeners before clearing
@@ -2228,6 +2351,8 @@ async function displayIntegratedReview(
     document.getElementById('suggested-questions-container').classList.remove('gl-hidden');
   }
 
+  } // end scoring-format branch (else of isSeverityFormat)
+
   // Show initial review feedback buttons
   // Use mrUrl to query the review document
   const initialFeedbackContainer = document.getElementById('initial-review-feedback-container');
@@ -2247,7 +2372,9 @@ async function displayIntegratedReview(
 
   // Store patch content and initialize conversation history
   currentPatchContent = patchContent;
-  const initialPrompt = `This is an AI code review. The summary is: "${review.summary}". I can answer questions about the suggestions, security issues, and best practices mentioned in the review. What would you like to know?`;
+  const initialPrompt = isSeverityFormat
+    ? `This is an AI code review (severity layout). The PR description is: "${(review.prDescription || '').slice(0, 500)}". I can answer questions about the critical, high, and low issues mentioned in the review. What would you like to know?`
+    : `This is an AI code review. The summary is: "${review.summary}". I can answer questions about the suggestions, security issues, and best practices mentioned in the review. What would you like to know?`;
   
   // Initialize conversation history without the patch content
   // The patch is sent separately as patchContent, so we don't need it in the conversation history
@@ -2605,4 +2732,22 @@ async function getLanguagePreference() {
  */
 function setLanguagePreference(language) {
   chrome.storage.local.set({ 'code-review-language': language });
+}
+
+/**
+ * Get the user's review format preference from extension storage
+ * @returns {Promise<string>} - 'scoring' (default) or 'severity'
+ */
+async function getReviewFormatPreference() {
+  const result = await chrome.storage.local.get(['code-review-format']);
+  return result['code-review-format'] === 'severity' ? 'severity' : 'scoring';
+}
+
+/**
+ * Set the user's review format preference in extension storage
+ * @param {string} format - 'scoring' or 'severity'
+ */
+function setReviewFormatPreference(format) {
+  const normalized = format === 'severity' ? 'severity' : 'scoring';
+  chrome.storage.local.set({ 'code-review-format': normalized });
 }

--- a/components/popup-modules/ide-assist-preference-widget.css
+++ b/components/popup-modules/ide-assist-preference-widget.css
@@ -141,3 +141,8 @@
   font-size: 12px;
   opacity: 0.9;
 }
+
+.thinkreview-ide-assist-item--link .thinkreview-ide-assist-item-check {
+  opacity: 0.55;
+  font-size: 11px;
+}

--- a/components/popup-modules/ide-assist-preference-widget.js
+++ b/components/popup-modules/ide-assist-preference-widget.js
@@ -44,11 +44,50 @@ function createNoneIdeIconSvg() {
   return svg;
 }
 
+/** MCP connector glyph (matches popup MCP button). */
+function createMcpIconSvg() {
+  const NS = 'http://www.w3.org/2000/svg';
+  const svg = document.createElementNS(NS, 'svg');
+  svg.setAttribute('width', '14');
+  svg.setAttribute('height', '14');
+  svg.setAttribute('viewBox', '0 0 24 24');
+  svg.setAttribute('fill', 'none');
+  svg.setAttribute('stroke', 'currentColor');
+  svg.setAttribute('stroke-width', '2');
+  svg.setAttribute('stroke-linecap', 'round');
+  svg.setAttribute('stroke-linejoin', 'round');
+  const paths = [
+    'M12 2v6',
+    'M12 16v6',
+    'M2 12h6',
+    'M16 12h6',
+    'm8 6 4-4 4 4',
+    'm8 18 4 4 4-4',
+    'm6 8-4 4 4 4',
+    'm18 8 4 4-4 4'
+  ];
+  for (const d of paths) {
+    const path = document.createElementNS(NS, 'path');
+    path.setAttribute('d', d);
+    svg.appendChild(path);
+  }
+  return svg;
+}
+
+const MCP_SETUP_URL = 'https://portal.thinkreview.dev/mcp';
+
 const ROWS = [
   { id: 'cursor', label: 'Cursor', icon: createCursorProductIconSvg },
   { id: 'github_copilot', label: 'GitHub Copilot via VS Code', icon: createGitHubCopilotIconSvg },
   { id: 'claude_code', label: 'Claude Code via VS Code', icon: createClaudeCodeIconSvg },
-  { id: 'none', label: 'None (hide Implement buttons)', icon: createNoneIdeIconSvg }
+  {
+    id: 'mcp',
+    label: 'MCP',
+    icon: createMcpIconSvg,
+    href: MCP_SETUP_URL,
+    dividerBefore: true
+  },
+  { id: 'none', label: 'None (hide Implement buttons)', icon: createNoneIdeIconSvg, dividerBefore: true }
 ];
 
 function _positionDropdown(dropdown, btn) {
@@ -64,7 +103,7 @@ function _positionDropdown(dropdown, btn) {
 }
 
 function _setTriggerIcon(btn, targetId) {
-  const row = ROWS.find((r) => r.id === targetId) || ROWS[0];
+  const row = ROWS.find((r) => r.id === targetId && !r.href) || ROWS[0];
   btn.replaceChildren();
   const icon = row.icon();
   icon.setAttribute('aria-hidden', 'true');
@@ -94,6 +133,13 @@ async function _trackIdeAssistMenu(eventName, params = {}) {
 
 function _refreshDropdownActive(dropdown, activeId) {
   dropdown.querySelectorAll('.thinkreview-ide-assist-item').forEach((el) => {
+    // Link rows (e.g. MCP setup) are never the active implement target
+    if (el.dataset.href) {
+      el.classList.remove('active');
+      const check = el.querySelector('.thinkreview-ide-assist-item-check');
+      if (check) check.textContent = '↗';
+      return;
+    }
     const id = el.dataset.ide;
     const on = id === activeId;
     el.classList.toggle('active', on);
@@ -151,7 +197,7 @@ export async function mountIdeAssistPreferenceWidget(headerActionsEl) {
   dropdown.appendChild(label);
 
   for (const row of ROWS) {
-    if (row.id === 'none') {
+    if (row.dividerBefore) {
       const divider = document.createElement('div');
       divider.className = 'thinkreview-ide-assist-divider';
       divider.setAttribute('role', 'separator');
@@ -162,6 +208,10 @@ export async function mountIdeAssistPreferenceWidget(headerActionsEl) {
     item.className = 'thinkreview-ide-assist-item';
     item.dataset.ide = row.id;
     item.setAttribute('role', 'menuitem');
+    if (row.href) {
+      item.dataset.href = row.href;
+      item.classList.add('thinkreview-ide-assist-item--link');
+    }
 
     const iconWrap = document.createElement('span');
     iconWrap.className = 'thinkreview-ide-assist-item-icon';
@@ -176,6 +226,10 @@ export async function mountIdeAssistPreferenceWidget(headerActionsEl) {
     const check = document.createElement('span');
     check.className = 'thinkreview-ide-assist-item-check';
     check.setAttribute('aria-hidden', 'true');
+    if (row.href) {
+      check.textContent = '↗';
+      check.setAttribute('aria-label', 'Opens in new tab');
+    }
 
     item.appendChild(iconWrap);
     item.appendChild(lab);
@@ -216,6 +270,15 @@ export async function mountIdeAssistPreferenceWidget(headerActionsEl) {
     if (!item) return;
     const id = item.dataset.ide;
     if (!id) return;
+
+    // Link rows open an external page (MCP setup) instead of changing the implement target
+    if (item.dataset.href) {
+      await _trackIdeAssistMenu(`ide_assist_menu_${id}_opened`, { ide: id, url: item.dataset.href });
+      dropdown.style.display = 'none';
+      btn.setAttribute('aria-expanded', 'false');
+      window.open(item.dataset.href, '_blank', 'noopener,noreferrer');
+      return;
+    }
 
     const previousIde = await getIdeAssistTarget();
     await setIdeAssistTarget(id);

--- a/components/popup-modules/review-format-preference-widget.css
+++ b/components/popup-modules/review-format-preference-widget.css
@@ -1,0 +1,178 @@
+/* Review format picker — header button + body-appended dropdown (matches IDE assist theme) */
+
+.thinkreview-review-format-btn-wrapper {
+  position: relative;
+  display: inline-flex;
+}
+
+.thinkreview-review-format-btn {
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  color: white;
+  border-radius: 4px;
+  cursor: pointer;
+  padding: 4px 7px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  line-height: 1;
+  transition: background 0.15s ease;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.thinkreview-review-format-btn:hover {
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.thinkreview-review-format-btn svg {
+  display: block;
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+.thinkreview-review-format-btn-label {
+  max-width: 72px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.thinkreview-review-format-tooltip {
+  position: absolute;
+  top: 100%;
+  left: auto;
+  right: 0;
+  transform: translateY(2px);
+  margin-top: 4px;
+  padding: 4px 8px;
+  background: #fff;
+  color: #333;
+  font-size: 12px;
+  white-space: nowrap;
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  border: 1px solid #e1e4e8;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.1s ease, transform 0.1s ease;
+  z-index: var(--thinkreview-z-tooltip, 10050);
+}
+
+.thinkreview-review-format-btn-wrapper:hover .thinkreview-review-format-tooltip {
+  opacity: 1;
+  transform: translateY(-2px);
+}
+
+#thinkreview-review-format-dropdown {
+  position: fixed;
+  z-index: 2147483647;
+  background: #1a1628;
+  border: 1px solid #3d2d6e;
+  border-radius: 10px;
+  padding: 6px 0;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.6), 0 2px 8px rgba(0, 0, 0, 0.3);
+  color: white;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-size: 13px;
+  animation: thinkreview-review-format-dropdown-in 0.12s ease;
+}
+
+@keyframes thinkreview-review-format-dropdown-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.thinkreview-review-format-section-label {
+  font-size: 10px;
+  font-weight: 700;
+  color: rgba(155, 126, 240, 0.75);
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  padding: 6px 14px 3px;
+}
+
+.thinkreview-review-format-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 9px 14px;
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.82);
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.12s ease;
+}
+
+.thinkreview-review-format-item:hover {
+  background: rgba(107, 79, 187, 0.22);
+  color: white;
+}
+
+.thinkreview-review-format-item.active {
+  color: #c9b4ff;
+  background: rgba(107, 79, 187, 0.15);
+}
+
+.thinkreview-review-format-item-icon {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.thinkreview-review-format-item[data-format="scoring"] .thinkreview-review-format-item-icon {
+  color: #a78bfa;
+}
+
+.thinkreview-review-format-item[data-format="severity"] .thinkreview-review-format-item-icon {
+  color: #f59e0b;
+}
+
+.thinkreview-review-format-item-icon svg {
+  width: 16px;
+  height: 16px;
+  display: block;
+}
+
+.thinkreview-review-format-item-text {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.thinkreview-review-format-item-label {
+  font-weight: 600;
+  font-size: 13px;
+  line-height: 1.2;
+}
+
+.thinkreview-review-format-item-desc {
+  font-size: 11px;
+  opacity: 0.65;
+  line-height: 1.3;
+}
+
+.thinkreview-review-format-item-check {
+  flex-shrink: 0;
+  font-size: 12px;
+  opacity: 0.9;
+  min-width: 12px;
+}

--- a/components/popup-modules/review-format-preference-widget.js
+++ b/components/popup-modules/review-format-preference-widget.js
@@ -1,0 +1,296 @@
+/**
+ * Header control: pick scoring vs severity review layout.
+ * Visual dropdown matches the Implement via / IDE assist picker.
+ */
+
+import { dbgWarn } from '../../utils/logger.js';
+
+const _cssURL = chrome.runtime.getURL('components/popup-modules/review-format-preference-widget.css');
+if (!document.querySelector(`link[href="${_cssURL}"]`)) {
+  const _link = document.createElement('link');
+  _link.rel = 'stylesheet';
+  _link.href = _cssURL;
+  document.head.appendChild(_link);
+}
+
+/** Scorecard / gauge icon for scoring format */
+function createScoringIconSvg() {
+  const NS = 'http://www.w3.org/2000/svg';
+  const svg = document.createElementNS(NS, 'svg');
+  svg.setAttribute('width', '16');
+  svg.setAttribute('height', '16');
+  svg.setAttribute('viewBox', '0 0 24 24');
+  svg.setAttribute('fill', 'none');
+  const path = document.createElementNS(NS, 'path');
+  path.setAttribute(
+    'd',
+    'M4 19V5M4 19h16M8 15V9m4 6V7m4 8v-3'
+  );
+  path.setAttribute('stroke', 'currentColor');
+  path.setAttribute('stroke-width', '2');
+  path.setAttribute('stroke-linecap', 'round');
+  path.setAttribute('stroke-linejoin', 'round');
+  svg.appendChild(path);
+  return svg;
+}
+
+/** Stacked severity / alert levels icon */
+function createSeverityIconSvg() {
+  const NS = 'http://www.w3.org/2000/svg';
+  const svg = document.createElementNS(NS, 'svg');
+  svg.setAttribute('width', '16');
+  svg.setAttribute('height', '16');
+  svg.setAttribute('viewBox', '0 0 24 24');
+  svg.setAttribute('fill', 'none');
+  const path = document.createElementNS(NS, 'path');
+  path.setAttribute(
+    'd',
+    'M12 3L3 20h18L12 3zm0 6v5m0 3h.01'
+  );
+  path.setAttribute('stroke', 'currentColor');
+  path.setAttribute('stroke-width', '2');
+  path.setAttribute('stroke-linecap', 'round');
+  path.setAttribute('stroke-linejoin', 'round');
+  svg.appendChild(path);
+  return svg;
+}
+
+const ROWS = [
+  {
+    id: 'scoring',
+    label: 'scoring',
+    description: 'Scorecard with strengths & suggestions',
+    icon: createScoringIconSvg
+  },
+  {
+    id: 'severity',
+    label: 'severity',
+    description: 'PR description with critical / high / low issues',
+    icon: createSeverityIconSvg
+  }
+];
+
+async function _getFormat() {
+  try {
+    const result = await chrome.storage.local.get(['code-review-format']);
+    return result['code-review-format'] === 'severity' ? 'severity' : 'scoring';
+  } catch (e) {
+    dbgWarn('Failed to load review format preference:', e);
+    return 'scoring';
+  }
+}
+
+async function _setFormat(format) {
+  const normalized = format === 'severity' ? 'severity' : 'scoring';
+  await chrome.storage.local.set({ 'code-review-format': normalized });
+  return normalized;
+}
+
+function _positionDropdown(dropdown, btn) {
+  const rect = btn.getBoundingClientRect();
+  const dropW = 280;
+  let left = rect.right - dropW;
+  if (left < 8) left = 8;
+  const top = rect.bottom + 6;
+  dropdown.style.position = 'fixed';
+  dropdown.style.left = `${left}px`;
+  dropdown.style.top = `${top}px`;
+  dropdown.style.width = `${dropW}px`;
+}
+
+function _setTrigger(btn, formatId) {
+  const row = ROWS.find((r) => r.id === formatId) || ROWS[0];
+  btn.replaceChildren();
+  const icon = row.icon();
+  icon.setAttribute('aria-hidden', 'true');
+  const label = document.createElement('span');
+  label.className = 'thinkreview-review-format-btn-label';
+  label.textContent = row.label;
+  btn.appendChild(icon);
+  btn.appendChild(label);
+  btn.setAttribute('aria-label', `Review format: ${row.label}`);
+  btn.title = `Review format: ${row.label}`;
+}
+
+function _refreshDropdownActive(dropdown, activeId) {
+  dropdown.querySelectorAll('.thinkreview-review-format-item').forEach((el) => {
+    const id = el.dataset.format;
+    const on = id === activeId;
+    el.classList.toggle('active', on);
+    const check = el.querySelector('.thinkreview-review-format-item-check');
+    if (check) check.textContent = on ? '\u2713' : '';
+  });
+}
+
+async function _trackFormatMenu(eventName, params = {}) {
+  try {
+    const analyticsModule = await import(chrome.runtime.getURL('utils/analytics-service.js'));
+    analyticsModule
+      .trackUserAction(eventName, {
+        context: 'integrated_review_panel',
+        location: 'review_format_header_menu',
+        ...params
+      })
+      .catch(() => {});
+  } catch (_) {
+    /* silent */
+  }
+}
+
+/**
+ * @param {HTMLElement} headerActionsEl
+ * @param {{ onFormatChange?: (format: string) => void | Promise<void>, insertBeforeEl?: HTMLElement | null }} [options]
+ */
+export async function mountReviewFormatPreferenceWidget(headerActionsEl, options = {}) {
+  if (!headerActionsEl || document.getElementById('thinkreview-review-format-btn')) return;
+
+  const { onFormatChange, insertBeforeEl = null } = options;
+  const current = await _getFormat();
+
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.id = 'thinkreview-review-format-btn';
+  btn.className = 'thinkreview-review-format-btn';
+  btn.setAttribute('aria-haspopup', 'true');
+  btn.setAttribute('aria-expanded', 'false');
+  _setTrigger(btn, current);
+
+  const wrapper = document.createElement('span');
+  wrapper.className = 'thinkreview-review-format-btn-wrapper';
+  wrapper.id = 'thinkreview-review-format-btn-wrapper';
+  const tooltip = document.createElement('span');
+  tooltip.className = 'thinkreview-review-format-tooltip';
+  tooltip.textContent = 'Review format';
+  wrapper.appendChild(btn);
+  wrapper.appendChild(tooltip);
+
+  if (insertBeforeEl && insertBeforeEl.parentElement === headerActionsEl) {
+    headerActionsEl.insertBefore(wrapper, insertBeforeEl);
+  } else {
+    const settingsWrapper = headerActionsEl.querySelector('.thinkreview-settings-btn-wrapper');
+    if (settingsWrapper) {
+      headerActionsEl.insertBefore(wrapper, settingsWrapper);
+    } else {
+      headerActionsEl.appendChild(wrapper);
+    }
+  }
+
+  const dropdown = document.createElement('div');
+  dropdown.id = 'thinkreview-review-format-dropdown';
+  dropdown.setAttribute('role', 'menu');
+  dropdown.style.display = 'none';
+
+  const sectionLabel = document.createElement('div');
+  sectionLabel.className = 'thinkreview-review-format-section-label';
+  sectionLabel.textContent = 'Review format';
+  dropdown.appendChild(sectionLabel);
+
+  for (const row of ROWS) {
+    const item = document.createElement('button');
+    item.type = 'button';
+    item.className = 'thinkreview-review-format-item';
+    item.dataset.format = row.id;
+    item.setAttribute('role', 'menuitem');
+
+    const iconWrap = document.createElement('span');
+    iconWrap.className = 'thinkreview-review-format-item-icon';
+    const ic = row.icon();
+    ic.setAttribute('aria-hidden', 'true');
+    iconWrap.appendChild(ic);
+
+    const textWrap = document.createElement('span');
+    textWrap.className = 'thinkreview-review-format-item-text';
+    const lab = document.createElement('span');
+    lab.className = 'thinkreview-review-format-item-label';
+    lab.textContent = row.label;
+    const desc = document.createElement('span');
+    desc.className = 'thinkreview-review-format-item-desc';
+    desc.textContent = row.description;
+    textWrap.appendChild(lab);
+    textWrap.appendChild(desc);
+
+    const check = document.createElement('span');
+    check.className = 'thinkreview-review-format-item-check';
+    check.setAttribute('aria-hidden', 'true');
+
+    item.appendChild(iconWrap);
+    item.appendChild(textWrap);
+    item.appendChild(check);
+    dropdown.appendChild(item);
+  }
+
+  _refreshDropdownActive(dropdown, current);
+  document.body.appendChild(dropdown);
+
+  btn.addEventListener('click', async (e) => {
+    e.stopPropagation();
+    e.preventDefault();
+    const isOpen = dropdown.style.display !== 'none';
+    if (isOpen) {
+      dropdown.style.display = 'none';
+      btn.setAttribute('aria-expanded', 'false');
+      return;
+    }
+    const active = await _getFormat();
+    await _trackFormatMenu('review_format_menu_open_clicked', { reviewFormat: active });
+    _refreshDropdownActive(dropdown, active);
+    _positionDropdown(dropdown, btn);
+    dropdown.style.display = 'block';
+    btn.setAttribute('aria-expanded', 'true');
+  });
+
+  document.addEventListener('click', (e) => {
+    if (e.target !== btn && !dropdown.contains(/** @type {Node} */ (e.target))) {
+      dropdown.style.display = 'none';
+      btn.setAttribute('aria-expanded', 'false');
+    }
+  });
+
+  dropdown.addEventListener('click', async (e) => {
+    e.stopPropagation();
+    const item = e.target.closest('.thinkreview-review-format-item');
+    if (!item) return;
+    const id = item.dataset.format;
+    if (!id) return;
+
+    const previous = await _getFormat();
+    if (id === previous) {
+      dropdown.style.display = 'none';
+      btn.setAttribute('aria-expanded', 'false');
+      return;
+    }
+
+    const selected = await _setFormat(id);
+    await _trackFormatMenu('review_format_changed', {
+      reviewFormat: selected,
+      previous_format: previous
+    });
+    _setTrigger(btn, selected);
+    _refreshDropdownActive(dropdown, selected);
+    dropdown.style.display = 'none';
+    btn.setAttribute('aria-expanded', 'false');
+
+    if (typeof onFormatChange === 'function') {
+      try {
+        await onFormatChange(selected);
+      } catch (err) {
+        dbgWarn('Review format change handler failed:', err);
+      }
+    }
+  });
+
+  window.addEventListener(
+    'scroll',
+    () => {
+      if (dropdown.style.display !== 'none') _positionDropdown(dropdown, btn);
+    },
+    { passive: true }
+  );
+  window.addEventListener(
+    'resize',
+    () => {
+      if (dropdown.style.display !== 'none') _positionDropdown(dropdown, btn);
+    },
+    { passive: true }
+  );
+}

--- a/components/severity-review-layout.js
+++ b/components/severity-review-layout.js
@@ -1,0 +1,251 @@
+/**
+ * Severity review layout — PR description + Critical / High / Low issues.
+ * Loaded via chrome.runtime.getURL for Firefox-safe dynamic imports.
+ */
+
+/**
+ * Format file location label for an issue
+ * @param {{ filePath?: string, startLine?: number, endLine?: number }} issue
+ * @returns {string}
+ */
+function formatLocation(issue) {
+  if (!issue || !issue.filePath) return '';
+  const start = typeof issue.startLine === 'number' ? issue.startLine : null;
+  const end = typeof issue.endLine === 'number' ? issue.endLine : start;
+  if (start == null) return issue.filePath;
+  if (end != null && end !== start) {
+    return `${issue.filePath}:${start}-${end}`;
+  }
+  return `${issue.filePath}:${start}`;
+}
+
+/**
+ * Build a severity issue list section
+ * @param {string} title
+ * @param {string} severityClass - CSS modifier (critical|high|low)
+ * @param {Array} issues
+ * @param {Object} handlers
+ * @param {Function} [handlers.onIssueClick]
+ * @param {Function} [handlers.markdownToHtml]
+ * @param {Function} [handlers.preprocessAIResponse]
+ * @param {Function} [handlers.attachCopyButtonToItem]
+ * @returns {HTMLElement|null}
+ */
+function buildIssueSection(title, severityClass, issues, handlers = {}) {
+  const section = document.createElement('div');
+  section.className = `gl-mb-4 thinkreview-severity-section thinkreview-severity-${severityClass}`;
+
+  const heading = document.createElement('h5');
+  heading.className = 'gl-font-weight-bold thinkreview-section-title';
+  heading.textContent = title;
+  section.appendChild(heading);
+
+  if (!Array.isArray(issues) || issues.length === 0) {
+    const empty = document.createElement('p');
+    empty.className = 'thinkreview-severity-empty';
+    empty.textContent = 'None found.';
+    section.appendChild(empty);
+    return section;
+  }
+
+  const list = document.createElement('ul');
+  list.className = 'gl-pl-5 thinkreview-section-list thinkreview-severity-list';
+
+  const {
+    onIssueClick,
+    markdownToHtml,
+    preprocessAIResponse,
+    attachCopyButtonToItem
+  } = handlers;
+
+  issues.forEach((issue) => {
+    const li = document.createElement('li');
+    li.className = 'thinkreview-severity-issue-item';
+
+    const wrapper = document.createElement('div');
+    wrapper.className = 'thinkreview-item-wrapper thinkreview-severity-issue-wrapper';
+
+    const content = document.createElement('div');
+    content.className = 'thinkreview-severity-issue-content';
+
+    const titleEl = document.createElement('div');
+    titleEl.className = 'thinkreview-severity-issue-title';
+    titleEl.textContent = issue.title || 'Untitled issue';
+    content.appendChild(titleEl);
+
+    const location = formatLocation(issue);
+    if (location) {
+      const locEl = document.createElement('div');
+      locEl.className = 'thinkreview-severity-issue-location';
+      locEl.textContent = location;
+      content.appendChild(locEl);
+    }
+
+    const descEl = document.createElement('div');
+    descEl.className = 'thinkreview-severity-issue-description thinkreview-section-content';
+    const descText = issue.description || '';
+    if (typeof markdownToHtml === 'function' && typeof preprocessAIResponse === 'function') {
+      descEl.innerHTML = markdownToHtml(preprocessAIResponse(descText));
+    } else {
+      descEl.textContent = descText;
+    }
+    content.appendChild(descEl);
+
+    if (typeof onIssueClick === 'function') {
+      wrapper.classList.add('thinkreview-clickable-item');
+      wrapper.setAttribute('title', 'Click to ask a follow-up about this issue');
+      wrapper.addEventListener('click', (e) => {
+        if (e.target.closest('.thinkreview-copy-btn') || e.target.closest('.thinkreview-ide-assist-btn')) {
+          return;
+        }
+        const plain = [
+          issue.title || '',
+          location,
+          issue.description || ''
+        ].filter(Boolean).join('\n');
+        onIssueClick(plain, severityClass, issue);
+      });
+    }
+
+    wrapper.appendChild(content);
+
+    if (typeof attachCopyButtonToItem === 'function') {
+      const copySource = document.createElement('div');
+      copySource.textContent = [
+        issue.title || '',
+        location,
+        issue.description || ''
+      ].filter(Boolean).join('\n\n');
+      attachCopyButtonToItem(copySource, wrapper);
+    }
+
+    li.appendChild(wrapper);
+    list.appendChild(li);
+  });
+
+  section.appendChild(list);
+  return section;
+}
+
+/**
+ * Render the severity review layout into a container.
+ * @param {HTMLElement} container
+ * @param {Object} review - { prDescription, criticalIssues, highIssues, lowIssues }
+ * @param {Object} [handlers]
+ * @param {Function} [handlers.onIssueClick] - (plainText, severity, issue) => void
+ * @param {Function} [handlers.markdownToHtml]
+ * @param {Function} [handlers.preprocessAIResponse]
+ * @param {Function} [handlers.attachCopyButtonToItem]
+ * @param {Function} [handlers.applySimpleSyntaxHighlighting]
+ * @returns {HTMLElement|null}
+ */
+export function renderSeverityLayout(container, review, handlers = {}) {
+  if (!container || !review) return null;
+
+  container.replaceChildren();
+  container.classList.remove('gl-hidden');
+
+  const {
+    markdownToHtml,
+    preprocessAIResponse,
+    attachCopyButtonToItem,
+    applySimpleSyntaxHighlighting,
+    onIssueClick
+  } = handlers;
+
+  // PR Description section
+  const prSection = document.createElement('div');
+  prSection.className = 'gl-mb-4 thinkreview-severity-pr-section';
+
+  const prHeader = document.createElement('div');
+  prHeader.className = 'thinkreview-section-header-row';
+
+  const prTitle = document.createElement('h5');
+  prTitle.className = 'gl-font-weight-bold thinkreview-section-title';
+  prTitle.textContent = 'PR Description';
+  prHeader.appendChild(prTitle);
+
+  const copyPrBtn = document.createElement('button');
+  copyPrBtn.type = 'button';
+  copyPrBtn.className = 'thinkreview-generate-pr-desc-btn thinkreview-copy-pr-desc-btn';
+  copyPrBtn.title = 'Copy PR description';
+  copyPrBtn.textContent = 'Copy';
+  copyPrBtn.addEventListener('click', async (e) => {
+    e.stopPropagation();
+    const text = review.prDescription || '';
+    if (!text.trim()) return;
+    try {
+      await navigator.clipboard.writeText(text);
+      const original = copyPrBtn.textContent;
+      copyPrBtn.textContent = 'Copied!';
+      setTimeout(() => {
+        copyPrBtn.textContent = original;
+      }, 2000);
+    } catch (err) {
+      console.warn('[severity-review-layout] Failed to copy PR description:', err);
+    }
+  });
+  prHeader.appendChild(copyPrBtn);
+  prSection.appendChild(prHeader);
+
+  const prWrapper = document.createElement('div');
+  prWrapper.className = 'thinkreview-item-wrapper';
+  const prContent = document.createElement('div');
+  prContent.className = 'thinkreview-section-content thinkreview-severity-pr-description';
+  const prText = review.prDescription || 'No PR description provided.';
+  if (typeof markdownToHtml === 'function' && typeof preprocessAIResponse === 'function') {
+    prContent.innerHTML = markdownToHtml(preprocessAIResponse(prText));
+  } else {
+    prContent.textContent = prText;
+  }
+  prWrapper.appendChild(prContent);
+
+  if (typeof attachCopyButtonToItem === 'function') {
+    const copySource = document.createElement('div');
+    copySource.textContent = prText;
+    attachCopyButtonToItem(copySource, prWrapper);
+  }
+
+  prSection.appendChild(prWrapper);
+  container.appendChild(prSection);
+
+  const issueHandlers = {
+    onIssueClick,
+    markdownToHtml,
+    preprocessAIResponse,
+    attachCopyButtonToItem
+  };
+
+  container.appendChild(
+    buildIssueSection(
+      `Critical Issues (${Array.isArray(review.criticalIssues) ? review.criticalIssues.length : 0})`,
+      'critical',
+      review.criticalIssues,
+      issueHandlers
+    )
+  );
+  container.appendChild(
+    buildIssueSection(
+      `High Issues (${Array.isArray(review.highIssues) ? review.highIssues.length : 0})`,
+      'high',
+      review.highIssues,
+      issueHandlers
+    )
+  );
+  container.appendChild(
+    buildIssueSection(
+      `Low Issues (${Array.isArray(review.lowIssues) ? review.lowIssues.length : 0})`,
+      'low',
+      review.lowIssues,
+      issueHandlers
+    )
+  );
+
+  if (typeof applySimpleSyntaxHighlighting === 'function') {
+    applySimpleSyntaxHighlighting(container);
+  }
+
+  return container;
+}
+
+export default { renderSeverityLayout };

--- a/components/severity-review-layout.js
+++ b/components/severity-review-layout.js
@@ -4,7 +4,19 @@
  */
 
 /**
- * Format file location label for an issue
+ * Add paragraph breaks after sentences for PR description readability.
+ * @param {string} text
+ * @returns {string}
+ */
+function formatPrDescriptionSpacing(text) {
+  if (!text) return '';
+  let formatted = String(text).trim();
+  formatted = formatted.replace(/([.!?])\n(?!\n)/g, '$1\n\n');
+  formatted = formatted.replace(/([.!?])\s+(?=[A-Z(])/g, '$1\n\n');
+  return formatted;
+}
+
+/**
  * @param {{ filePath?: string, startLine?: number, endLine?: number }} issue
  * @returns {string}
  */
@@ -192,7 +204,7 @@ export function renderSeverityLayout(container, review, handlers = {}) {
   prWrapper.className = 'thinkreview-item-wrapper';
   const prContent = document.createElement('div');
   prContent.className = 'thinkreview-section-content thinkreview-severity-pr-description';
-  const prText = review.prDescription || 'No PR description provided.';
+  const prText = formatPrDescriptionSpacing(review.prDescription || 'No PR description provided.');
   if (typeof markdownToHtml === 'function' && typeof preprocessAIResponse === 'function') {
     prContent.innerHTML = markdownToHtml(preprocessAIResponse(prText));
   } else {

--- a/components/severity-review-layout.js
+++ b/components/severity-review-layout.js
@@ -4,19 +4,6 @@
  */
 
 /**
- * Add paragraph breaks after sentences for PR description readability.
- * @param {string} text
- * @returns {string}
- */
-function formatPrDescriptionSpacing(text) {
-  if (!text) return '';
-  let formatted = String(text).trim();
-  formatted = formatted.replace(/([.!?])\n(?!\n)/g, '$1\n\n');
-  formatted = formatted.replace(/([.!?])\s+(?=[A-Z(])/g, '$1\n\n');
-  return formatted;
-}
-
-/**
  * @param {{ filePath?: string, startLine?: number, endLine?: number }} issue
  * @returns {string}
  */
@@ -182,7 +169,9 @@ export function renderSeverityLayout(container, review, handlers = {}) {
   prWrapper.className = 'thinkreview-item-wrapper';
   const prContent = document.createElement('div');
   prContent.className = 'thinkreview-section-content thinkreview-severity-pr-description';
-  const prText = formatPrDescriptionSpacing(review.prDescription || 'No PR description provided.');
+  // Spacing comes from the model (blank lines after sentences); markdownToHtml
+  // turns those newlines into breaks — do not regex-split on '.' / '!' / '?'.
+  const prText = review.prDescription || 'No PR description provided.';
   if (typeof markdownToHtml === 'function' && typeof preprocessAIResponse === 'function') {
     prContent.innerHTML = markdownToHtml(preprocessAIResponse(prText));
   } else {

--- a/components/severity-review-layout.js
+++ b/components/severity-review-layout.js
@@ -176,28 +176,6 @@ export function renderSeverityLayout(container, review, handlers = {}) {
   prTitle.className = 'gl-font-weight-bold thinkreview-section-title';
   prTitle.textContent = 'PR Description';
   prHeader.appendChild(prTitle);
-
-  const copyPrBtn = document.createElement('button');
-  copyPrBtn.type = 'button';
-  copyPrBtn.className = 'thinkreview-generate-pr-desc-btn thinkreview-copy-pr-desc-btn';
-  copyPrBtn.title = 'Copy PR description';
-  copyPrBtn.textContent = 'Copy';
-  copyPrBtn.addEventListener('click', async (e) => {
-    e.stopPropagation();
-    const text = review.prDescription || '';
-    if (!text.trim()) return;
-    try {
-      await navigator.clipboard.writeText(text);
-      const original = copyPrBtn.textContent;
-      copyPrBtn.textContent = 'Copied!';
-      setTimeout(() => {
-        copyPrBtn.textContent = original;
-      }, 2000);
-    } catch (err) {
-      console.warn('[severity-review-layout] Failed to copy PR description:', err);
-    }
-  });
-  prHeader.appendChild(copyPrBtn);
   prSection.appendChild(prHeader);
 
   const prWrapper = document.createElement('div');

--- a/components/utils/review-markdown.js
+++ b/components/utils/review-markdown.js
@@ -2,12 +2,58 @@
 // Utilities for building Markdown representations of review data
 
 /**
+ * Format a severity issue as markdown bullet
+ * @param {Object} issue
+ * @returns {string}
+ */
+function formatSeverityIssueMarkdown(issue) {
+  if (!issue) return '';
+  const title = issue.title || 'Untitled';
+  const location = issue.filePath
+    ? (typeof issue.startLine === 'number'
+      ? (typeof issue.endLine === 'number' && issue.endLine !== issue.startLine
+        ? `${issue.filePath}:${issue.startLine}-${issue.endLine}`
+        : `${issue.filePath}:${issue.startLine}`)
+      : issue.filePath)
+    : '';
+  const desc = String(issue.description || '').trim();
+  const locLine = location ? ` (${location})` : '';
+  return `- **${title}**${locLine}${desc ? `\n  ${desc}` : ''}`;
+}
+
+/**
  * Builds a Markdown string from the review data for copy-all.
  * @param {Object} review - The review data object
  * @returns {string} Formatted Markdown text
  */
 export function buildReviewMarkdown(review) {
   if (!review) return '';
+
+  // Severity layout
+  if (review.reviewFormat === 'severity') {
+    const sections = ['# AI Code Review'];
+
+    if (review.prDescription) {
+      sections.push(`## PR Description\n\n${review.prDescription}`);
+    }
+
+    if (Array.isArray(review.criticalIssues) && review.criticalIssues.length > 0) {
+      const items = review.criticalIssues.map(formatSeverityIssueMarkdown).join('\n');
+      sections.push(`## Critical Issues\n\n${items}`);
+    }
+
+    if (Array.isArray(review.highIssues) && review.highIssues.length > 0) {
+      const items = review.highIssues.map(formatSeverityIssueMarkdown).join('\n');
+      sections.push(`## High Issues\n\n${items}`);
+    }
+
+    if (Array.isArray(review.lowIssues) && review.lowIssues.length > 0) {
+      const items = review.lowIssues.map(formatSeverityIssueMarkdown).join('\n');
+      sections.push(`## Low Issues\n\n${items}`);
+    }
+
+    return sections.join('\n\n');
+  }
 
   const sections = ['# AI Code Review'];
 
@@ -47,4 +93,3 @@ export function buildReviewMarkdown(review) {
 
   return sections.join('\n\n');
 }
-

--- a/content.js
+++ b/content.js
@@ -1457,8 +1457,9 @@ async function fetchAndDisplayCodeReview(forceRegenerate = false, isAutoTriggere
     }
     
     // Get the user's language preference from extension storage
-    const result = await chrome.storage.local.get(['code-review-language']);
+    const result = await chrome.storage.local.get(['code-review-language', 'code-review-format']);
     const language = result['code-review-language'] || 'English';
+    const reviewFormat = result['code-review-format'] === 'severity' ? 'severity' : 'scoring';
     
     // Get the full MR/PR URL
     const mrUrl = window.location.href;
@@ -1486,7 +1487,8 @@ async function fetchAndDisplayCodeReview(forceRegenerate = false, isAutoTriggere
         mrUrl: mrUrl, // Include the full MR/PR URL
         language, // Include the language preference
         platform, // Include platform information
-        forceRegenerate // Include force regenerate flag
+        forceRegenerate, // Include force regenerate flag
+        reviewFormat // Include review layout format (scoring | severity)
       }, resolve);
     });
 
@@ -1565,6 +1567,10 @@ async function fetchAndDisplayCodeReview(forceRegenerate = false, isAutoTriggere
     }
 
     // Display the review results (use filtered patch — same string as reviewPatchCode_1_1 for agent checksums).
+    // Ensure reviewFormat is on the review object for conditional rendering (API may also set top-level reviewFormat).
+    if (!data.review.reviewFormat) {
+      data.review.reviewFormat = data.reviewFormat || reviewFormat || 'scoring';
+    }
     displayIntegratedReview(
       data.review,
       filteredCodeContent,

--- a/services/cloud-service.js
+++ b/services/cloud-service.js
@@ -285,9 +285,10 @@ export class CloudService {
    * @param {string} [mrUrl] - Optional merge request URL for tracking
    * @param {boolean} [forceRegenerate] - Optional flag to force regenerate review even if cached
    * @param {string} [platform] - Optional platform information ('gitlab' or 'azure-devops')
+   * @param {string} [reviewFormat='scoring'] - Optional review layout: 'scoring' (default) or 'severity'
    * @returns {Promise<Object>} - Code review results from Gemini API
    */
-  static async reviewPatchCode(patchContent, language = 'English', mrId = null, mrUrl = null, forceRegenerate = false, platform = null) {
+  static async reviewPatchCode(patchContent, language = 'English', mrId = null, mrUrl = null, forceRegenerate = false, platform = null, reviewFormat = 'scoring') {
     dbgLog('Sending patch for code review');
     
     if (!patchContent) {
@@ -363,6 +364,11 @@ export class CloudService {
       // Include platform information if provided
       if (platform) {
         requestBody.platform = platform;
+      }
+
+      // Include reviewFormat when not the default scoring layout
+      if (reviewFormat && reviewFormat !== 'scoring') {
+        requestBody.reviewFormat = reviewFormat;
       }
       
       const response = await CloudService.thinkReviewFetch(await CloudService.getReviewCodeUrlV11(), requestBody);


### PR DESCRIPTION
This PR introduces a new "severity" review layout as an alternative to the existing "scoring" review layout.

Users can now toggle between the two formats via a new header dropdown widget (`review-format-preference-widget.js/css`), with the preference persisted in `chrome.storage.local` under `code-review-format`.

The severity format renders a PR description section followed by Critical / High / Low issue lists, implemented in the new `components/severity-review-layout.js` module, and is wired into `displayIntegratedReview` in `integrated-review.js` via a large conditional branch that toggles visibility of the old scoring-specific containers (metrics, summary, suggestions, security, practices).

The chosen `reviewFormat` is propagated end-to-end: `content.js` reads the stored preference and sends it to `background.js`, which forwards it to `CloudService.reviewPatchCode`, which includes it in the request body only when non-default.

`buildReviewMarkdown` in `review-markdown.js` was extended to produce severity-formatted markdown for the copy-all feature.

Additionally, this PR removes the bug-report button and its associated CSS/JS/tooltip logic from the integrated review panel header, adds an MCP setup link entry to the existing IDE-assist preference dropdown, and makes a minor wording tweak to the Indonesian language option label.

New "Custom Rules" and "Add an Agent" action buttons were also added to the feedback row, shown for both layouts, along with associated CSS and analytics tracking hooks.