### PR TITLE
Fix full sidebar layout so docked panel fills the viewport.

### DIFF
--- a/components/integrated-review.css
+++ b/components/integrated-review.css
@@ -2638,28 +2638,28 @@ body[data-theme="high-contrast"] #gitlab-mr-integrated-review .thinkreview-table
   right: auto;
 }
 
-/* ── Docked sidebar panel mode ───────────────────────────── */
-.thinkreview-panel-container.thinkreview-panel-docked {
+/* ── Full (docked) sidebar panel mode ──────────────────────
+   ID selectors on #gitlab-mr-integrated-review beat class-only
+   docked rules for top/height — keep full-bleed overrides here. */
+.thinkreview-panel-container.thinkreview-panel-docked,
+#gitlab-mr-integrated-review.thinkreview-panel-docked {
   right: 0;
   top: 0;
+  bottom: 0;
   height: 100vh;
+  min-height: 100vh;
   max-height: 100vh;
   border-radius: 0;
   z-index: var(--thinkreview-z-docked-panel);
 }
 
-/* Override #gitlab-mr-integrated-review so right-docked panel stays on the right when switching from left */
+/* Right-docked: pin to the right edge when switching from left */
 #gitlab-mr-integrated-review.thinkreview-panel-docked:not(.thinkreview-panel-docked-left) {
   left: auto;
   right: 0;
 }
 
-.thinkreview-panel-container.thinkreview-panel-docked.thinkreview-panel-docked-left {
-  left: 0;
-  right: auto;
-}
-
-/* Override #gitlab-mr-integrated-review so left-docked panel actually appears on the left */
+.thinkreview-panel-container.thinkreview-panel-docked.thinkreview-panel-docked-left,
 #gitlab-mr-integrated-review.thinkreview-panel-docked.thinkreview-panel-docked-left {
   left: 0;
   right: auto;

--- a/components/popup-modules/layout-settings-widget.js
+++ b/components/popup-modules/layout-settings-widget.js
@@ -32,17 +32,17 @@ const LAYOUT_GROUPS = [
     ],
   },
   {
-    label: 'Sidebar Tab',
-    combos: [
-      { id: 'tab-right', label: 'Right side', settings: { triggerMode: 'sidebar-tab', buttonPosition: 'bottom-right', panelMode: 'overlay', sidebarSide: 'right' } },
-      { id: 'tab-left',  label: 'Left side',  settings: { triggerMode: 'sidebar-tab', buttonPosition: 'bottom-right', panelMode: 'overlay', sidebarSide: 'left'  } },
-    ],
-  },
-  {
     label: 'Full Sidebar',
     combos: [
       { id: 'docked-right', label: 'Right side', settings: { triggerMode: 'sidebar-tab', buttonPosition: 'bottom-right', panelMode: 'docked', sidebarSide: 'right' } },
       { id: 'docked-left',  label: 'Left side',  settings: { triggerMode: 'sidebar-tab', buttonPosition: 'bottom-right', panelMode: 'docked', sidebarSide: 'left'  } },
+    ],
+  },
+  {
+    label: 'Sidebar Tab',
+    combos: [
+      { id: 'tab-right', label: 'Right side', settings: { triggerMode: 'sidebar-tab', buttonPosition: 'bottom-right', panelMode: 'overlay', sidebarSide: 'right' } },
+      { id: 'tab-left',  label: 'Left side',  settings: { triggerMode: 'sidebar-tab', buttonPosition: 'bottom-right', panelMode: 'overlay', sidebarSide: 'left'  } },
     ],
   },
 ];

--- a/components/popup-modules/layout-settings-widget.js
+++ b/components/popup-modules/layout-settings-widget.js
@@ -39,7 +39,7 @@ const LAYOUT_GROUPS = [
     ],
   },
   {
-    label: 'Docked Sidebar',
+    label: 'Full Sidebar',
     combos: [
       { id: 'docked-right', label: 'Right side', settings: { triggerMode: 'sidebar-tab', buttonPosition: 'bottom-right', panelMode: 'docked', sidebarSide: 'right' } },
       { id: 'docked-left',  label: 'Left side',  settings: { triggerMode: 'sidebar-tab', buttonPosition: 'bottom-right', panelMode: 'docked', sidebarSide: 'left'  } },
@@ -95,7 +95,7 @@ function _getActiveComboId(settings) {
   return getActiveLayoutComboId(settings);
 }
 
-/** Human-readable label for the current layout combo (e.g. "Docked Sidebar · Right side"). */
+/** Human-readable label for the current layout combo (e.g. "Full Sidebar · Right side"). */
 export function getLayoutComboSummary(settings) {
   const activeId = getActiveLayoutComboId(settings);
   for (const group of LAYOUT_GROUPS) {

--- a/components/popup-modules/panel-settings-tour.js
+++ b/components/popup-modules/panel-settings-tour.js
@@ -211,7 +211,7 @@ function _buildSteps(panelEl) {
     {
       id: 'layout',
       title: 'Choose a layout',
-      body: 'Floating, sidebar tab, or docked — left or right. Try a layout that keeps the PR readable while you review.',
+      body: 'Floating, sidebar tab, or full sidebar — left or right. Try a layout that keeps the PR readable while you review.',
       getTarget: async () => {
         const row = await _openLayoutSubmenu();
         return row || document.getElementById('thinkreview-settings-layout-submenu');


### PR DESCRIPTION
This PR updates the docked panel experience to position it as a full-height sidebar and aligns product copy to call that mode "Full Sidebar" instead of "Docked Sidebar".

In the CSS, docked-mode rules were broadened to target both the panel container and `#gitlab-mr-integrated-review` so full-bleed positioning reliably wins against more specific ID-based rules.

The docked layout now explicitly sets `top: 0`, `bottom: 0`, `height/min-height/max-height: 100vh`, and zero border radius, while preserving right/left pinning behavior for side-specific docked states.

In popup UI text, the layout group label and related documentation/tour strings were updated from "Docked Sidebar" to "Full Sidebar" for clearer terminology consistency.

No functional JavaScript behavior changed beyond user-facing labels and descriptive copy.