### PR TITLE
Feature/user friendly prompts

### DIFF
--- a/background.js
+++ b/background.js
@@ -1436,11 +1436,13 @@ async function updateContentScripts() {
         }
         
         // Prepare script configuration
+        // content.js first so the ThinkReview trigger can inject before the heavy panel bundle parses.
+        // document_end: don't wait for full page idle (images/network) before showing the button.
         const scriptConfig = {
           id: scriptId,
           matches: [matchPattern],
-          js: ['vendor/honeybadger.ext.min.js', 'vendor/diff.min.js', 'components/integrated-review.js', 'content.js'],
-          runAt: 'document_idle'
+          js: ['vendor/honeybadger.ext.min.js', 'content.js', 'vendor/diff.min.js', 'components/integrated-review.js'],
+          runAt: 'document_end'
         };
         
         if (scriptExists) {

--- a/components/google-signin/google-signin.js
+++ b/components/google-signin/google-signin.js
@@ -16,6 +16,108 @@ function escapeHtml(str) {
     .replace(/'/g, '&#39;');
 }
 
+/**
+ * Friendly toast in the popup (avoids native alert).
+ * @param {string} text
+ * @param {'info'|'error'|'success'} [type]
+ */
+function showSignInToast(text, type = 'error') {
+  const existing = document.getElementById('thinkreview-signin-toast');
+  if (existing) existing.remove();
+
+  const colors = {
+    success: { bg: '#166534', border: '#22c55e' },
+    error: { bg: '#7f1d1d', border: '#ef4444' },
+    info: { bg: '#1a1628', border: '#6b4fbb' },
+  };
+  const palette = colors[type] || colors.info;
+
+  const toast = document.createElement('div');
+  toast.id = 'thinkreview-signin-toast';
+  toast.setAttribute('role', 'status');
+  toast.style.cssText = `
+    position: fixed; top: 12px; left: 50%; transform: translateX(-50%);
+    background: ${palette.bg}; border: 1px solid ${palette.border}; color: #fff;
+    padding: 10px 14px; border-radius: 8px; font-size: 12px; line-height: 1.4;
+    z-index: 10000; max-width: calc(100% - 24px); text-align: center;
+    box-shadow: 0 6px 20px rgba(0,0,0,0.35);
+  `;
+  toast.textContent = text;
+  document.body.appendChild(toast);
+  setTimeout(() => {
+    if (toast.parentNode) {
+      toast.style.transition = 'opacity 0.2s ease-out';
+      toast.style.opacity = '0';
+      setTimeout(() => toast.remove(), 200);
+    }
+  }, 4000);
+}
+
+/**
+ * Friendly confirm overlay (avoids native confirm).
+ * @param {string} text
+ * @param {{ confirmLabel?: string, cancelLabel?: string }} [options]
+ * @returns {Promise<boolean>}
+ */
+function showSignInConfirm(text, options = {}) {
+  const confirmLabel = options.confirmLabel || 'OK';
+  const cancelLabel = options.cancelLabel || 'Cancel';
+  return new Promise((resolve) => {
+    const existing = document.getElementById('thinkreview-signin-confirm');
+    if (existing) existing.remove();
+
+    const overlay = document.createElement('div');
+    overlay.id = 'thinkreview-signin-confirm';
+    overlay.style.cssText = `
+      position: fixed; inset: 0; z-index: 10001; background: rgba(0,0,0,0.45);
+      display: flex; align-items: center; justify-content: center; padding: 16px;
+    `;
+
+    const dialog = document.createElement('div');
+    dialog.setAttribute('role', 'dialog');
+    dialog.style.cssText = `
+      background: #1a1628; border: 1px solid #3d2d6e; border-radius: 10px;
+      padding: 16px; max-width: 300px; width: 100%; color: #fff;
+      box-shadow: 0 8px 24px rgba(0,0,0,0.45);
+    `;
+
+    const msg = document.createElement('p');
+    msg.style.cssText = 'margin: 0 0 14px; font-size: 13px; line-height: 1.45; color: rgba(255,255,255,0.9); white-space: pre-line;';
+    msg.textContent = text;
+    dialog.appendChild(msg);
+
+    const actions = document.createElement('div');
+    actions.style.cssText = 'display: flex; gap: 8px; justify-content: flex-end; flex-wrap: wrap;';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.type = 'button';
+    cancelBtn.textContent = cancelLabel;
+    cancelBtn.style.cssText = 'padding: 6px 12px; border-radius: 6px; border: 1px solid #3d2d6e; background: transparent; color: rgba(255,255,255,0.85); cursor: pointer; font-size: 12px;';
+
+    const okBtn = document.createElement('button');
+    okBtn.type = 'button';
+    okBtn.textContent = confirmLabel;
+    okBtn.style.cssText = 'padding: 6px 12px; border-radius: 6px; border: none; background: #6b4fbb; color: #fff; cursor: pointer; font-size: 12px; font-weight: 500;';
+
+    const finish = (value) => {
+      overlay.remove();
+      resolve(value);
+    };
+    cancelBtn.addEventListener('click', () => finish(false));
+    okBtn.addEventListener('click', () => finish(true));
+    overlay.addEventListener('click', (e) => {
+      if (e.target === overlay) finish(false);
+    });
+
+    actions.appendChild(cancelBtn);
+    actions.appendChild(okBtn);
+    dialog.appendChild(actions);
+    overlay.appendChild(dialog);
+    document.body.appendChild(overlay);
+    okBtn.focus();
+  });
+}
+
 async function loadCloudService() {
   try {
     const module = await import('../../services/cloud-service.js');
@@ -406,7 +508,7 @@ class GoogleSignIn extends HTMLElement {
       this.render();
       
       // Show user-friendly error
-      alert('Login failed: ' + (error.message || 'Unknown error'));
+      showSignInToast('Sign-in failed: ' + (error.message || 'Unknown error'), 'error');
       
       // Dispatch error event
       this.dispatchEvent(new CustomEvent('signin-error', {
@@ -459,10 +561,9 @@ class GoogleSignIn extends HTMLElement {
         this.render();
         
         // Show user-friendly error asking to report bug
-        const userConfirmed = confirm(
-          'Sign-in failed: Both portal sign-in and fallback authentication failed.\n\n' +
-          'Please help us fix this by reporting the issue.\n\n' +
-          'Click OK to open the bug report page, or Cancel to dismiss.'
+        const userConfirmed = await showSignInConfirm(
+          'Sign-in failed. Please help us fix this by reporting the issue.',
+          { confirmLabel: 'Report issue', cancelLabel: 'Dismiss' }
         );
         
         if (userConfirmed) {

--- a/components/integrated-review.css
+++ b/components/integrated-review.css
@@ -8,7 +8,7 @@
   --thinkreview-border-light: rgba(255, 255, 255, 0.1);
 
   /* Panel width for body margin when docked (synced with resize) */
-  --thinkreview-panel-width: 520px;
+  --thinkreview-panel-width: 580px;
 
   /* Panel vertical positioning: top offset and bottom gap define max-height.
      Bottom gap keeps a small buffer above the floating ThinkReview button. */
@@ -46,7 +46,8 @@
   position: fixed;
   right: 20px;
   top: var(--thinkreview-panel-top);
-  width: 500px;
+  width: 580px;
+  min-width: 560px;
   max-width: 90vw;
   /* Use a fixed height so the panel doesn't resize vertically
      when switching between tabs or when content height changes */
@@ -67,7 +68,8 @@
   position: fixed;
   right: 20px;
   top: var(--thinkreview-panel-top);
-  width: 500px;
+  width: 580px;
+  min-width: 560px;
   max-width: 90vw;
   /* Legacy selector: keep height in sync with main container rule above */
   height: var(--thinkreview-panel-max-height);
@@ -200,6 +202,7 @@
   align-items: center;
   gap: 8px;
   margin-top: -8px;
+  flex-shrink: 0;
 }
 
 #gitlab-mr-integrated-review .thinkreview-language-dropdown {
@@ -1032,6 +1035,7 @@ body[data-theme="high-contrast"] #gitlab-mr-integrated-review .thinkreview-table
   position: relative;
   display: inline-flex;
   margin-right: 4px;
+  flex-shrink: 0;
 }
 
 #gitlab-mr-integrated-review .thinkreview-settings-tooltip {

--- a/components/integrated-review.js
+++ b/components/integrated-review.js
@@ -1076,7 +1076,8 @@ function detectAzureDevOpsTheme() {
   return 'light';
 }
 
-const INTEGRATED_REVIEW_PANEL_RESIZE_MIN_WIDTH_PX = 400;
+// Wide enough for regenerate + text size + language + review format + settings in the header
+const INTEGRATED_REVIEW_PANEL_RESIZE_MIN_WIDTH_PX = 560;
 const INTEGRATED_REVIEW_PANEL_RESIZE_MAX_WIDTH_PX = 800;
 
 /**
@@ -1095,11 +1096,20 @@ function initializeResizeHandle(container) {
   chrome.storage.local.get(['gitlab-mr-review-width'], (result) => {
     const savedWidth = result['gitlab-mr-review-width'];
     if (savedWidth != null && savedWidth !== '' && !container.classList.contains('minimized')) {
-      const widthPx = (typeof savedWidth === 'number' ? savedWidth : parseInt(savedWidth, 10)) + 'px';
-      if (!isNaN(parseInt(savedWidth, 10))) {
+      const parsed = typeof savedWidth === 'number' ? savedWidth : parseInt(savedWidth, 10);
+      if (!isNaN(parsed)) {
+        const clamped = Math.max(
+          INTEGRATED_REVIEW_PANEL_RESIZE_MIN_WIDTH_PX,
+          Math.min(INTEGRATED_REVIEW_PANEL_RESIZE_MAX_WIDTH_PX, parsed)
+        );
+        const widthPx = `${clamped}px`;
         container.style.width = widthPx;
         if (container.classList.contains('thinkreview-panel-docked')) {
           document.documentElement.style.setProperty('--thinkreview-panel-width', widthPx);
+        }
+        // Persist if an older narrow width was upgraded to the new minimum
+        if (clamped !== parsed) {
+          chrome.storage.local.set({ 'gitlab-mr-review-width': clamped });
         }
       }
     }

--- a/components/integrated-review.js
+++ b/components/integrated-review.js
@@ -953,6 +953,15 @@ async function createIntegratedReviewPanel(patchUrl) {
     dbgWarn('Failed to apply panel text size preference:', error);
   }
 
+  // First-open interactive tour of panel settings (runs once when the panel is expanded)
+  try {
+    const tourUrl = chrome.runtime.getURL('components/popup-modules/panel-settings-tour.js');
+    const { maybeStartPanelSettingsTour } = await import(tourUrl);
+    maybeStartPanelSettingsTour(container).catch(() => {});
+  } catch (error) {
+    dbgWarn('Failed to start panel settings tour:', error);
+  }
+
   return container;
 }
 

--- a/components/popup-modules/panel-settings-menu-widget.js
+++ b/components/popup-modules/panel-settings-menu-widget.js
@@ -534,11 +534,7 @@ export async function mountPanelSettingsMenu(settingsButton, options = {}) {
       if (valueEl) valueEl.textContent = getLayoutComboSummary(settings);
       // Keep the layout picker open during the first-open tour so the spotlight can follow
       if (document.documentElement.hasAttribute('data-thinkreview-tour-active')) {
-        requestAnimationFrame(() => {
-          reposition();
-          setTimeout(reposition, 50);
-          setTimeout(reposition, 320);
-        });
+        scheduleRepositionAfterLayoutChange();
         return;
       }
       _closeAll();
@@ -813,16 +809,69 @@ export async function mountPanelSettingsMenu(settingsButton, options = {}) {
     if (openSubmenu === 'text-size') _positionSubmenu(textSizeSub, textSizeRow, 220);
     if (openSubmenu === 'buy-credits') _positionSubmenu(creditsSub, buyCreditsRow, 280);
   };
-  window.addEventListener('scroll', reposition, { passive: true });
-  window.addEventListener('resize', reposition, { passive: true });
+
+  // Coalesce layout reads/writes to at most once per animation frame
+  let repositionRaf = 0;
+  let layoutFollowUpTimer = 0;
+  /** @type {((e: TransitionEvent) => void) | null} */
+  let layoutTransitionHandler = null;
+
+  const scheduleReposition = () => {
+    if (repositionRaf) return;
+    repositionRaf = requestAnimationFrame(() => {
+      repositionRaf = 0;
+      reposition();
+    });
+  };
+
+  const clearLayoutFollowUp = () => {
+    clearTimeout(layoutFollowUpTimer);
+    layoutFollowUpTimer = 0;
+    if (layoutTransitionHandler) {
+      document
+        .getElementById('gitlab-mr-integrated-review')
+        ?.removeEventListener('transitionend', layoutTransitionHandler);
+      layoutTransitionHandler = null;
+    }
+  };
+
+  /**
+   * After a layout change: one rAF pass now, then one follow-up when the panel's
+   * CSS transition ends (fallback timeout matches the 0.5s right/width transition).
+   */
+  const scheduleRepositionAfterLayoutChange = () => {
+    if (main.style.display === 'none') return;
+    scheduleReposition();
+
+    clearLayoutFollowUp();
+    const panel = document.getElementById('gitlab-mr-integrated-review');
+    if (panel) {
+      layoutTransitionHandler = (e) => {
+        if (e.target !== panel) return;
+        if (e.propertyName !== 'right' && e.propertyName !== 'left' && e.propertyName !== 'width') {
+          return;
+        }
+        clearLayoutFollowUp();
+        scheduleReposition();
+      };
+      panel.addEventListener('transitionend', layoutTransitionHandler);
+    }
+
+    layoutFollowUpTimer = setTimeout(() => {
+      layoutFollowUpTimer = 0;
+      if (layoutTransitionHandler) {
+        panel?.removeEventListener('transitionend', layoutTransitionHandler);
+        layoutTransitionHandler = null;
+      }
+      scheduleReposition();
+    }, 520);
+  };
+
+  window.addEventListener('scroll', scheduleReposition, { passive: true });
+  window.addEventListener('resize', scheduleReposition, { passive: true });
 
   const onLayoutChanged = () => {
-    if (main.style.display === 'none') return;
-    requestAnimationFrame(() => {
-      reposition();
-      setTimeout(reposition, 50);
-      setTimeout(reposition, 320);
-    });
+    scheduleRepositionAfterLayoutChange();
   };
   document.addEventListener('thinkreview:layoutchanged', onLayoutChanged);
 
@@ -835,7 +884,9 @@ export async function mountPanelSettingsMenu(settingsButton, options = {}) {
     openSubmenu: _openSubmenu,
     closeSubmenus: _closeSubmenus,
     closeAll: _closeAll,
-    reposition
+    reposition,
+    scheduleReposition,
+    scheduleRepositionAfterLayoutChange
   };
   // Used by the first-open panel settings tour
   settingsButton.__thinkreviewSettingsMenuApi = menuApi;
@@ -847,8 +898,13 @@ export async function mountPanelSettingsMenu(settingsButton, options = {}) {
     document.removeEventListener('click', onDocumentClick);
     document.removeEventListener('thinkreview:layoutchanged', onLayoutChanged);
     chrome.storage.onChanged.removeListener(onStorageChanged);
-    window.removeEventListener('scroll', reposition);
-    window.removeEventListener('resize', reposition);
+    window.removeEventListener('scroll', scheduleReposition);
+    window.removeEventListener('resize', scheduleReposition);
+    if (repositionRaf) {
+      cancelAnimationFrame(repositionRaf);
+      repositionRaf = 0;
+    }
+    clearLayoutFollowUp();
     if (settingsButton.__thinkreviewSettingsMenuApi === menuApi) {
       delete settingsButton.__thinkreviewSettingsMenuApi;
     }

--- a/components/popup-modules/panel-settings-menu-widget.js
+++ b/components/popup-modules/panel-settings-menu-widget.js
@@ -532,6 +532,15 @@ export async function mountPanelSettingsMenu(settingsButton, options = {}) {
     onSelect: async (settings) => {
       const valueEl = layoutRow.querySelector('[data-menu-value="layout"]');
       if (valueEl) valueEl.textContent = getLayoutComboSummary(settings);
+      // Keep the layout picker open during the first-open tour so the spotlight can follow
+      if (document.documentElement.hasAttribute('data-thinkreview-tour-active')) {
+        requestAnimationFrame(() => {
+          reposition();
+          setTimeout(reposition, 50);
+          setTimeout(reposition, 320);
+        });
+        return;
+      }
       _closeAll();
     }
   });
@@ -807,6 +816,16 @@ export async function mountPanelSettingsMenu(settingsButton, options = {}) {
   window.addEventListener('scroll', reposition, { passive: true });
   window.addEventListener('resize', reposition, { passive: true });
 
+  const onLayoutChanged = () => {
+    if (main.style.display === 'none') return;
+    requestAnimationFrame(() => {
+      reposition();
+      setTimeout(reposition, 50);
+      setTimeout(reposition, 320);
+    });
+  };
+  document.addEventListener('thinkreview:layoutchanged', onLayoutChanged);
+
   // Keep tooltip text in sync with inclusive menu
   const tooltip = options.settingsWrapper?.querySelector('.thinkreview-settings-tooltip');
   if (tooltip) tooltip.textContent = 'Settings';
@@ -815,7 +834,8 @@ export async function mountPanelSettingsMenu(settingsButton, options = {}) {
     openMain: _openMain,
     openSubmenu: _openSubmenu,
     closeSubmenus: _closeSubmenus,
-    closeAll: _closeAll
+    closeAll: _closeAll,
+    reposition
   };
   // Used by the first-open panel settings tour
   settingsButton.__thinkreviewSettingsMenuApi = menuApi;
@@ -825,6 +845,7 @@ export async function mountPanelSettingsMenu(settingsButton, options = {}) {
     if (destroyed) return;
     destroyed = true;
     document.removeEventListener('click', onDocumentClick);
+    document.removeEventListener('thinkreview:layoutchanged', onLayoutChanged);
     chrome.storage.onChanged.removeListener(onStorageChanged);
     window.removeEventListener('scroll', reposition);
     window.removeEventListener('resize', reposition);

--- a/components/popup-modules/panel-settings-menu-widget.js
+++ b/components/popup-modules/panel-settings-menu-widget.js
@@ -765,6 +765,10 @@ export async function mountPanelSettingsMenu(settingsButton, options = {}) {
   });
 
   const onDocumentClick = (e) => {
+    // Keep menus open while the first-open settings tour is driving them
+    if (document.documentElement.hasAttribute('data-thinkreview-tour-active')) {
+      return;
+    }
     const t = /** @type {Node} */ (e.target);
     if (
       t === settingsButton ||
@@ -773,7 +777,9 @@ export async function mountPanelSettingsMenu(settingsButton, options = {}) {
       layoutSub.contains(t) ||
       ideSub.contains(t) ||
       textSizeSub.contains(t) ||
-      creditsSub.contains(t)
+      creditsSub.contains(t) ||
+      (t instanceof Element && t.closest('#thinkreview-panel-settings-tour')) ||
+      (t instanceof Element && t.closest('#thinkreview-panel-settings-tour-card'))
     ) {
       return;
     }
@@ -805,6 +811,15 @@ export async function mountPanelSettingsMenu(settingsButton, options = {}) {
   const tooltip = options.settingsWrapper?.querySelector('.thinkreview-settings-tooltip');
   if (tooltip) tooltip.textContent = 'Settings';
 
+  const menuApi = {
+    openMain: _openMain,
+    openSubmenu: _openSubmenu,
+    closeSubmenus: _closeSubmenus,
+    closeAll: _closeAll
+  };
+  // Used by the first-open panel settings tour
+  settingsButton.__thinkreviewSettingsMenuApi = menuApi;
+
   let destroyed = false;
   function _destroy() {
     if (destroyed) return;
@@ -813,6 +828,9 @@ export async function mountPanelSettingsMenu(settingsButton, options = {}) {
     chrome.storage.onChanged.removeListener(onStorageChanged);
     window.removeEventListener('scroll', reposition);
     window.removeEventListener('resize', reposition);
+    if (settingsButton.__thinkreviewSettingsMenuApi === menuApi) {
+      delete settingsButton.__thinkreviewSettingsMenuApi;
+    }
     main.remove();
     layoutSub.remove();
     ideSub.remove();
@@ -835,5 +853,5 @@ export async function mountPanelSettingsMenu(settingsButton, options = {}) {
     panelObserver.observe(panelEl.parentNode, { childList: true });
   }
 
-  return { destroy: _destroy };
+  return { destroy: _destroy, ...menuApi };
 }

--- a/components/popup-modules/panel-settings-tour.css
+++ b/components/popup-modules/panel-settings-tour.css
@@ -1,0 +1,169 @@
+/* First-open interactive tour for panel settings */
+
+#thinkreview-panel-settings-tour {
+  position: fixed;
+  inset: 0;
+  z-index: 2147483645;
+  pointer-events: none;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+.thinkreview-tour-blocker {
+  position: fixed;
+  inset: 0;
+  pointer-events: auto;
+  background: transparent;
+  z-index: 0;
+}
+
+.thinkreview-tour-spotlight {
+  position: fixed;
+  border-radius: 8px;
+  box-shadow:
+    0 0 0 2px #9b7ef0,
+    0 0 0 6px rgba(155, 126, 240, 0.28),
+    0 0 0 9999px rgba(10, 8, 20, 0.55);
+  pointer-events: none;
+  transition: top 0.22s ease, left 0.22s ease, width 0.22s ease, height 0.22s ease;
+  z-index: 1;
+}
+
+.thinkreview-tour-card {
+  position: fixed;
+  width: min(320px, calc(100vw - 24px));
+  background: #1a1628;
+  border: 1px solid #3d2d6e;
+  border-radius: 12px;
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.55), 0 2px 10px rgba(0, 0, 0, 0.35);
+  color: #fff;
+  padding: 16px 16px 14px;
+  pointer-events: auto;
+  z-index: 2147483647;
+  animation: thinkreview-tour-card-in 0.18s ease;
+}
+
+/* Keep highlighted controls / open menus above the tour dim */
+.thinkreview-tour-raised {
+  z-index: 2147483646 !important;
+}
+
+.thinkreview-tour-target-pulse {
+  outline: 2px solid #9b7ef0 !important;
+  outline-offset: 2px;
+}
+
+@keyframes thinkreview-tour-card-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.thinkreview-tour-eyebrow {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+  color: rgba(155, 126, 240, 0.85);
+  margin-bottom: 6px;
+}
+
+.thinkreview-tour-title {
+  font-size: 15px;
+  font-weight: 700;
+  line-height: 1.3;
+  margin: 0 0 6px;
+  color: #fff;
+}
+
+.thinkreview-tour-body {
+  font-size: 13px;
+  line-height: 1.45;
+  color: rgba(255, 255, 255, 0.78);
+  margin: 0 0 14px;
+}
+
+.thinkreview-tour-progress {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-bottom: 12px;
+}
+
+.thinkreview-tour-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.22);
+  transition: background 0.15s ease, transform 0.15s ease;
+}
+
+.thinkreview-tour-dot.is-active {
+  background: #9b7ef0;
+  transform: scale(1.2);
+}
+
+.thinkreview-tour-dot.is-done {
+  background: rgba(155, 126, 240, 0.55);
+}
+
+.thinkreview-tour-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.thinkreview-tour-actions-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.thinkreview-tour-btn {
+  appearance: none;
+  border: none;
+  cursor: pointer;
+  border-radius: 7px;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 7px 12px;
+  line-height: 1.2;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+
+.thinkreview-tour-btn-skip {
+  background: transparent;
+  color: rgba(255, 255, 255, 0.55);
+  padding-left: 4px;
+  padding-right: 4px;
+}
+
+.thinkreview-tour-btn-skip:hover {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.thinkreview-tour-btn-secondary {
+  background: transparent;
+  color: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.22);
+}
+
+.thinkreview-tour-btn-secondary:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.thinkreview-tour-btn-primary {
+  background: #6b4fbb;
+  color: #fff;
+  border: 1px solid #6b4fbb;
+}
+
+.thinkreview-tour-btn-primary:hover {
+  background: #7d61d0;
+  border-color: #7d61d0;
+}

--- a/components/popup-modules/panel-settings-tour.js
+++ b/components/popup-modules/panel-settings-tour.js
@@ -409,6 +409,7 @@ function _runTour(panelEl) {
     document.documentElement.removeAttribute(PANEL_SETTINGS_TOUR_ACTIVE_ATTR);
     window.removeEventListener('resize', onReposition);
     window.removeEventListener('scroll', onReposition, true);
+    document.removeEventListener('thinkreview:layoutchanged', onLayoutChanged);
     root.remove();
     card.remove();
     await _markSeen();
@@ -425,6 +426,71 @@ function _runTour(panelEl) {
     }
     const target = await step.getTarget();
     return target instanceof Element ? target : null;
+  };
+
+  const applyHighlight = (step, target) => {
+    const formatDropdown = document.getElementById('thinkreview-review-format-dropdown');
+    const settingsDropdown = document.getElementById('thinkreview-settings-dropdown');
+    const layoutSubmenu = document.getElementById('thinkreview-settings-layout-submenu');
+
+    const extraRaise = [];
+    if (step.id === 'review-format' && formatDropdown?.style.display !== 'none') {
+      extraRaise.push(formatDropdown);
+    }
+    if (
+      (step.id === 'settings-menu' || step.id === 'layout' || step.id === 'auto-start') &&
+      settingsDropdown?.style.display !== 'none'
+    ) {
+      extraRaise.push(settingsDropdown);
+    }
+    if (step.id === 'layout' && layoutSubmenu?.style.display !== 'none') {
+      extraRaise.push(layoutSubmenu);
+    }
+
+    clearHighlight();
+    if (target) {
+      highlightedEl = target;
+      target.classList.add('thinkreview-tour-target-pulse');
+      raiseEls(target, ...extraRaise);
+      const rect =
+        unionRect(target, ...extraRaise) || target.getBoundingClientRect();
+      _positionSpotlight(spotlight, rect);
+      _positionCard(card, rect);
+      spotlight.style.display = 'block';
+    } else {
+      spotlight.style.display = 'none';
+      card.style.top = '72px';
+      card.style.left = `${Math.max(8, window.innerWidth - 340)}px`;
+    }
+  };
+
+  const onReposition = () => {
+    if (!highlightedEl || !document.body.contains(highlightedEl)) return;
+    const api = _getSettingsMenuApi();
+    api?.reposition?.();
+    const rect = unionRect(highlightedEl, ...raisedEls) || highlightedEl.getBoundingClientRect();
+    _positionSpotlight(spotlight, rect);
+    _positionCard(card, rect);
+  };
+
+  /** Follow panel/menu movement after a live layout change (incl. CSS left transition). */
+  const refreshHighlightAfterLayoutChange = async () => {
+    const step = steps[stepIndex];
+    if (!step || !document.getElementById(TOUR_ROOT_ID)) return;
+
+    if (step.id === 'layout') {
+      const target = await _openLayoutSubmenu();
+      applyHighlight(step, target || document.getElementById('thinkreview-settings-layout-submenu'));
+    }
+
+    const bump = () => onReposition();
+    requestAnimationFrame(bump);
+    setTimeout(bump, 50);
+    setTimeout(bump, 320);
+  };
+
+  const onLayoutChanged = () => {
+    refreshHighlightAfterLayoutChange().catch(() => {});
   };
 
   const renderStep = async () => {
@@ -446,54 +512,15 @@ function _runTour(panelEl) {
       dot.classList.toggle('is-done', i < stepIndex);
     });
 
-    clearHighlight();
     const target = await resolveTarget(step);
     if (!document.getElementById(TOUR_ROOT_ID)) return;
 
-    const formatDropdown = document.getElementById('thinkreview-review-format-dropdown');
-    const settingsDropdown = document.getElementById('thinkreview-settings-dropdown');
-    const layoutSubmenu = document.getElementById('thinkreview-settings-layout-submenu');
-
-    const extraRaise = [];
-    if (step.id === 'review-format' && formatDropdown?.style.display !== 'none') {
-      extraRaise.push(formatDropdown);
-    }
-    if (
-      (step.id === 'settings-menu' || step.id === 'layout' || step.id === 'auto-start') &&
-      settingsDropdown?.style.display !== 'none'
-    ) {
-      extraRaise.push(settingsDropdown);
-    }
-    if (step.id === 'layout' && layoutSubmenu?.style.display !== 'none') {
-      extraRaise.push(layoutSubmenu);
-    }
-
-    if (target) {
-      highlightedEl = target;
-      target.classList.add('thinkreview-tour-target-pulse');
-      raiseEls(target, ...extraRaise);
-      const rect =
-        unionRect(target, ...extraRaise) || target.getBoundingClientRect();
-      _positionSpotlight(spotlight, rect);
-      _positionCard(card, rect);
-      spotlight.style.display = 'block';
-    } else {
-      spotlight.style.display = 'none';
-      card.style.top = '72px';
-      card.style.left = `${Math.max(8, window.innerWidth - 340)}px`;
-    }
+    applyHighlight(step, target);
 
     await _track('panel_settings_tour_step_viewed', {
       step_id: step.id,
       step_index: stepIndex
     });
-  };
-
-  const onReposition = () => {
-    if (!highlightedEl || !document.body.contains(highlightedEl)) return;
-    const rect = unionRect(highlightedEl, ...raisedEls) || highlightedEl.getBoundingClientRect();
-    _positionSpotlight(spotlight, rect);
-    _positionCard(card, rect);
   };
 
   skipBtn.addEventListener('click', (e) => {
@@ -525,6 +552,7 @@ function _runTour(panelEl) {
 
   window.addEventListener('resize', onReposition, { passive: true });
   window.addEventListener('scroll', onReposition, true);
+  document.addEventListener('thinkreview:layoutchanged', onLayoutChanged);
 
   _track('panel_settings_tour_started', { step_count: steps.length });
   renderStep();

--- a/components/popup-modules/panel-settings-tour.js
+++ b/components/popup-modules/panel-settings-tour.js
@@ -1,0 +1,572 @@
+/**
+ * First-open interactive tour for integrated panel settings.
+ * Walks through review format, text size, settings gear, layout, and auto-start.
+ */
+
+import { dbgWarn } from '../../utils/logger.js';
+
+const _cssURL = chrome.runtime.getURL('components/popup-modules/panel-settings-tour.css');
+if (!document.querySelector(`link[href="${_cssURL}"]`)) {
+  const _link = document.createElement('link');
+  _link.rel = 'stylesheet';
+  _link.href = _cssURL;
+  document.head.appendChild(_link);
+}
+
+export const PANEL_SETTINGS_TOUR_SEEN_KEY = 'thinkreview-panel-settings-tour-seen';
+export const PANEL_SETTINGS_TOUR_ACTIVE_ATTR = 'data-thinkreview-tour-active';
+
+const TOUR_ROOT_ID = 'thinkreview-panel-settings-tour';
+const PAD = 6;
+
+/** @type {AbortController | null} */
+let _activeAbort = null;
+
+export function isPanelSettingsTourActive() {
+  return document.documentElement.hasAttribute(PANEL_SETTINGS_TOUR_ACTIVE_ATTR);
+}
+
+async function _markSeen() {
+  try {
+    await chrome.storage.local.set({ [PANEL_SETTINGS_TOUR_SEEN_KEY]: true });
+  } catch (e) {
+    dbgWarn('Failed to persist panel settings tour seen flag:', e);
+  }
+}
+
+async function _track(eventName, params = {}) {
+  try {
+    const analyticsModule = await import(chrome.runtime.getURL('utils/analytics-service.js'));
+    await analyticsModule.trackUserAction(eventName, {
+      context: 'panel_settings_tour',
+      ...params
+    });
+  } catch (_) {
+    /* silent */
+  }
+}
+
+function _delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function _waitForPanelExpanded(panelEl, signal) {
+  return new Promise((resolve) => {
+    if (!panelEl) {
+      resolve(false);
+      return;
+    }
+    if (!panelEl.classList.contains('thinkreview-panel-minimized-to-button')) {
+      resolve(true);
+      return;
+    }
+
+    const observer = new MutationObserver(() => {
+      if (!panelEl.classList.contains('thinkreview-panel-minimized-to-button')) {
+        observer.disconnect();
+        resolve(true);
+      }
+    });
+    observer.observe(panelEl, { attributes: true, attributeFilter: ['class'] });
+
+    const onAbort = () => {
+      observer.disconnect();
+      resolve(false);
+    };
+    if (signal) {
+      if (signal.aborted) {
+        onAbort();
+        return;
+      }
+      signal.addEventListener('abort', onAbort, { once: true });
+    }
+  });
+}
+
+function _getSettingsMenuApi() {
+  const btn = document.getElementById('thinkreview-settings-btn');
+  return btn?.__thinkreviewSettingsMenuApi || null;
+}
+
+function _closeMenusQuietly() {
+  const api = _getSettingsMenuApi();
+  api?.closeAll?.();
+  const formatBtn = document.getElementById('thinkreview-review-format-btn');
+  const formatDropdown = document.getElementById('thinkreview-review-format-dropdown');
+  if (formatDropdown) formatDropdown.style.display = 'none';
+  if (formatBtn) formatBtn.setAttribute('aria-expanded', 'false');
+}
+
+async function _openFormatDropdown() {
+  const btn = document.getElementById('thinkreview-review-format-btn');
+  const dropdown = document.getElementById('thinkreview-review-format-dropdown');
+  if (!btn || !dropdown) return null;
+  if (dropdown.style.display === 'none' || !dropdown.style.display) {
+    btn.click();
+    await _delay(40);
+  }
+  return btn;
+}
+
+async function _openSettingsMain() {
+  const api = _getSettingsMenuApi();
+  if (!api?.openMain) return null;
+  const dropdown = document.getElementById('thinkreview-settings-dropdown');
+  if (!dropdown || dropdown.style.display === 'none') {
+    await api.openMain();
+    await _delay(40);
+  }
+  return document.getElementById('thinkreview-settings-btn');
+}
+
+async function _openLayoutSubmenu() {
+  const api = _getSettingsMenuApi();
+  if (!api) return null;
+  await _openSettingsMain();
+  api.closeSubmenus?.();
+  await api.openSubmenu('layout');
+  await _delay(40);
+  return document.querySelector('[data-menu-action="layout"]');
+}
+
+function _buildSteps(panelEl) {
+  const hasFormat = !!document.getElementById('thinkreview-review-format-btn');
+
+  /** @type {Array<{ id: string, title: string, body: string, getTarget: () => (Element | null | Promise<Element | null>), before?: () => Promise<void> }>} */
+  const steps = [
+    {
+      id: 'welcome',
+      title: 'Customize your review panel',
+      body: 'Take a quick tour of the controls in the header — review format, text size, layout, and more.',
+      getTarget: () =>
+        panelEl.querySelector('.thinkreview-header-actions') ||
+        panelEl.querySelector('.thinkreview-card-header'),
+      before: async () => {
+        _closeMenusQuietly();
+      }
+    },
+    {
+      id: 'regenerate',
+      title: 'Regenerate review',
+      body: 'ThinkReview detects PR changes automatically. Use refresh when you want a second pass or to re-run with a different model.',
+      getTarget: () =>
+        panelEl.querySelector('#regenerate-review-btn') ||
+        panelEl.querySelector('.thinkreview-regenerate-btn-wrapper'),
+      before: async () => {
+        _closeMenusQuietly();
+      }
+    },
+    {
+      id: 'text-size',
+      title: 'Adjust text size',
+      body: 'Use − / + to make review text smaller or larger. The size is saved for next time.',
+      getTarget: () => panelEl.querySelector('.thinkreview-text-size-controls'),
+      before: async () => {
+        _closeMenusQuietly();
+      }
+    },
+    {
+      id: 'language',
+      title: 'Review language',
+      body: 'Choose the language for the AI review. The review is written in the language you select here.',
+      getTarget: () => panelEl.querySelector('#language-selector'),
+      before: async () => {
+        _closeMenusQuietly();
+      }
+    }
+  ];
+
+  if (hasFormat) {
+    steps.push({
+      id: 'review-format',
+      title: 'Scoring or severity',
+      body: 'Switch between a scorecard review and a severity layout (critical / high / low issues). Pick what fits your workflow — you can change it anytime.',
+      getTarget: async () => {
+        await _openFormatDropdown();
+        return document.getElementById('thinkreview-review-format-btn');
+      },
+      before: async () => {
+        const api = _getSettingsMenuApi();
+        api?.closeAll?.();
+      }
+    });
+  }
+
+  steps.push(
+    {
+      id: 'settings-menu',
+      title: 'Open Settings',
+      body: 'The gear menu holds layout, implement-via IDE, text size, auto-start, credits, and portal links.',
+      getTarget: async () => {
+        await _openSettingsMain();
+        return document.getElementById('thinkreview-settings-btn');
+      },
+      before: async () => {
+        const formatDropdown = document.getElementById('thinkreview-review-format-dropdown');
+        const formatBtn = document.getElementById('thinkreview-review-format-btn');
+        if (formatDropdown) formatDropdown.style.display = 'none';
+        if (formatBtn) formatBtn.setAttribute('aria-expanded', 'false');
+      }
+    },
+    {
+      id: 'layout',
+      title: 'Choose a layout',
+      body: 'Floating, sidebar tab, or docked — left or right. Try a layout that keeps the PR readable while you review.',
+      getTarget: async () => {
+        const row = await _openLayoutSubmenu();
+        return row || document.getElementById('thinkreview-settings-layout-submenu');
+      }
+    },
+    {
+      id: 'auto-start',
+      title: 'Auto-start reviews',
+      body: 'When on, ThinkReview starts reviewing as you open a PR. Turn it off if you prefer to start reviews manually.',
+      getTarget: async () => {
+        await _openSettingsMain();
+        const api = _getSettingsMenuApi();
+        api?.closeSubmenus?.();
+        await _delay(30);
+        return document.querySelector('[data-menu-action="auto-start-review"]');
+      }
+    },
+    {
+      id: 'done',
+      title: "You're all set",
+      body: 'Explore the rest of the settings anytime from the gear. You can reopen full extension settings from the bottom of that menu.',
+      getTarget: () => document.getElementById('thinkreview-settings-btn'),
+      before: async () => {
+        _closeMenusQuietly();
+      }
+    }
+  );
+
+  return steps;
+}
+
+function _positionCard(card, targetRect) {
+  const cardW = card.offsetWidth || 320;
+  const cardH = card.offsetHeight || 180;
+  const gap = 12;
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+
+  let top = targetRect.bottom + gap;
+  let left = Math.min(Math.max(8, targetRect.right - cardW), vw - cardW - 8);
+
+  if (top + cardH > vh - 8) {
+    top = Math.max(8, targetRect.top - cardH - gap);
+  }
+  if (top < 8) top = 8;
+
+  card.style.top = `${top}px`;
+  card.style.left = `${left}px`;
+}
+
+function _positionSpotlight(spotlight, targetRect) {
+  spotlight.style.top = `${Math.max(0, targetRect.top - PAD)}px`;
+  spotlight.style.left = `${Math.max(0, targetRect.left - PAD)}px`;
+  spotlight.style.width = `${targetRect.width + PAD * 2}px`;
+  spotlight.style.height = `${targetRect.height + PAD * 2}px`;
+}
+
+/**
+ * @param {HTMLElement} panelEl
+ */
+function _runTour(panelEl) {
+  if (document.getElementById(TOUR_ROOT_ID)) return;
+
+  const steps = _buildSteps(panelEl);
+  if (!steps.length) return;
+
+  document.documentElement.setAttribute(PANEL_SETTINGS_TOUR_ACTIVE_ATTR, '1');
+
+  const root = document.createElement('div');
+  root.id = TOUR_ROOT_ID;
+  root.setAttribute('role', 'dialog');
+  root.setAttribute('aria-modal', 'true');
+  root.setAttribute('aria-label', 'ThinkReview settings tour');
+
+  const blocker = document.createElement('div');
+  blocker.className = 'thinkreview-tour-blocker';
+  blocker.addEventListener('click', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+  });
+  blocker.addEventListener('mousedown', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+  });
+  root.appendChild(blocker);
+
+  const spotlight = document.createElement('div');
+  spotlight.className = 'thinkreview-tour-spotlight';
+  root.appendChild(spotlight);
+
+  // Card is a body-level sibling so it can stack above open menus (same max z-index).
+  const card = document.createElement('div');
+  card.className = 'thinkreview-tour-card';
+  card.id = 'thinkreview-panel-settings-tour-card';
+
+  const eyebrow = document.createElement('div');
+  eyebrow.className = 'thinkreview-tour-eyebrow';
+  card.appendChild(eyebrow);
+
+  const title = document.createElement('h3');
+  title.className = 'thinkreview-tour-title';
+  card.appendChild(title);
+
+  const body = document.createElement('p');
+  body.className = 'thinkreview-tour-body';
+  card.appendChild(body);
+
+  const progress = document.createElement('div');
+  progress.className = 'thinkreview-tour-progress';
+  progress.setAttribute('aria-hidden', 'true');
+  for (let i = 0; i < steps.length; i += 1) {
+    const dot = document.createElement('span');
+    dot.className = 'thinkreview-tour-dot';
+    progress.appendChild(dot);
+  }
+  card.appendChild(progress);
+
+  const actions = document.createElement('div');
+  actions.className = 'thinkreview-tour-actions';
+
+  const skipBtn = document.createElement('button');
+  skipBtn.type = 'button';
+  skipBtn.className = 'thinkreview-tour-btn thinkreview-tour-btn-skip';
+  skipBtn.textContent = 'Skip';
+
+  const right = document.createElement('div');
+  right.className = 'thinkreview-tour-actions-right';
+
+  const backBtn = document.createElement('button');
+  backBtn.type = 'button';
+  backBtn.className = 'thinkreview-tour-btn thinkreview-tour-btn-secondary';
+  backBtn.textContent = 'Back';
+
+  const nextBtn = document.createElement('button');
+  nextBtn.type = 'button';
+  nextBtn.className = 'thinkreview-tour-btn thinkreview-tour-btn-primary';
+  nextBtn.textContent = 'Next';
+
+  right.appendChild(backBtn);
+  right.appendChild(nextBtn);
+  actions.appendChild(skipBtn);
+  actions.appendChild(right);
+  card.appendChild(actions);
+
+  document.body.appendChild(root);
+  document.body.appendChild(card);
+
+  let stepIndex = 0;
+  /** @type {Element | null} */
+  let highlightedEl = null;
+  /** @type {Element[]} */
+  let raisedEls = [];
+
+  const clearHighlight = () => {
+    if (highlightedEl) {
+      highlightedEl.classList.remove('thinkreview-tour-target-pulse');
+      highlightedEl = null;
+    }
+    raisedEls.forEach((el) => el.classList.remove('thinkreview-tour-raised'));
+    raisedEls = [];
+  };
+
+  const raiseEls = (...els) => {
+    raisedEls.forEach((el) => el.classList.remove('thinkreview-tour-raised'));
+    raisedEls = [];
+    els.forEach((el) => {
+      if (!el) return;
+      el.classList.add('thinkreview-tour-raised');
+      raisedEls.push(el);
+    });
+  };
+
+  const unionRect = (...els) => {
+    const valid = els.filter((el) => el && el.getBoundingClientRect);
+    if (!valid.length) return null;
+    let top = Infinity;
+    let left = Infinity;
+    let right = -Infinity;
+    let bottom = -Infinity;
+    valid.forEach((el) => {
+      const r = el.getBoundingClientRect();
+      if (r.width === 0 && r.height === 0) return;
+      top = Math.min(top, r.top);
+      left = Math.min(left, r.left);
+      right = Math.max(right, r.right);
+      bottom = Math.max(bottom, r.bottom);
+    });
+    if (!Number.isFinite(top)) return null;
+    return { top, left, width: right - left, height: bottom - top, right, bottom };
+  };
+
+  const endTour = async (reason) => {
+    clearHighlight();
+    _closeMenusQuietly();
+    document.documentElement.removeAttribute(PANEL_SETTINGS_TOUR_ACTIVE_ATTR);
+    window.removeEventListener('resize', onReposition);
+    window.removeEventListener('scroll', onReposition, true);
+    root.remove();
+    card.remove();
+    await _markSeen();
+    await _track('panel_settings_tour_completed', {
+      reason,
+      last_step: steps[stepIndex]?.id || null,
+      step_index: stepIndex
+    });
+  };
+
+  const resolveTarget = async (step) => {
+    if (typeof step.before === 'function') {
+      await step.before();
+    }
+    const target = await step.getTarget();
+    return target instanceof Element ? target : null;
+  };
+
+  const renderStep = async () => {
+    const step = steps[stepIndex];
+    if (!step) {
+      await endTour('finished');
+      return;
+    }
+
+    eyebrow.textContent = `Step ${stepIndex + 1} of ${steps.length}`;
+    title.textContent = step.title;
+    body.textContent = step.body;
+    backBtn.style.visibility = stepIndex === 0 ? 'hidden' : 'visible';
+    nextBtn.textContent = stepIndex === steps.length - 1 ? 'Done' : 'Next';
+    skipBtn.style.visibility = stepIndex === steps.length - 1 ? 'hidden' : 'visible';
+
+    progress.querySelectorAll('.thinkreview-tour-dot').forEach((dot, i) => {
+      dot.classList.toggle('is-active', i === stepIndex);
+      dot.classList.toggle('is-done', i < stepIndex);
+    });
+
+    clearHighlight();
+    const target = await resolveTarget(step);
+    if (!document.getElementById(TOUR_ROOT_ID)) return;
+
+    const formatDropdown = document.getElementById('thinkreview-review-format-dropdown');
+    const settingsDropdown = document.getElementById('thinkreview-settings-dropdown');
+    const layoutSubmenu = document.getElementById('thinkreview-settings-layout-submenu');
+
+    const extraRaise = [];
+    if (step.id === 'review-format' && formatDropdown?.style.display !== 'none') {
+      extraRaise.push(formatDropdown);
+    }
+    if (
+      (step.id === 'settings-menu' || step.id === 'layout' || step.id === 'auto-start') &&
+      settingsDropdown?.style.display !== 'none'
+    ) {
+      extraRaise.push(settingsDropdown);
+    }
+    if (step.id === 'layout' && layoutSubmenu?.style.display !== 'none') {
+      extraRaise.push(layoutSubmenu);
+    }
+
+    if (target) {
+      highlightedEl = target;
+      target.classList.add('thinkreview-tour-target-pulse');
+      raiseEls(target, ...extraRaise);
+      const rect =
+        unionRect(target, ...extraRaise) || target.getBoundingClientRect();
+      _positionSpotlight(spotlight, rect);
+      _positionCard(card, rect);
+      spotlight.style.display = 'block';
+    } else {
+      spotlight.style.display = 'none';
+      card.style.top = '72px';
+      card.style.left = `${Math.max(8, window.innerWidth - 340)}px`;
+    }
+
+    await _track('panel_settings_tour_step_viewed', {
+      step_id: step.id,
+      step_index: stepIndex
+    });
+  };
+
+  const onReposition = () => {
+    if (!highlightedEl || !document.body.contains(highlightedEl)) return;
+    const rect = unionRect(highlightedEl, ...raisedEls) || highlightedEl.getBoundingClientRect();
+    _positionSpotlight(spotlight, rect);
+    _positionCard(card, rect);
+  };
+
+  skipBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    endTour('skipped');
+  });
+
+  backBtn.addEventListener('click', async (e) => {
+    e.stopPropagation();
+    if (stepIndex <= 0) return;
+    stepIndex -= 1;
+    await renderStep();
+  });
+
+  nextBtn.addEventListener('click', async (e) => {
+    e.stopPropagation();
+    if (stepIndex >= steps.length - 1) {
+      await endTour('finished');
+      return;
+    }
+    stepIndex += 1;
+    await renderStep();
+  });
+
+  root.addEventListener('click', (e) => e.stopPropagation());
+  root.addEventListener('mousedown', (e) => e.stopPropagation());
+  card.addEventListener('click', (e) => e.stopPropagation());
+  card.addEventListener('mousedown', (e) => e.stopPropagation());
+
+  window.addEventListener('resize', onReposition, { passive: true });
+  window.addEventListener('scroll', onReposition, true);
+
+  _track('panel_settings_tour_started', { step_count: steps.length });
+  renderStep();
+}
+
+/**
+ * Start the panel settings tour on first expand if the user hasn't seen it.
+ * @param {HTMLElement} panelEl
+ */
+export async function maybeStartPanelSettingsTour(panelEl) {
+  if (!panelEl) return;
+  if (document.getElementById(TOUR_ROOT_ID)) return;
+
+  try {
+    const result = await chrome.storage.local.get([PANEL_SETTINGS_TOUR_SEEN_KEY]);
+    if (result[PANEL_SETTINGS_TOUR_SEEN_KEY]) return;
+  } catch (e) {
+    dbgWarn('Failed to read panel settings tour flag:', e);
+    return;
+  }
+
+  if (_activeAbort) {
+    _activeAbort.abort();
+  }
+  const abort = new AbortController();
+  _activeAbort = abort;
+
+  const expanded = await _waitForPanelExpanded(panelEl, abort.signal);
+  if (!expanded || abort.signal.aborted) return;
+
+  await _delay(700);
+  if (abort.signal.aborted) return;
+
+  try {
+    const again = await chrome.storage.local.get([PANEL_SETTINGS_TOUR_SEEN_KEY]);
+    if (again[PANEL_SETTINGS_TOUR_SEEN_KEY]) return;
+  } catch (_) {
+    return;
+  }
+
+  if (document.getElementById(TOUR_ROOT_ID)) return;
+  if (panelEl.classList.contains('thinkreview-panel-minimized-to-button')) return;
+
+  _runTour(panelEl);
+}

--- a/components/popup-modules/panel-settings-tour.js
+++ b/components/popup-modules/panel-settings-tour.js
@@ -403,13 +403,34 @@ function _runTour(panelEl) {
     return { top, left, width: right - left, height: bottom - top, right, bottom };
   };
 
+  let repositionRaf = 0;
+  let layoutFollowUpTimer = 0;
+  /** @type {((e: TransitionEvent) => void) | null} */
+  let layoutTransitionHandler = null;
+
+  const clearLayoutFollowUp = () => {
+    clearTimeout(layoutFollowUpTimer);
+    layoutFollowUpTimer = 0;
+    if (layoutTransitionHandler) {
+      document
+        .getElementById('gitlab-mr-integrated-review')
+        ?.removeEventListener('transitionend', layoutTransitionHandler);
+      layoutTransitionHandler = null;
+    }
+  };
+
   const endTour = async (reason) => {
     clearHighlight();
     _closeMenusQuietly();
     document.documentElement.removeAttribute(PANEL_SETTINGS_TOUR_ACTIVE_ATTR);
-    window.removeEventListener('resize', onReposition);
-    window.removeEventListener('scroll', onReposition, true);
+    window.removeEventListener('resize', scheduleReposition);
+    window.removeEventListener('scroll', scheduleReposition, true);
     document.removeEventListener('thinkreview:layoutchanged', onLayoutChanged);
+    if (repositionRaf) {
+      cancelAnimationFrame(repositionRaf);
+      repositionRaf = 0;
+    }
+    clearLayoutFollowUp();
     root.remove();
     card.remove();
     await _markSeen();
@@ -466,14 +487,25 @@ function _runTour(panelEl) {
 
   const onReposition = () => {
     if (!highlightedEl || !document.body.contains(highlightedEl)) return;
-    const api = _getSettingsMenuApi();
-    api?.reposition?.();
+    // Sync menu reposition so spotlight reads up-to-date menu geometry this frame
+    _getSettingsMenuApi()?.reposition?.();
     const rect = unionRect(highlightedEl, ...raisedEls) || highlightedEl.getBoundingClientRect();
     _positionSpotlight(spotlight, rect);
     _positionCard(card, rect);
   };
 
-  /** Follow panel/menu movement after a live layout change (incl. CSS left transition). */
+  const scheduleReposition = () => {
+    if (repositionRaf) return;
+    repositionRaf = requestAnimationFrame(() => {
+      repositionRaf = 0;
+      onReposition();
+    });
+  };
+
+  /**
+   * Follow panel/menu movement after a live layout change.
+   * One rAF now + one follow-up on panel transitionend (0.5s fallback).
+   */
   const refreshHighlightAfterLayoutChange = async () => {
     const step = steps[stepIndex];
     if (!step || !document.getElementById(TOUR_ROOT_ID)) return;
@@ -483,10 +515,30 @@ function _runTour(panelEl) {
       applyHighlight(step, target || document.getElementById('thinkreview-settings-layout-submenu'));
     }
 
-    const bump = () => onReposition();
-    requestAnimationFrame(bump);
-    setTimeout(bump, 50);
-    setTimeout(bump, 320);
+    scheduleReposition();
+    clearLayoutFollowUp();
+
+    const panel = document.getElementById('gitlab-mr-integrated-review');
+    if (panel) {
+      layoutTransitionHandler = (e) => {
+        if (e.target !== panel) return;
+        if (e.propertyName !== 'right' && e.propertyName !== 'left' && e.propertyName !== 'width') {
+          return;
+        }
+        clearLayoutFollowUp();
+        scheduleReposition();
+      };
+      panel.addEventListener('transitionend', layoutTransitionHandler);
+    }
+
+    layoutFollowUpTimer = setTimeout(() => {
+      layoutFollowUpTimer = 0;
+      if (layoutTransitionHandler) {
+        panel?.removeEventListener('transitionend', layoutTransitionHandler);
+        layoutTransitionHandler = null;
+      }
+      scheduleReposition();
+    }, 520);
   };
 
   const onLayoutChanged = () => {
@@ -550,8 +602,8 @@ function _runTour(panelEl) {
   card.addEventListener('click', (e) => e.stopPropagation());
   card.addEventListener('mousedown', (e) => e.stopPropagation());
 
-  window.addEventListener('resize', onReposition, { passive: true });
-  window.addEventListener('scroll', onReposition, true);
+  window.addEventListener('resize', scheduleReposition, { passive: true });
+  window.addEventListener('scroll', scheduleReposition, true);
   document.addEventListener('thinkreview:layoutchanged', onLayoutChanged);
 
   _track('panel_settings_tour_started', { step_count: steps.length });

--- a/components/popup-modules/review-format-preference-widget.js
+++ b/components/popup-modules/review-format-preference-widget.js
@@ -240,10 +240,20 @@ export async function mountReviewFormatPreferenceWidget(headerActionsEl, options
   });
 
   document.addEventListener('click', (e) => {
-    if (e.target !== btn && !dropdown.contains(/** @type {Node} */ (e.target))) {
-      dropdown.style.display = 'none';
-      btn.setAttribute('aria-expanded', 'false');
+    if (document.documentElement.hasAttribute('data-thinkreview-tour-active')) {
+      return;
     }
+    const t = /** @type {Node} */ (e.target);
+    if (
+      t === btn ||
+      dropdown.contains(t) ||
+      (t instanceof Element && t.closest('#thinkreview-panel-settings-tour')) ||
+      (t instanceof Element && t.closest('#thinkreview-panel-settings-tour-card'))
+    ) {
+      return;
+    }
+    dropdown.style.display = 'none';
+    btn.setAttribute('aria-expanded', 'false');
   });
 
   dropdown.addEventListener('click', async (e) => {

--- a/components/popup-modules/review-format-preference-widget.js
+++ b/components/popup-modules/review-format-preference-widget.js
@@ -57,31 +57,31 @@ function createSeverityIconSvg() {
 
 const ROWS = [
   {
-    id: 'scoring',
-    label: 'scoring',
-    description: 'Scorecard with strengths & suggestions',
-    icon: createScoringIconSvg
-  },
-  {
     id: 'severity',
     label: 'severity',
     description: 'PR description with critical / high / low issues',
     icon: createSeverityIconSvg
+  },
+  {
+    id: 'scoring',
+    label: 'scoring',
+    description: 'Scorecard with strengths & suggestions',
+    icon: createScoringIconSvg
   }
 ];
 
 async function _getFormat() {
   try {
     const result = await chrome.storage.local.get(['code-review-format']);
-    return result['code-review-format'] === 'severity' ? 'severity' : 'scoring';
+    return result['code-review-format'] === 'scoring' ? 'scoring' : 'severity';
   } catch (e) {
     dbgWarn('Failed to load review format preference:', e);
-    return 'scoring';
+    return 'severity';
   }
 }
 
 async function _setFormat(format) {
-  const normalized = format === 'severity' ? 'severity' : 'scoring';
+  const normalized = format === 'scoring' ? 'scoring' : 'severity';
   await chrome.storage.local.set({ 'code-review-format': normalized });
   return normalized;
 }

--- a/components/popup-modules/user-toast.css
+++ b/components/popup-modules/user-toast.css
@@ -1,0 +1,134 @@
+/* User-facing toast near the ThinkReview trigger (replaces native alert) */
+.thinkreview-user-toast,
+#thinkreview-user-toast {
+  width: 320px;
+  max-width: min(320px, calc(100vw - 48px));
+  padding: 12px 14px;
+  background: #1a1628;
+  border: 1px solid #3d2d6e;
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+  color: rgba(255, 255, 255, 0.92);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-size: 13px;
+  line-height: 1.45;
+  box-sizing: border-box;
+  pointer-events: auto;
+  animation: thinkreview-user-toast-in 0.22s ease-out;
+}
+
+.thinkreview-user-toast-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.thinkreview-user-toast-icon {
+  flex-shrink: 0;
+  margin-top: 1px;
+  color: #a78bfa;
+}
+
+.thinkreview-user-toast-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.thinkreview-user-toast-title {
+  display: block;
+  font-weight: 600;
+  font-size: 13px;
+  color: #fff;
+  margin-bottom: 2px;
+}
+
+.thinkreview-user-toast-message {
+  display: block;
+  color: rgba(255, 255, 255, 0.78);
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+
+.thinkreview-user-toast-close {
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  margin: -2px -4px 0 0;
+  padding: 0;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.55);
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.thinkreview-user-toast-close:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.thinkreview-user-toast-float-left {
+  animation-name: thinkreview-user-toast-in-float-left;
+}
+
+.thinkreview-user-toast-sidebar {
+  animation-name: thinkreview-user-toast-in-sidebar;
+}
+
+.thinkreview-user-toast-center {
+  animation-name: thinkreview-user-toast-in-center;
+}
+
+.thinkreview-user-toast-out {
+  opacity: 0;
+  transition: opacity 0.2s ease-out, transform 0.2s ease-out;
+}
+
+@keyframes thinkreview-user-toast-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes thinkreview-user-toast-in-float-left {
+  from {
+    opacity: 0;
+    transform: translateY(-50%) translateX(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(-50%) translateX(0);
+  }
+}
+
+@keyframes thinkreview-user-toast-in-sidebar {
+  from {
+    opacity: 0;
+    transform: translateY(-50%) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(-50%) scale(1);
+  }
+}
+
+@keyframes thinkreview-user-toast-in-center {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
+}

--- a/components/popup-modules/user-toast.js
+++ b/components/popup-modules/user-toast.js
@@ -1,0 +1,195 @@
+/**
+ * user-toast.js
+ * Friendly in-page toast near the ThinkReview trigger (replaces native alert()).
+ */
+
+const TOAST_ID = 'thinkreview-user-toast';
+const DEFAULT_DURATION_MS = 4500;
+
+const cssURL = chrome.runtime.getURL('components/popup-modules/user-toast.css');
+if (!document.querySelector(`link[href="${cssURL}"]`)) {
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = cssURL;
+  document.head.appendChild(link);
+}
+
+let hideTimeoutId = null;
+
+/**
+ * Info circle icon for toast.
+ * @returns {SVGElement}
+ */
+function createInfoIconSvg() {
+  const NS = 'http://www.w3.org/2000/svg';
+  const svg = document.createElementNS(NS, 'svg');
+  svg.setAttribute('width', '18');
+  svg.setAttribute('height', '18');
+  svg.setAttribute('viewBox', '0 0 24 24');
+  svg.setAttribute('fill', 'none');
+  svg.setAttribute('aria-hidden', 'true');
+  svg.classList.add('thinkreview-user-toast-icon');
+
+  const circle = document.createElementNS(NS, 'circle');
+  circle.setAttribute('cx', '12');
+  circle.setAttribute('cy', '12');
+  circle.setAttribute('r', '9');
+  circle.setAttribute('stroke', 'currentColor');
+  circle.setAttribute('stroke-width', '2');
+  svg.appendChild(circle);
+
+  const stem = document.createElementNS(NS, 'path');
+  stem.setAttribute('d', 'M12 11v5');
+  stem.setAttribute('stroke', 'currentColor');
+  stem.setAttribute('stroke-width', '2');
+  stem.setAttribute('stroke-linecap', 'round');
+  svg.appendChild(stem);
+
+  const dot = document.createElementNS(NS, 'circle');
+  dot.setAttribute('cx', '12');
+  dot.setAttribute('cy', '8');
+  dot.setAttribute('r', '1.25');
+  dot.setAttribute('fill', 'currentColor');
+  svg.appendChild(dot);
+
+  return svg;
+}
+
+/**
+ * Position toast relative to trigger, or top-center as fallback.
+ * @param {HTMLElement} toast
+ * @param {HTMLElement|null} triggerEl
+ */
+function positionToast(toast, triggerEl) {
+  toast.style.position = 'fixed';
+  toast.style.zIndex = '10002';
+
+  if (!triggerEl) {
+    toast.style.top = '24px';
+    toast.style.left = '50%';
+    toast.style.right = 'auto';
+    toast.style.bottom = 'auto';
+    toast.style.transform = 'translateX(-50%)';
+    toast.classList.add('thinkreview-user-toast-center');
+    return;
+  }
+
+  const triggerRect = triggerEl.getBoundingClientRect();
+  const isSidebar = triggerEl.id === 'thinkreview-sidebar-tab';
+  const sideRight = triggerEl.classList.contains('side-right');
+  const gap = 10;
+
+  if (isSidebar) {
+    if (sideRight) {
+      toast.style.right = `${window.innerWidth - triggerRect.left + gap}px`;
+      toast.style.left = 'auto';
+    } else {
+      toast.style.left = `${triggerRect.right + gap}px`;
+      toast.style.right = 'auto';
+    }
+    toast.style.top = `${triggerRect.top + triggerRect.height / 2}px`;
+    toast.style.bottom = 'auto';
+    toast.style.transform = 'translateY(-50%)';
+    toast.classList.add('thinkreview-user-toast-sidebar');
+    return;
+  }
+
+  toast.style.right = `${window.innerWidth - triggerRect.left + gap}px`;
+  toast.style.left = 'auto';
+  toast.style.top = `${triggerRect.top + triggerRect.height / 2}px`;
+  toast.style.bottom = 'auto';
+  toast.style.transform = 'translateY(-50%)';
+  toast.classList.add('thinkreview-user-toast-float-left');
+}
+
+/**
+ * Shows a non-blocking toast near the ThinkReview trigger.
+ * @param {Object} options
+ * @param {string} options.message - Body text
+ * @param {string} [options.title] - Optional short title
+ * @param {number} [options.durationMs] - Auto-hide duration (default 4500)
+ * @param {HTMLElement|null} [options.triggerEl] - Anchor element; resolved if omitted
+ */
+export async function showUserToast({ message, title, durationMs = DEFAULT_DURATION_MS, triggerEl = null } = {}) {
+  hideUserToast();
+
+  if (!message || typeof message !== 'string') return;
+
+  let anchor = triggerEl;
+  if (!anchor) {
+    try {
+      const triggerResolver = await import(chrome.runtime.getURL('components/popup-modules/trigger-resolver.js'));
+      anchor = triggerResolver.getActiveTriggerElement();
+    } catch (_) {
+      anchor = document.getElementById('code-review-btn') || document.getElementById('thinkreview-sidebar-tab');
+    }
+  }
+
+  const toast = document.createElement('div');
+  toast.id = TOAST_ID;
+  toast.className = 'thinkreview-user-toast';
+  toast.setAttribute('role', 'status');
+  toast.setAttribute('aria-live', 'polite');
+
+  const row = document.createElement('div');
+  row.className = 'thinkreview-user-toast-row';
+  row.appendChild(createInfoIconSvg());
+
+  const body = document.createElement('div');
+  body.className = 'thinkreview-user-toast-body';
+
+  if (title) {
+    const titleEl = document.createElement('span');
+    titleEl.className = 'thinkreview-user-toast-title';
+    titleEl.textContent = title;
+    body.appendChild(titleEl);
+  }
+
+  const messageEl = document.createElement('span');
+  messageEl.className = 'thinkreview-user-toast-message';
+  messageEl.textContent = message;
+  body.appendChild(messageEl);
+  row.appendChild(body);
+
+  const closeBtn = document.createElement('button');
+  closeBtn.type = 'button';
+  closeBtn.className = 'thinkreview-user-toast-close';
+  closeBtn.setAttribute('aria-label', 'Dismiss');
+  closeBtn.textContent = '×';
+  closeBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    hideUserToast();
+  });
+  row.appendChild(closeBtn);
+
+  toast.appendChild(row);
+  positionToast(toast, anchor);
+  document.body.appendChild(toast);
+
+  hideTimeoutId = setTimeout(() => {
+    hideUserToast(true);
+  }, durationMs);
+}
+
+/**
+ * Hides and removes the toast.
+ * @param {boolean} [animate] - Fade out before remove
+ */
+export function hideUserToast(animate = false) {
+  if (hideTimeoutId != null) {
+    clearTimeout(hideTimeoutId);
+    hideTimeoutId = null;
+  }
+  const toast = document.getElementById(TOAST_ID);
+  if (!toast) return;
+
+  if (animate) {
+    toast.classList.add('thinkreview-user-toast-out');
+    setTimeout(() => {
+      const el = document.getElementById(TOAST_ID);
+      if (el) el.remove();
+    }, 200);
+    return;
+  }
+  toast.remove();
+}

--- a/content.js
+++ b/content.js
@@ -1471,7 +1471,7 @@ async function fetchAndDisplayCodeReview(forceRegenerate = false, isAutoTriggere
     // Get the user's language preference from extension storage
     const result = await chrome.storage.local.get(['code-review-language', 'code-review-format']);
     const language = result['code-review-language'] || 'English';
-    const reviewFormat = result['code-review-format'] === 'severity' ? 'severity' : 'scoring';
+    const reviewFormat = result['code-review-format'] === 'scoring' ? 'scoring' : 'severity';
     
     // Get the full MR/PR URL
     const mrUrl = window.location.href;
@@ -1595,7 +1595,7 @@ async function fetchAndDisplayCodeReview(forceRegenerate = false, isAutoTriggere
     // Display the review results (use filtered patch — same string as reviewPatchCode_1_1 for agent checksums).
     // Ensure reviewFormat is on the review object for conditional rendering (API may also set top-level reviewFormat).
     if (!data.review.reviewFormat) {
-      data.review.reviewFormat = data.reviewFormat || reviewFormat || 'scoring';
+      data.review.reviewFormat = data.reviewFormat || reviewFormat || 'severity';
     }
     displayIntegratedReview(
       data.review,

--- a/content.js
+++ b/content.js
@@ -109,29 +109,19 @@ let platformDetector = null;
 // Import Azure DevOps token error module
 let azureDevOpsTokenError = null;
 
-// Initialize platform detection
-async function initializePlatformDetection() {
+/**
+ * Azure-only extras (API helpers, token UI, on-prem version probe).
+ * Kept off the critical path so the ThinkReview button can appear sooner.
+ */
+async function initializeAzurePlatformExtras() {
   try {
-    // Dynamically import platform detector
-    const platformModule = await import(chrome.runtime.getURL('services/platform-detector.js'));
-    platformDetector = platformModule.platformDetector;
-    platformDetector.init();
-
-    // Load custom Azure DevOps domains so on-prem URLs are detected
-    const storage = await chrome.storage.local.get(['azureDevOpsDomains', 'bitbucketDataCenterDomains']);
-    platformDetector.setAzureDevOpsCustomDomains(storage.azureDevOpsDomains || []);
-
-    // Load custom Bitbucket Data Center domains
-    platformDetector.setBitbucketCustomDomains(storage.bitbucketDataCenterDomains || []);
-    
-    // Dynamically import Azure DevOps API module for error handling
     const apiModule = await import(chrome.runtime.getURL('services/azure-devops-api.js'));
 
-    // Run server version detection only for on-prem/custom domains (skip dev.azure.com and visualstudio.com)
     const hostname = window.location.hostname || '';
     const isAzureCloud = hostname.includes('dev.azure.com') || hostname.includes('visualstudio.com');
     if (
       !isAzureCloud &&
+      platformDetector &&
       platformDetector.isAzureDevOpsSite() &&
       typeof apiModule.detectAndCacheServerVersion === 'function'
     ) {
@@ -141,7 +131,6 @@ async function initializePlatformDetection() {
       apiModule.detectAndCacheServerVersion(origin, collection)
         .then((result) => {
           if (!result || result.fromCache !== false) return;
-          // Send to cloud via background script (avoids content script fetch to external API / CSP)
           chrome.runtime.sendMessage({
             type: 'LOG_AZURE_DEVOPS_VERSION',
             origin,
@@ -149,7 +138,7 @@ async function initializePlatformDetection() {
             collection,
             azureOnPremiseApiVersion: result.azureOnPremiseApiVersion ?? null,
             azureOnPremiseVersion: result.azureOnPremiseVersion ?? null
-          }, (response) => {
+          }, () => {
             if (chrome.runtime.lastError) dbgWarn('Azure DevOps version cloud log failed (non-critical):', chrome.runtime.lastError);
           });
         })
@@ -157,11 +146,28 @@ async function initializePlatformDetection() {
           dbgWarn('Azure DevOps server version detection failed (non-critical):', err);
         });
     }
-    
-    // Dynamically import Azure DevOps token error module
+
     const tokenErrorModule = await import(chrome.runtime.getURL('components/azure-devops-token-error.js'));
     azureDevOpsTokenError = tokenErrorModule;
-    
+  } catch (error) {
+    dbgWarn('Error initializing Azure platform extras:', error);
+  }
+}
+
+// Initialize platform detection (lightweight — enough to decide whether to show the button)
+async function initializePlatformDetection() {
+  try {
+    const platformModule = await import(chrome.runtime.getURL('services/platform-detector.js'));
+    platformDetector = platformModule.platformDetector;
+    platformDetector.init();
+
+    const storage = await chrome.storage.local.get(['azureDevOpsDomains', 'bitbucketDataCenterDomains']);
+    platformDetector.setAzureDevOpsCustomDomains(storage.azureDevOpsDomains || []);
+    platformDetector.setBitbucketCustomDomains(storage.bitbucketDataCenterDomains || []);
+
+    // Do not block button injection on Azure API / token-error modules
+    initializeAzurePlatformExtras().catch(() => {});
+
     dbgLog('Platform detection initialized');
   } catch (error) {
     dbgWarn('Error initializing platform detection:', error);
@@ -353,7 +359,7 @@ function applyDockedBodyMargin(isExpanded, panelMode, sidebarSide) {
 const areButtonsInjected = () =>
   !!(document.getElementById('code-review-btns') || document.getElementById('thinkreview-sidebar-tab'));
 
-async function injectButtons() {
+async function injectButtons(preloaded = null) {
   if (areButtonsInjected()) {
     dbgLog('Buttons already injected');
     return;
@@ -361,9 +367,16 @@ async function injectButtons() {
 
   dbgLog('Injecting trigger UI');
   try {
-    const settings = await getLayoutSettings();
-    const { injectTrigger } = await import(chrome.runtime.getURL('components/layout-trigger.js'));
-    injectTrigger(settings, toggleReviewPanel);
+    const settingsPromise = preloaded?.settingsPromise || getLayoutSettings();
+    let triggerModulePromise = preloaded?.triggerModulePromise;
+    if (!triggerModulePromise) {
+      triggerModulePromise = import(chrome.runtime.getURL('components/layout-trigger.js'));
+    }
+    const [settings, triggerModule] = await Promise.all([settingsPromise, triggerModulePromise]);
+    if (!triggerModule?.injectTrigger) {
+      throw new Error('layout-trigger module unavailable');
+    }
+    triggerModule.injectTrigger(settings, toggleReviewPanel);
     dbgLog('Trigger injected via layout-trigger.js, mode:', settings.triggerMode);
   } catch (error) {
     dbgError('Failed to load layout-trigger.js, falling back to inline button:', error);
@@ -1989,19 +2002,26 @@ function startSPANavigationMonitoring() {
 
 // Initialize when the page is loaded
 async function initializeExtension() {
-  // Initialize platform detection first
+  // Prefetch trigger deps in parallel with platform detection so the button isn't
+  // blocked on a second round-trip after shouldShowButton() returns.
+  const settingsPromise = getLayoutSettings();
+  const triggerModulePromise = import(chrome.runtime.getURL('components/layout-trigger.js')).catch((error) => {
+    dbgWarn('Early layout-trigger prefetch failed:', error);
+    return null;
+  });
+
   await initializePlatformDetection();
-  
+
   // Check if we should show the button (always true for Azure DevOps and GitHub, only on MR pages for GitLab)
   if (shouldShowButton()) {
     const platform = getCurrentPlatform();
     dbgLog('Initializing for platform:', platform);
-    
-    await injectButtons();
+
+    await injectButtons({ settingsPromise, triggerModulePromise });
 
     // If the trigger still didn't land (e.g. extension context warming up right after install/update),
     // watch for DOM changes and inject as soon as the body is mutated instead of guessing a delay.
-      if (!areButtonsInjected()) {
+    if (!areButtonsInjected()) {
       dbgWarn('Trigger not found after injectButtons(), observing DOM for retry...');
 
       retryState.observer = new MutationObserver(() => {
@@ -2030,18 +2050,20 @@ async function initializeExtension() {
         }, 150);
       });
 
-      retryState.observer.observe(document.body, { childList: true, subtree: true });
+      if (document.body) {
+        retryState.observer.observe(document.body, { childList: true, subtree: true });
+      }
 
       // Hard-stop: clear everything after 10 s if the page never settles.
       retryState.timeoutId = setTimeout(_teardownRetryObserver, 10_000);
     }
-    
+
     // Start SPA navigation monitoring for GitHub, Azure DevOps, and Bitbucket (SPAs)
     // Check by site (domain) rather than platform, because platform is null on non-PR pages
     if (platformDetector && (platformDetector.isGitHubSite() || platformDetector.isAzureDevOpsSite() || platformDetector.isBitbucketSite())) {
       startSPANavigationMonitoring();
     }
-    
+
     // Wait for the page to fully load before injecting the integrated review panel
     setTimeout(() => {
       injectIntegratedReviewPanel();
@@ -2054,7 +2076,7 @@ async function initializeExtension() {
           arrowSpan.textContent = '▲';
         }
       }
-      
+
       // Save the minimized state to extension storage
       chrome.storage.local.set({ 'code-review-minimized-to-button': 'true' });
     }, 1000);

--- a/content.js
+++ b/content.js
@@ -507,6 +507,12 @@ async function checkAndTriggerReviewForNewPR() {
     } catch (error) {
       // Silently fail if module not available
     }
+    try {
+      const toastModule = await import(chrome.runtime.getURL('components/popup-modules/user-toast.js'));
+      toastModule.hideUserToast();
+    } catch (error) {
+      // Silently fail if module not available
+    }
     
     return;
   }
@@ -1726,8 +1732,16 @@ async function toggleReviewPanel() {
   // Check if we're on a supported page first (before creating/opening panel)
   // For Azure DevOps and GitHub (SPAs), this ensures we're on a PR page
   if (!isSupportedPage()) {
-    dbgLog('Not on a supported page, showing alert');
-    alert('Please navigate to a Pull Request page to generate an AI code review.');
+    dbgLog('Not on a supported page, showing toast');
+    try {
+      const toastModule = await import(chrome.runtime.getURL('components/popup-modules/user-toast.js'));
+      await toastModule.showUserToast({
+        title: 'Open a pull request',
+        message: 'Navigate to a PR page to generate an AI code review with ThinkReview.',
+      });
+    } catch (error) {
+      dbgWarn('Failed to show user toast:', error);
+    }
     return;
   }
   

--- a/popup.js
+++ b/popup.js
@@ -1084,7 +1084,7 @@ async function addDomain() {
   const inputValue = domainInput.value.trim().toLowerCase();
   
   if (!validateDomainInput(inputValue)) {
-    alert('Please enter a valid domain (e.g., gitlab.example.com, localhost:8083, http://localhost:8083)');
+    showMessage('Enter a valid domain (e.g. gitlab.example.com or http://localhost:8083)', 'error');
     return;
   }
   
@@ -1116,7 +1116,7 @@ async function addDomain() {
     });
 
     if (!granted) {
-      alert('Permission not granted. The extension needs permission to access this domain.');
+      showMessage('Permission needed — allow access to this domain to continue.', 'error');
       return;
     }
 
@@ -1124,7 +1124,7 @@ async function addDomain() {
     const domains = result.gitlabDomains || DEFAULT_DOMAINS;
 
     if (domains.includes(domain)) {
-      alert('Domain already exists');
+      showMessage('That domain is already added.', 'error');
       return;
     }
 
@@ -1161,7 +1161,7 @@ async function addDomain() {
     
   } catch (error) {
     dbgWarn('Error adding domain:', error);
-    alert(`Error adding domain: ${error.message}. Please try again.`);
+    showMessage(`Couldn't add domain: ${error.message}`, 'error');
   } finally {
     isAddingDomain = false;
     if (addButton) {
@@ -1260,7 +1260,7 @@ async function addGitHubEnterpriseDomain() {
   const inputValue = domainInput?.value?.trim()?.toLowerCase() ?? '';
 
   if (!validateDomainInput(inputValue)) {
-    alert('Please enter a valid domain (e.g., github.mycompany.com, https://github.mycompany.com)');
+    showMessage('Enter a valid domain (e.g. github.mycompany.com)', 'error');
     return;
   }
 
@@ -1286,7 +1286,7 @@ async function addGitHubEnterpriseDomain() {
     // Firefox: permissions.request must run before any other await (user-gesture stack).
     const granted = await chrome.permissions.request({ origins: [originPattern] });
     if (!granted) {
-      alert('Permission not granted. The extension needs permission to access this domain.');
+      showMessage('Permission needed — allow access to this domain to continue.', 'error');
       return;
     }
 
@@ -1294,7 +1294,7 @@ async function addGitHubEnterpriseDomain() {
     const domains = result.githubEnterpriseDomains || GITHUB_ENTERPRISE_DEFAULT_DOMAINS;
 
     if (domains.includes(domain)) {
-      alert('Domain already exists');
+      showMessage('That domain is already added.', 'error');
       return;
     }
 
@@ -1321,7 +1321,7 @@ async function addGitHubEnterpriseDomain() {
     showMessage('Domain added successfully! You may need to reload GitHub Enterprise pages for changes to take effect.', 'success');
   } catch (error) {
     dbgWarn('Error adding GitHub Enterprise domain:', error);
-    alert(`Error adding domain: ${error.message}. Please try again.`);
+    showMessage(`Couldn't add domain: ${error.message}`, 'error');
   } finally {
     isAddingGitHubEnterpriseDomain = false;
     if (addButton) {
@@ -1332,7 +1332,7 @@ async function addGitHubEnterpriseDomain() {
 }
 
 async function removeGitHubEnterpriseDomain(domain) {
-  if (!confirm(`Remove domain "${domain}"?`)) return;
+  if (!(await showConfirm(`Remove domain "${domain}"?`, { confirmLabel: 'Remove' }))) return;
 
   try {
     const result = await chrome.storage.local.get(['githubEnterpriseDomains']);
@@ -1356,17 +1356,17 @@ async function removeGitHubEnterpriseDomain(domain) {
     showMessage('Domain removed successfully!', 'success');
   } catch (error) {
     dbgWarn('Error removing GitHub Enterprise domain:', error);
-    alert('Error removing domain. Please try again.');
+    showMessage('Couldn't remove domain. Please try again.', 'error');
   }
 }
 
 async function removeDomain(domain) {
   if (DEFAULT_DOMAINS.includes(domain)) {
-    alert('Cannot remove default domain');
+    showMessage('Default domains can’t be removed.', 'error');
     return;
   }
   
-  if (!confirm(`Remove domain "${domain}"?`)) {
+  if (!(await showConfirm(`Remove domain "${domain}"?`, { confirmLabel: 'Remove' }))) {
     return;
   }
   
@@ -1397,7 +1397,7 @@ async function removeDomain(domain) {
     
   } catch (error) {
     dbgWarn('Error removing domain:', error);
-    alert('Error removing domain. Please try again.');
+    showMessage('Couldn't remove domain. Please try again.', 'error');
   }
 }
 
@@ -1516,7 +1516,7 @@ async function addAzureDevOpsDomain() {
   const inputValue = domainInput?.value?.trim()?.toLowerCase() ?? '';
 
   if (!validateDomainInput(inputValue)) {
-    alert('Please enter a valid domain (e.g., devops.companyname.com, https://devops.companyname.com)');
+    showMessage('Enter a valid domain (e.g. devops.companyname.com)', 'error');
     return;
   }
 
@@ -1540,7 +1540,7 @@ async function addAzureDevOpsDomain() {
     // Firefox: permissions.request must run before any other await (user-gesture stack).
     const granted = await chrome.permissions.request({ origins: [originPattern] });
     if (!granted) {
-      alert('Permission not granted. The extension needs permission to access this domain.');
+      showMessage('Permission needed — allow access to this domain to continue.', 'error');
       return;
     }
 
@@ -1548,7 +1548,7 @@ async function addAzureDevOpsDomain() {
     const domains = result.azureDevOpsDomains || [];
 
     if (domains.includes(domain)) {
-      alert('Domain already exists');
+      showMessage('That domain is already added.', 'error');
       return;
     }
 
@@ -1564,7 +1564,7 @@ async function addAzureDevOpsDomain() {
     showMessage('Domain added. You may need to reload Azure DevOps pages for changes to take effect.', 'success');
   } catch (error) {
     dbgWarn('Error adding Azure DevOps domain:', error);
-    alert(`Error adding domain: ${error.message}. Please try again.`);
+    showMessage(`Couldn't add domain: ${error.message}`, 'error');
   } finally {
     isAddingAzureDomain = false;
     if (addButton) {
@@ -1575,7 +1575,7 @@ async function addAzureDevOpsDomain() {
 }
 
 async function removeAzureDevOpsDomain(domain) {
-  if (!confirm(`Remove domain "${domain}"?`)) return;
+  if (!(await showConfirm(`Remove domain "${domain}"?`, { confirmLabel: 'Remove' }))) return;
 
   try {
     const result = await chrome.storage.local.get(['azureDevOpsDomains']);
@@ -1590,7 +1590,7 @@ async function removeAzureDevOpsDomain(domain) {
     showMessage('Domain removed successfully!', 'success');
   } catch (error) {
     dbgWarn('Error removing Azure DevOps domain:', error);
-    alert('Error removing domain. Please try again.');
+    showMessage('Couldn't remove domain. Please try again.', 'error');
   }
 }
 
@@ -1852,7 +1852,7 @@ async function addBitbucketDataCenterDomain() {
   const inputValue = domainInput?.value?.trim()?.toLowerCase() ?? '';
 
   if (!validateDomainInput(inputValue)) {
-    alert('Please enter a valid domain (e.g., bitbucket.mycompany.com, https://bitbucket.mycompany.com)');
+    showMessage('Enter a valid domain (e.g. bitbucket.mycompany.com)', 'error');
     return;
   }
 
@@ -1878,7 +1878,7 @@ async function addBitbucketDataCenterDomain() {
     // Firefox: permissions.request must run before any other await (user-gesture stack).
     const granted = await chrome.permissions.request({ origins: [originPattern] });
     if (!granted) {
-      alert('Permission not granted. The extension needs permission to access this domain.');
+      showMessage('Permission needed — allow access to this domain to continue.', 'error');
       return;
     }
 
@@ -1886,7 +1886,7 @@ async function addBitbucketDataCenterDomain() {
     const domains = result.bitbucketDataCenterDomains || [];
 
     if (domains.includes(domain)) {
-      alert('Domain already exists');
+      showMessage('That domain is already added.', 'error');
       return;
     }
 
@@ -1908,7 +1908,7 @@ async function addBitbucketDataCenterDomain() {
     showMessage('Domain added. Reload your Bitbucket Data Center pages to use AI reviews.', 'success');
   } catch (error) {
     dbgWarn('Error adding Bitbucket Data Center domain:', error);
-    alert(`Error adding domain: ${error.message}. Please try again.`);
+    showMessage(`Couldn't add domain: ${error.message}`, 'error');
   } finally {
     isAddingBitbucketDCDomain = false;
     if (addButton) {
@@ -1919,7 +1919,7 @@ async function addBitbucketDataCenterDomain() {
 }
 
 async function removeBitbucketDataCenterDomain(domain) {
-  if (!confirm(`Remove domain "${domain}"?`)) return;
+  if (!(await showConfirm(`Remove domain "${domain}"?`, { confirmLabel: 'Remove' }))) return;
 
   try {
     const result = await chrome.storage.local.get(['bitbucketDataCenterDomains']);
@@ -1939,7 +1939,7 @@ async function removeBitbucketDataCenterDomain(domain) {
     showMessage('Domain removed successfully!', 'success');
   } catch (error) {
     dbgWarn('Error removing Bitbucket Data Center domain:', error);
-    alert('Error removing domain. Please try again.');
+    showMessage('Couldn't remove domain. Please try again.', 'error');
   }
 }
 
@@ -2018,31 +2018,122 @@ async function saveBitbucketDataCenterToken() {
 }
 
 function showMessage(text, type = 'info') {
-  // Create a temporary message element
+  const existing = document.getElementById('thinkreview-popup-toast');
+  if (existing) existing.remove();
+
+  const colors = {
+    success: { bg: '#166534', border: '#22c55e' },
+    error: { bg: '#7f1d1d', border: '#ef4444' },
+    info: { bg: '#1a1628', border: '#6b4fbb' },
+  };
+  const palette = colors[type] || colors.info;
+
   const message = document.createElement('div');
+  message.id = 'thinkreview-popup-toast';
+  message.setAttribute('role', 'status');
+  message.setAttribute('aria-live', 'polite');
   message.style.cssText = `
     position: fixed;
-    top: 10px;
+    top: 12px;
     left: 50%;
     transform: translateX(-50%);
-    background: ${type === 'success' ? '#4caf50' : type === 'error' ? '#f44336' : '#2196f3'};
-    color: white;
-    padding: 8px 16px;
-    border-radius: 4px;
+    background: ${palette.bg};
+    border: 1px solid ${palette.border};
+    color: #fff;
+    padding: 10px 14px;
+    border-radius: 8px;
     font-size: 12px;
+    line-height: 1.4;
     z-index: 10000;
-    max-width: 300px;
+    max-width: calc(100% - 24px);
+    width: max-content;
     text-align: center;
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
+    animation: thinkreview-popup-toast-in 0.2s ease-out;
   `;
   message.textContent = text;
-  
   document.body.appendChild(message);
-  
+
   setTimeout(() => {
     if (document.body.contains(message)) {
-      document.body.removeChild(message);
+      message.style.transition = 'opacity 0.2s ease-out';
+      message.style.opacity = '0';
+      setTimeout(() => message.remove(), 200);
     }
-  }, 3000);
+  }, type === 'error' ? 4000 : 3000);
+}
+
+/**
+ * Non-blocking confirm dialog for the popup (replaces native confirm()).
+ * @param {string} text
+ * @param {{ confirmLabel?: string }} [options]
+ * @returns {Promise<boolean>}
+ */
+function showConfirm(text, options = {}) {
+  const confirmLabel = options.confirmLabel || 'Confirm';
+  return new Promise((resolve) => {
+    const existing = document.getElementById('thinkreview-popup-confirm');
+    if (existing) existing.remove();
+
+    const overlay = document.createElement('div');
+    overlay.id = 'thinkreview-popup-confirm';
+    overlay.style.cssText = `
+      position: fixed; inset: 0; z-index: 10001;
+      background: rgba(0, 0, 0, 0.45);
+      display: flex; align-items: center; justify-content: center;
+      padding: 16px;
+    `;
+
+    const dialog = document.createElement('div');
+    dialog.setAttribute('role', 'dialog');
+    dialog.setAttribute('aria-modal', 'true');
+    dialog.style.cssText = `
+      background: #1a1628; border: 1px solid #3d2d6e; border-radius: 10px;
+      padding: 16px; max-width: 280px; width: 100%;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45); color: #fff;
+    `;
+
+    const msg = document.createElement('p');
+    msg.style.cssText = 'margin: 0 0 14px; font-size: 13px; line-height: 1.45; color: rgba(255,255,255,0.9);';
+    msg.textContent = text;
+    dialog.appendChild(msg);
+
+    const actions = document.createElement('div');
+    actions.style.cssText = 'display: flex; gap: 8px; justify-content: flex-end;';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.type = 'button';
+    cancelBtn.textContent = 'Cancel';
+    cancelBtn.style.cssText = `
+      padding: 6px 12px; border-radius: 6px; border: 1px solid #3d2d6e;
+      background: transparent; color: rgba(255,255,255,0.85); cursor: pointer; font-size: 12px;
+    `;
+
+    const okBtn = document.createElement('button');
+    okBtn.type = 'button';
+    okBtn.textContent = confirmLabel;
+    okBtn.style.cssText = `
+      padding: 6px 12px; border-radius: 6px; border: none;
+      background: #6b4fbb; color: #fff; cursor: pointer; font-size: 12px; font-weight: 500;
+    `;
+
+    const finish = (value) => {
+      overlay.remove();
+      resolve(value);
+    };
+    cancelBtn.addEventListener('click', () => finish(false));
+    okBtn.addEventListener('click', () => finish(true));
+    overlay.addEventListener('click', (e) => {
+      if (e.target === overlay) finish(false);
+    });
+
+    actions.appendChild(cancelBtn);
+    actions.appendChild(okBtn);
+    dialog.appendChild(actions);
+    overlay.appendChild(dialog);
+    document.body.appendChild(overlay);
+    okBtn.focus();
+  });
 }
 
 // Azure DevOps Settings Functionality

--- a/services/cloud-service.js
+++ b/services/cloud-service.js
@@ -285,10 +285,10 @@ export class CloudService {
    * @param {string} [mrUrl] - Optional merge request URL for tracking
    * @param {boolean} [forceRegenerate] - Optional flag to force regenerate review even if cached
    * @param {string} [platform] - Optional platform information ('gitlab' or 'azure-devops')
-   * @param {string} [reviewFormat='scoring'] - Optional review layout: 'scoring' (default) or 'severity'
+   * @param {string} [reviewFormat='severity'] - Optional review layout: 'severity' (default) or 'scoring'
    * @returns {Promise<Object>} - Code review results from Gemini API
    */
-  static async reviewPatchCode(patchContent, language = 'English', mrId = null, mrUrl = null, forceRegenerate = false, platform = null, reviewFormat = 'scoring') {
+  static async reviewPatchCode(patchContent, language = 'English', mrId = null, mrUrl = null, forceRegenerate = false, platform = null, reviewFormat = 'severity') {
     dbgLog('Sending patch for code review');
     
     if (!patchContent) {
@@ -366,8 +366,9 @@ export class CloudService {
         requestBody.platform = platform;
       }
 
-      // Include reviewFormat when not the default scoring layout
-      if (reviewFormat && reviewFormat !== 'scoring') {
+      // Always send reviewFormat so the API gets the extension preference
+      // (backend still defaults to scoring if omitted)
+      if (reviewFormat) {
         requestBody.reviewFormat = reviewFormat;
       }
       


### PR DESCRIPTION
This PR replaces blocking native browser dialogs (alert/confirm) with custom non-blocking UI components across sign-in, popup settings, and content interactions to improve UX consistency and tone.

It introduces reusable toast and confirm patterns in `components/google-signin/google-signin.js` and a new in-page toast module (`components/popup-modules/user-toast.js` + `user-toast.css`) used by `content.js` when users trigger actions on unsupported pages.

It also updates popup domain-management flows in `popup.js` to use styled `showMessage` toasts and async `showConfirm` dialogs, including revised user-facing copy for permission and validation errors.

Finally, it switches the default code review output format from `scoring` to `severity` in UI preference handling, content request assembly, and cloud service defaults, and ensures `reviewFormat` is always sent in review API requests.