### PR TITLE
Feature/panel text size

### DIFF
--- a/components/integrated-review.css
+++ b/components/integrated-review.css
@@ -228,6 +228,46 @@
   box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.3);
 }
 
+#gitlab-mr-integrated-review .thinkreview-text-size-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+#gitlab-mr-integrated-review .thinkreview-text-size-btn {
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  color: white;
+  cursor: pointer;
+  padding: 0;
+  border-radius: 4px;
+  transition: background 0.15s ease, border-color 0.15s ease, opacity 0.15s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  box-sizing: border-box;
+  height: 28px;
+  width: 28px;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+#gitlab-mr-integrated-review .thinkreview-text-size-btn:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.18);
+  border-color: rgba(255, 255, 255, 0.5);
+}
+
+#gitlab-mr-integrated-review .thinkreview-text-size-btn:active:not(:disabled) {
+  background: rgba(255, 255, 255, 0.22);
+  transform: scale(0.95);
+}
+
+#gitlab-mr-integrated-review .thinkreview-text-size-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
 #gitlab-mr-integrated-review .thinkreview-card-body {
   padding: 0;
   display: flex;

--- a/components/integrated-review.css
+++ b/components/integrated-review.css
@@ -27,6 +27,9 @@
   --thinkreview-z-tooltip: 1100;
   --thinkreview-z-modal-overlay: 1200;
   --thinkreview-z-toast: 1250;
+
+  /* Panel body text zoom (1 = medium); set via panel-text-size-widget */
+  --thinkreview-text-zoom: 1;
 }
 
 /* Defensive reset: prevent host-page (e.g. GitLab) bare pre/code rules from
@@ -235,6 +238,7 @@
   /* Default to dark theme for better readability */
   background-color: #1e1e1e;
   color: #ffffff;
+  zoom: var(--thinkreview-text-zoom, 1);
 }
 
 #review-content {

--- a/components/integrated-review.js
+++ b/components/integrated-review.js
@@ -338,6 +338,10 @@ async function createIntegratedReviewPanel(patchUrl) {
             </button>
             <span class="thinkreview-regenerate-tooltip" aria-hidden="true">Regenerate review</span>
           </span>
+          <span class="thinkreview-text-size-controls" aria-label="Text size">
+            <button type="button" id="thinkreview-text-size-decrease" class="thinkreview-text-size-btn" aria-label="Decrease text size" title="Decrease text size">−</button>
+            <button type="button" id="thinkreview-text-size-increase" class="thinkreview-text-size-btn" aria-label="Increase text size" title="Increase text size">+</button>
+          </span>
           <select id="language-selector" class="thinkreview-language-dropdown" title="Select review language">
             <option value="English">English</option>
             <option value="Spanish">Español</option>
@@ -839,6 +843,10 @@ async function createIntegratedReviewPanel(patchUrl) {
           e.target.closest('#language-selector') ||
           e.target.id === 'thinkreview-review-format-btn' ||
           e.target.closest('#thinkreview-review-format-btn') ||
+          e.target.id === 'thinkreview-text-size-decrease' ||
+          e.target.closest('#thinkreview-text-size-decrease') ||
+          e.target.id === 'thinkreview-text-size-increase' ||
+          e.target.closest('#thinkreview-text-size-increase') ||
           e.target.id === 'thinkreview-settings-btn' ||
           e.target.closest('#thinkreview-settings-btn')) {
         return; // Don't block these events
@@ -937,9 +945,10 @@ async function createIntegratedReviewPanel(patchUrl) {
 
   try {
     const textSizeUrl = chrome.runtime.getURL('components/popup-modules/panel-text-size-widget.js');
-    const { getPanelTextSize, applyPanelTextSize } = await import(textSizeUrl);
+    const { getPanelTextSize, applyPanelTextSize, mountTextSizeStepControls } = await import(textSizeUrl);
     const textSize = await getPanelTextSize();
     applyPanelTextSize(container, textSize);
+    mountTextSizeStepControls(container);
   } catch (error) {
     dbgWarn('Failed to apply panel text size preference:', error);
   }

--- a/components/integrated-review.js
+++ b/components/integrated-review.js
@@ -935,6 +935,15 @@ async function createIntegratedReviewPanel(patchUrl) {
 
   getOllamaBrowserExtensionCorsMessageModule().catch(() => {});
 
+  try {
+    const textSizeUrl = chrome.runtime.getURL('components/popup-modules/panel-text-size-widget.js');
+    const { getPanelTextSize, applyPanelTextSize } = await import(textSizeUrl);
+    const textSize = await getPanelTextSize();
+    applyPanelTextSize(container, textSize);
+  } catch (error) {
+    dbgWarn('Failed to apply panel text size preference:', error);
+  }
+
   return container;
 }
 

--- a/components/popup-modules/panel-settings-menu-widget.css
+++ b/components/popup-modules/panel-settings-menu-widget.css
@@ -170,6 +170,10 @@
   width: 280px;
 }
 
+#thinkreview-settings-text-size-submenu {
+  width: 220px;
+}
+
 #thinkreview-settings-credits-submenu {
   width: 280px;
 }

--- a/components/popup-modules/panel-settings-menu-widget.js
+++ b/components/popup-modules/panel-settings-menu-widget.js
@@ -419,7 +419,7 @@ export async function mountPanelSettingsMenu(settingsButton, options = {}) {
     refreshTextSizeActiveItems
   } = textSizeMod;
 
-  const [layoutSettings, ideTarget, autoStartEnabled] = await Promise.all([
+  const [layoutSettings, ideTarget, autoStartEnabled, textSize] = await Promise.all([
     getLayoutSettings(),
     getIdeAssistTarget(),
     _getAutoStartReviewEnabled(),
@@ -660,7 +660,7 @@ export async function mountPanelSettingsMenu(settingsButton, options = {}) {
   }
 
   async function _openMain() {
-    const [currentLayout, currentIde, currentAutoStart] = await Promise.all([
+    const [currentLayout, currentIde, currentAutoStart, currentTextSize] = await Promise.all([
       getLayoutSettings(),
       getIdeAssistTarget(),
       _getAutoStartReviewEnabled(),
@@ -713,6 +713,8 @@ export async function mountPanelSettingsMenu(settingsButton, options = {}) {
       await _trackSettingsMenu(next ? 'auto_start_review_enabled' : 'auto_start_review_disabled', {
         via: 'settings_header_menu'
       });
+      return;
+    }
     if (action === 'text-size') {
       await _trackSettingsMenu('settings_menu_text_size_clicked');
       await _openSubmenu('text-size');

--- a/components/popup-modules/panel-settings-menu-widget.js
+++ b/components/popup-modules/panel-settings-menu-widget.js
@@ -1,6 +1,6 @@
 /**
  * panel-settings-menu-widget.js
- * Settings gear opens a body-appended menu with nested Layout and Implement via flyouts,
+ * Settings gear opens a body-appended menu with nested Layout, Implement via, and Text size flyouts,
  * plus a link to the full extension settings popup.
  */
 
@@ -16,6 +16,10 @@ if (!document.querySelector(`link[href="${_cssURL}"]`)) {
 
 function _layoutIconSvg() {
   return `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>`;
+}
+
+function _textSizeIconSvg() {
+  return `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 7V4h16v3"/><path d="M9 20h6"/><path d="M12 4v16"/></svg>`;
 }
 
 function _implementIconSvg() {
@@ -378,15 +382,18 @@ export async function mountPanelSettingsMenu(settingsButton, options = {}) {
 
   const layoutUrl = chrome.runtime.getURL('components/popup-modules/layout-settings-widget.js');
   const ideUrl = chrome.runtime.getURL('components/popup-modules/ide-assist-preference-widget.js');
+  const textSizeUrl = chrome.runtime.getURL('components/popup-modules/panel-text-size-widget.js');
   const idePrefUrl = chrome.runtime.getURL('utils/ide-integration/ide-assist-preference.js');
 
   let layoutMod;
   let ideMod;
+  let textSizeMod;
   let getIdeAssistTarget;
   try {
-    [layoutMod, ideMod, { getIdeAssistTarget }] = await Promise.all([
+    [layoutMod, ideMod, textSizeMod, { getIdeAssistTarget }] = await Promise.all([
       import(layoutUrl),
       import(ideUrl),
+      import(textSizeUrl),
       import(idePrefUrl)
     ]);
   } catch (e) {
@@ -405,11 +412,18 @@ export async function mountPanelSettingsMenu(settingsButton, options = {}) {
     refreshIdeAssistActiveItems,
     getIdeAssistRowLabel
   } = ideMod;
+  const {
+    getPanelTextSize,
+    getPanelTextSizeLabel,
+    populateTextSizeOptions,
+    refreshTextSizeActiveItems
+  } = textSizeMod;
 
   const [layoutSettings, ideTarget, autoStartEnabled] = await Promise.all([
     getLayoutSettings(),
     getIdeAssistTarget(),
-    _getAutoStartReviewEnabled()
+    _getAutoStartReviewEnabled(),
+    getPanelTextSize()
   ]);
 
   settingsButton.setAttribute('aria-haspopup', 'true');
@@ -441,8 +455,16 @@ export async function mountPanelSettingsMenu(settingsButton, options = {}) {
     iconHtml: _implementIconSvg(),
     hasSubmenu: true
   });
+  const textSizeRow = _createMenuRow({
+    id: 'text-size',
+    label: 'Text size',
+    value: getPanelTextSizeLabel(textSize),
+    iconHtml: _textSizeIconSvg(),
+    hasSubmenu: true
+  });
   main.appendChild(layoutRow);
   main.appendChild(ideRow);
+  main.appendChild(textSizeRow);
 
   const autoStartRow = _createAutoStartToggleRow(autoStartEnabled);
   main.appendChild(autoStartRow);
@@ -532,6 +554,21 @@ export async function mountPanelSettingsMenu(settingsButton, options = {}) {
   });
   document.body.appendChild(ideSub);
 
+  const textSizeSub = document.createElement('div');
+  textSizeSub.id = 'thinkreview-settings-text-size-submenu';
+  textSizeSub.className = 'thinkreview-settings-submenu';
+  textSizeSub.setAttribute('role', 'menu');
+  textSizeSub.style.display = 'none';
+  populateTextSizeOptions(textSizeSub, {
+    activeId: textSize,
+    onSelect: async (sizeId) => {
+      const valueEl = textSizeRow.querySelector('[data-menu-value="text-size"]');
+      if (valueEl) valueEl.textContent = getPanelTextSizeLabel(sizeId);
+      _closeAll();
+    }
+  });
+  document.body.appendChild(textSizeSub);
+
   const creditsSub = document.createElement('div');
   creditsSub.id = 'thinkreview-settings-credits-submenu';
   creditsSub.className = 'thinkreview-settings-submenu';
@@ -539,16 +576,18 @@ export async function mountPanelSettingsMenu(settingsButton, options = {}) {
   creditsSub.style.display = 'none';
   document.body.appendChild(creditsSub);
 
-  let openSubmenu = null; // 'layout' | 'implement' | 'buy-credits' | null
+  let openSubmenu = null; // 'layout' | 'implement' | 'text-size' | 'buy-credits' | null
   let creditsLoadPromise = null;
   let creditsPacksCached = false;
 
   function _closeSubmenus() {
     layoutSub.style.display = 'none';
     ideSub.style.display = 'none';
+    textSizeSub.style.display = 'none';
     creditsSub.style.display = 'none';
     layoutRow.setAttribute('aria-expanded', 'false');
     ideRow.setAttribute('aria-expanded', 'false');
+    textSizeRow.setAttribute('aria-expanded', 'false');
     buyCreditsRow.setAttribute('aria-expanded', 'false');
     openSubmenu = null;
   }
@@ -601,6 +640,14 @@ export async function mountPanelSettingsMenu(settingsButton, options = {}) {
       _positionSubmenu(ideSub, ideRow, 280);
       ideSub.style.display = 'block';
       ideRow.setAttribute('aria-expanded', 'true');
+    } else if (kind === 'text-size') {
+      const active = await getPanelTextSize();
+      refreshTextSizeActiveItems(textSizeSub, active);
+      const valueEl = textSizeRow.querySelector('[data-menu-value="text-size"]');
+      if (valueEl) valueEl.textContent = getPanelTextSizeLabel(active);
+      _positionSubmenu(textSizeSub, textSizeRow, 220);
+      textSizeSub.style.display = 'block';
+      textSizeRow.setAttribute('aria-expanded', 'true');
     } else if (kind === 'buy-credits') {
       _positionSubmenu(creditsSub, buyCreditsRow, 280);
       creditsSub.style.display = 'block';
@@ -616,13 +663,16 @@ export async function mountPanelSettingsMenu(settingsButton, options = {}) {
     const [currentLayout, currentIde, currentAutoStart] = await Promise.all([
       getLayoutSettings(),
       getIdeAssistTarget(),
-      _getAutoStartReviewEnabled()
+      _getAutoStartReviewEnabled(),
+      getPanelTextSize()
     ]);
     const layoutVal = layoutRow.querySelector('[data-menu-value="layout"]');
     const ideVal = ideRow.querySelector('[data-menu-value="implement"]');
+    const textSizeVal = textSizeRow.querySelector('[data-menu-value="text-size"]');
     if (layoutVal) layoutVal.textContent = getLayoutComboSummary(currentLayout);
     if (ideVal) ideVal.textContent = getIdeAssistRowLabel(currentIde);
     _syncAutoStartToggleUI(autoStartRow, currentAutoStart);
+    if (textSizeVal) textSizeVal.textContent = getPanelTextSizeLabel(currentTextSize);
 
     _positionMainMenu(main, settingsButton);
     main.style.display = 'block';
@@ -663,6 +713,9 @@ export async function mountPanelSettingsMenu(settingsButton, options = {}) {
       await _trackSettingsMenu(next ? 'auto_start_review_enabled' : 'auto_start_review_disabled', {
         via: 'settings_header_menu'
       });
+    if (action === 'text-size') {
+      await _trackSettingsMenu('settings_menu_text_size_clicked');
+      await _openSubmenu('text-size');
       return;
     }
     if (action === 'buy-credits') {
@@ -717,6 +770,7 @@ export async function mountPanelSettingsMenu(settingsButton, options = {}) {
       main.contains(t) ||
       layoutSub.contains(t) ||
       ideSub.contains(t) ||
+      textSizeSub.contains(t) ||
       creditsSub.contains(t)
     ) {
       return;
@@ -739,6 +793,7 @@ export async function mountPanelSettingsMenu(settingsButton, options = {}) {
     _positionMainMenu(main, settingsButton);
     if (openSubmenu === 'layout') _positionSubmenu(layoutSub, layoutRow, 232);
     if (openSubmenu === 'implement') _positionSubmenu(ideSub, ideRow, 280);
+    if (openSubmenu === 'text-size') _positionSubmenu(textSizeSub, textSizeRow, 220);
     if (openSubmenu === 'buy-credits') _positionSubmenu(creditsSub, buyCreditsRow, 280);
   };
   window.addEventListener('scroll', reposition, { passive: true });
@@ -759,6 +814,7 @@ export async function mountPanelSettingsMenu(settingsButton, options = {}) {
     main.remove();
     layoutSub.remove();
     ideSub.remove();
+    textSizeSub.remove();
     creditsSub.remove();
     creditsLoadPromise = null;
   }

--- a/components/popup-modules/panel-text-size-widget.css
+++ b/components/popup-modules/panel-text-size-widget.css
@@ -1,0 +1,59 @@
+/* panel-text-size-widget.css — text size submenu in panel settings */
+
+.thinkreview-text-size-section-label {
+  font-size: 10px;
+  font-weight: 700;
+  color: rgba(155, 126, 240, 0.75);
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  padding: 6px 14px 3px;
+}
+
+.thinkreview-text-size-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 14px;
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.88);
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.12s ease;
+  font-family: inherit;
+  font-size: 13px;
+}
+
+.thinkreview-text-size-item:hover,
+.thinkreview-text-size-item.active {
+  background: rgba(107, 79, 187, 0.22);
+  color: white;
+}
+
+.thinkreview-text-size-preview {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 24px;
+  border-radius: 4px;
+  background: rgba(107, 79, 187, 0.2);
+  color: #c9b4ff;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.thinkreview-text-size-item-label {
+  flex: 1;
+  font-weight: 500;
+  line-height: 1.2;
+}
+
+.thinkreview-text-size-item-check {
+  flex-shrink: 0;
+  font-size: 13px;
+  color: #c9b4ff;
+  line-height: 1;
+}

--- a/components/popup-modules/panel-text-size-widget.js
+++ b/components/popup-modules/panel-text-size-widget.js
@@ -64,6 +64,78 @@ export function applyPanelTextSize(panelEl, sizeId) {
   panelEl.style.setProperty('--thinkreview-text-zoom', String(option.zoom));
 }
 
+export async function applyAndPersistPanelTextSize(sizeId) {
+  const option = TEXT_SIZE_OPTIONS.find((o) => o.id === sizeId);
+  if (!option) return null;
+  await savePanelTextSize(option.id);
+  const panelEl = document.getElementById('gitlab-mr-integrated-review');
+  applyPanelTextSize(panelEl, option.id);
+  document.dispatchEvent(new CustomEvent('thinkreview:textsizechanged', { detail: { sizeId: option.id } }));
+  return option.id;
+}
+
+/**
+ * Step text size up (+1) or down (-1). Returns the new size id, or null if at a bound.
+ * @param {number} direction
+ */
+export async function changePanelTextSize(direction) {
+  const current = await getPanelTextSize();
+  const idx = TEXT_SIZE_OPTIONS.findIndex((o) => o.id === current);
+  const nextIdx = idx + direction;
+  if (nextIdx < 0 || nextIdx >= TEXT_SIZE_OPTIONS.length) return null;
+  return applyAndPersistPanelTextSize(TEXT_SIZE_OPTIONS[nextIdx].id);
+}
+
+export function syncTextSizeStepButtons(decreaseBtn, increaseBtn, sizeId) {
+  const idx = TEXT_SIZE_OPTIONS.findIndex((o) => o.id === sizeId);
+  if (decreaseBtn) {
+    const atMin = idx <= 0;
+    decreaseBtn.disabled = atMin;
+    decreaseBtn.setAttribute('aria-disabled', atMin ? 'true' : 'false');
+  }
+  if (increaseBtn) {
+    const atMax = idx >= TEXT_SIZE_OPTIONS.length - 1;
+    increaseBtn.disabled = atMax;
+    increaseBtn.setAttribute('aria-disabled', atMax ? 'true' : 'false');
+  }
+}
+
+/**
+ * Wire +/- header controls to step panel text size.
+ * @param {HTMLElement} panelEl
+ */
+export function mountTextSizeStepControls(panelEl) {
+  const decreaseBtn = panelEl?.querySelector('#thinkreview-text-size-decrease');
+  const increaseBtn = panelEl?.querySelector('#thinkreview-text-size-increase');
+  if (!decreaseBtn || !increaseBtn) return;
+
+  const refresh = async () => {
+    const sizeId = await getPanelTextSize();
+    syncTextSizeStepButtons(decreaseBtn, increaseBtn, sizeId);
+  };
+
+  decreaseBtn.addEventListener('click', async (e) => {
+    e.stopPropagation();
+    e.preventDefault();
+    await changePanelTextSize(-1);
+    await refresh();
+  });
+
+  increaseBtn.addEventListener('click', async (e) => {
+    e.stopPropagation();
+    e.preventDefault();
+    await changePanelTextSize(1);
+    await refresh();
+  });
+
+  document.addEventListener('thinkreview:textsizechanged', refresh);
+  chrome.storage.onChanged.addListener((changes, area) => {
+    if (area === 'local' && changes[PANEL_TEXT_SIZE_STORAGE_KEY]) refresh();
+  });
+
+  refresh();
+}
+
 /**
  * Fill a container with text size options (settings submenu).
  * @param {HTMLElement} container
@@ -116,12 +188,8 @@ export function populateTextSizeOptions(container, options = {}) {
     const sizeId = item.dataset.textSize;
     if (!sizeId || item.classList.contains('active')) return;
 
-    await savePanelTextSize(sizeId);
+    await applyAndPersistPanelTextSize(sizeId);
     refreshTextSizeActiveItems(container, sizeId);
-
-    const panelEl = document.getElementById('gitlab-mr-integrated-review');
-    applyPanelTextSize(panelEl, sizeId);
-    document.dispatchEvent(new CustomEvent('thinkreview:textsizechanged', { detail: { sizeId } }));
 
     if (typeof onSelect === 'function') {
       await onSelect(sizeId);

--- a/components/popup-modules/panel-text-size-widget.js
+++ b/components/popup-modules/panel-text-size-widget.js
@@ -1,0 +1,147 @@
+/**
+ * panel-text-size-widget.js
+ * In-panel text size preference (Small / Medium / Large / Extra large).
+ * Used by the panel settings gear submenu.
+ */
+
+import { dbgWarn } from '../../utils/logger.js';
+
+const _cssURL = chrome.runtime.getURL('components/popup-modules/panel-text-size-widget.css');
+if (!document.querySelector(`link[href="${_cssURL}"]`)) {
+  const _link = document.createElement('link');
+  _link.rel = 'stylesheet';
+  _link.href = _cssURL;
+  document.head.appendChild(_link);
+}
+
+export const PANEL_TEXT_SIZE_STORAGE_KEY = 'panelTextSize';
+
+export const TEXT_SIZE_OPTIONS = [
+  { id: 'small', label: 'Small', zoom: 0.875 },
+  { id: 'medium', label: 'Medium', zoom: 1 },
+  { id: 'large', label: 'Large', zoom: 1.125 },
+  { id: 'x-large', label: 'Extra large', zoom: 1.25 }
+];
+
+const DEFAULT_TEXT_SIZE = 'medium';
+
+export async function getPanelTextSize() {
+  try {
+    const result = await chrome.storage.local.get([PANEL_TEXT_SIZE_STORAGE_KEY]);
+    const raw = result[PANEL_TEXT_SIZE_STORAGE_KEY];
+    return TEXT_SIZE_OPTIONS.some((o) => o.id === raw) ? raw : DEFAULT_TEXT_SIZE;
+  } catch (e) {
+    dbgWarn('Failed to load panel text size:', e);
+    return DEFAULT_TEXT_SIZE;
+  }
+}
+
+export async function savePanelTextSize(sizeId) {
+  const option = TEXT_SIZE_OPTIONS.find((o) => o.id === sizeId);
+  if (!option) return;
+  await chrome.storage.local.set({ [PANEL_TEXT_SIZE_STORAGE_KEY]: option.id });
+}
+
+export function getPanelTextSizeLabel(sizeId) {
+  const option = TEXT_SIZE_OPTIONS.find((o) => o.id === sizeId);
+  return option ? option.label : 'Medium';
+}
+
+export function getPanelTextSizeZoom(sizeId) {
+  const option = TEXT_SIZE_OPTIONS.find((o) => o.id === sizeId);
+  return option ? option.zoom : 1;
+}
+
+/**
+ * Apply text size to the integrated review panel root element.
+ * @param {HTMLElement | null | undefined} panelEl
+ * @param {string} sizeId
+ */
+export function applyPanelTextSize(panelEl, sizeId) {
+  if (!panelEl) return;
+  const option = TEXT_SIZE_OPTIONS.find((o) => o.id === sizeId) || TEXT_SIZE_OPTIONS[1];
+  panelEl.dataset.panelTextSize = option.id;
+  panelEl.style.setProperty('--thinkreview-text-zoom', String(option.zoom));
+}
+
+/**
+ * Fill a container with text size options (settings submenu).
+ * @param {HTMLElement} container
+ * @param {{ activeId?: string, onSelect?: (sizeId: string) => void | Promise<void> }} [options]
+ */
+export function populateTextSizeOptions(container, options = {}) {
+  const { activeId = DEFAULT_TEXT_SIZE, onSelect } = options;
+  container.replaceChildren();
+
+  const label = document.createElement('div');
+  label.className = 'thinkreview-text-size-section-label';
+  label.textContent = 'Text size';
+  container.appendChild(label);
+
+  for (const option of TEXT_SIZE_OPTIONS) {
+    const item = document.createElement('button');
+    item.type = 'button';
+    item.className = `thinkreview-text-size-item${option.id === activeId ? ' active' : ''}`;
+    item.dataset.textSize = option.id;
+    item.setAttribute('role', 'menuitem');
+
+    const preview = document.createElement('span');
+    preview.className = 'thinkreview-text-size-preview';
+    preview.textContent = 'Aa';
+    preview.style.fontSize = `${Math.round(14 * option.zoom)}px`;
+
+    const text = document.createElement('span');
+    text.className = 'thinkreview-text-size-item-label';
+    text.textContent = option.label;
+
+    item.appendChild(preview);
+    item.appendChild(text);
+
+    if (option.id === activeId) {
+      const check = document.createElement('span');
+      check.className = 'thinkreview-text-size-item-check';
+      check.setAttribute('aria-label', 'active');
+      check.textContent = '✓';
+      item.appendChild(check);
+    }
+
+    container.appendChild(item);
+  }
+
+  container.addEventListener('click', async (e) => {
+    e.stopPropagation();
+    const item = e.target.closest('.thinkreview-text-size-item');
+    if (!item) return;
+
+    const sizeId = item.dataset.textSize;
+    if (!sizeId || item.classList.contains('active')) return;
+
+    await savePanelTextSize(sizeId);
+    refreshTextSizeActiveItems(container, sizeId);
+
+    const panelEl = document.getElementById('gitlab-mr-integrated-review');
+    applyPanelTextSize(panelEl, sizeId);
+    document.dispatchEvent(new CustomEvent('thinkreview:textsizechanged', { detail: { sizeId } }));
+
+    if (typeof onSelect === 'function') {
+      await onSelect(sizeId);
+    }
+  });
+}
+
+export function refreshTextSizeActiveItems(container, activeId) {
+  container.querySelectorAll('.thinkreview-text-size-item').forEach((item) => {
+    const isActive = item.dataset.textSize === activeId;
+    item.classList.toggle('active', isActive);
+    let check = item.querySelector('.thinkreview-text-size-item-check');
+    if (isActive && !check) {
+      check = document.createElement('span');
+      check.className = 'thinkreview-text-size-item-check';
+      check.setAttribute('aria-label', 'active');
+      check.textContent = '✓';
+      item.appendChild(check);
+    } else if (!isActive && check) {
+      check.remove();
+    }
+  });
+}

--- a/content.js
+++ b/content.js
@@ -1476,7 +1476,11 @@ async function fetchAndDisplayCodeReview(forceRegenerate = false, isAutoTriggere
     // PR changed while we were fetching — do not call the cloud or update UI for the old PR
     if (sessionAtStart !== reviewSessionId) {
       dbgLog('Review session invalidated after patch fetch (PR changed); aborting');
-      dismissIntegratedReviewLoadingUI();
+      try {
+        dismissIntegratedReviewLoadingUI();
+      } catch (error) {
+        dbgLog('Failed to dismiss loading UI after session invalidation:', error);
+      }
       return;
     }
 
@@ -1486,7 +1490,11 @@ async function fetchAndDisplayCodeReview(forceRegenerate = false, isAutoTriggere
       const decision = shouldProceedWithAutoReview(filteredCodeContent, { platform, mrId: reviewId });
       if (!decision.proceed) {
         dbgLog('Auto review skipped by autoReviewDecisionMaker:', decision.reason, decision.details);
-        dismissIntegratedReviewLoadingUI();
+        try {
+          dismissIntegratedReviewLoadingUI();
+        } catch (error) {
+          dbgLog('Failed to dismiss loading UI after auto review skip:', error);
+        }
         return;
       }
     }

--- a/content.js
+++ b/content.js
@@ -2101,3 +2101,16 @@ document.addEventListener('thinkreview:panelminimized', () => {
     panel.classList.remove('thinkreview-panel-docked', 'thinkreview-panel-docked-left');
   }
 });
+
+chrome.storage.onChanged.addListener(async (changes, area) => {
+  if (area !== 'local' || !changes.panelTextSize) return;
+  const panel = document.getElementById('gitlab-mr-integrated-review');
+  if (!panel) return;
+  try {
+    const textSizeUrl = chrome.runtime.getURL('components/popup-modules/panel-text-size-widget.js');
+    const { applyPanelTextSize } = await import(textSizeUrl);
+    applyPanelTextSize(panel, changes.panelTextSize.newValue || 'medium');
+  } catch (e) {
+    dbgWarn('Failed to apply panel text size from storage:', e);
+  }
+});


### PR DESCRIPTION
- Re-enabled the previously hidden helpful-tip banner with real HTML markup and settings/usage buttons.
- Added a new panel text-size preference feature (small/medium/large/x-large), including a new widget module, CSS, and integration into the settings menu and CSS zoom variable.
- Removed the standalone patch-viewer.html/js/css files and their manifest web_accessible_resources entries, consolidating review UI into the integrated panel.
- Re-enabled the 'Start review automatically' toggle in popup.html/popup.js (previously hidden) and removed the TEMP_FORCE_MANUAL_REVIEW_ONLY override in content.js.
- Introduced a reviewSessionId mechanism in content.js to invalidate in-flight/pending reviews on PR navigation, preventing stale review results and race conditions.
- Added a defensive type-check in autoReviewDecisionMaker.js guarding against non-string patch content.
- Added chrome.storage.onChanged listener to reactively apply text-size changes across tabs.