### PR TITLE
Feat/two step store feedback popup

### DIFF
--- a/assets/icons.js
+++ b/assets/icons.js
@@ -16,6 +16,9 @@ const SETTINGS_ICON_SVG = `<svg width="16" height="16" viewBox="0 0 24 24" fill=
 // Configure/Slider icon SVG constant
 const CONFIGURE_ICON_SVG = `<svg width="14" height="14" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><rect x="2" y="3" width="4" height="2.5" rx="1.25"/><circle cx="8" cy="4.25" r="1.5"/><rect x="10" y="3" width="8" height="2.5" rx="1.25"/><rect x="2" y="8.75" width="6" height="2.5" rx="1.25"/><circle cx="10" cy="10" r="1.5"/><rect x="12" y="8.75" width="6" height="2.5" rx="1.25"/><rect x="2" y="14.5" width="4" height="2.5" rx="1.25"/><circle cx="8" cy="15.75" r="1.5"/><rect x="10" y="14.5" width="8" height="2.5" rx="1.25"/></svg>`;
 
+// GitHub mark icon SVG constant
+const GITHUB_ICON_SVG = `<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>`;
+
 // Export constants (ES6 module syntax needed for dynamic imports, but structure is simple constants)
-export { REFRESH_ICON_SVG, SETTINGS_ICON_SVG, CONFIGURE_ICON_SVG };
+export { REFRESH_ICON_SVG, SETTINGS_ICON_SVG, CONFIGURE_ICON_SVG, GITHUB_ICON_SVG };
 

--- a/assets/icons.js
+++ b/assets/icons.js
@@ -19,6 +19,9 @@ const CONFIGURE_ICON_SVG = `<svg width="14" height="14" viewBox="0 0 20 20" fill
 // GitHub mark icon SVG constant
 const GITHUB_ICON_SVG = `<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>`;
 
+// Star icon for GitHub star CTA
+const STAR_ICON_SVG = `<svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25z"/></svg>`;
+
 // Export constants (ES6 module syntax needed for dynamic imports, but structure is simple constants)
-export { REFRESH_ICON_SVG, SETTINGS_ICON_SVG, CONFIGURE_ICON_SVG, GITHUB_ICON_SVG };
+export { REFRESH_ICON_SVG, SETTINGS_ICON_SVG, CONFIGURE_ICON_SVG, GITHUB_ICON_SVG, STAR_ICON_SVG };
 

--- a/components/integrated-review.css
+++ b/components/integrated-review.css
@@ -162,7 +162,7 @@
 }
 #gitlab-mr-integrated-review .thinkreview-card-title-row {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
 }
 
 #gitlab-mr-integrated-review .thinkreview-header-subscription {
@@ -1028,6 +1028,47 @@ body[data-theme="high-contrast"] #gitlab-mr-integrated-review .thinkreview-table
 #gitlab-mr-integrated-review .thinkreview-regenerate-btn:active {
   transform: scale(0.95);
   background-color: rgba(107, 79, 187, 0.3);
+}
+
+/* Version + GitHub stacked under the title row */
+#gitlab-mr-integrated-review .thinkreview-version-stack {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  margin-left: 6px;
+  padding-top: 10px;
+  line-height: 1.1;
+  gap: 2px;
+}
+
+#gitlab-mr-integrated-review .thinkreview-github-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  color: rgba(255, 255, 255, 0.85);
+  text-decoration: none;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  line-height: 1;
+  opacity: 0.9;
+  transition: opacity 0.15s ease, color 0.15s ease;
+}
+
+#gitlab-mr-integrated-review .thinkreview-github-btn:hover {
+  color: #ffffff;
+  opacity: 1;
+}
+
+#gitlab-mr-integrated-review .thinkreview-github-btn svg {
+  width: 11px;
+  height: 11px;
+  display: block;
+  flex-shrink: 0;
+}
+
+#gitlab-mr-integrated-review .thinkreview-github-label {
+  line-height: 1;
 }
 
 /* Wrapper for settings button + fast tooltip */
@@ -2564,10 +2605,15 @@ body[data-theme="high-contrast"] #gitlab-mr-integrated-review .thinkreview-table
   height: 20px;
   margin-right: 8px;
   flex-shrink: 0;
+  align-self: center;
+}
+
+#gitlab-mr-integrated-review .thinkreview-card-title-row > .gl-font-weight-bold {
+  align-self: center;
 }
 
 #gitlab-mr-integrated-review .thinkreview-version-link {
-  margin-left: 8px;
+  margin-left: 0;
   font-size: 11px;
   font-weight: 500;
   color: rgba(255, 255, 255, 0.8);

--- a/components/integrated-review.css
+++ b/components/integrated-review.css
@@ -147,7 +147,7 @@
   border-bottom: 1px solid #5a3ea5;
   display: flex;
   justify-content: space-between;
-  align-items: flex-start;
+  align-items: center;
   cursor: pointer;
   flex-shrink: 0;
   position: relative;
@@ -165,8 +165,15 @@
   align-items: flex-start;
 }
 
+#gitlab-mr-integrated-review .thinkreview-brand-block {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1px;
+}
+
 #gitlab-mr-integrated-review .thinkreview-header-subscription {
-  margin-left: 28px; /* align with "ThinkReview" (logo 20px + margin-right 8px) */
+  margin-left: 0;
   margin-top: -1px;
   padding: 0 5px;
   font-size: 9px;
@@ -201,7 +208,6 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  margin-top: -8px;
   flex-shrink: 0;
 }
 
@@ -1030,21 +1036,21 @@ body[data-theme="high-contrast"] #gitlab-mr-integrated-review .thinkreview-table
   background-color: rgba(107, 79, 187, 0.3);
 }
 
-/* Version + GitHub stacked under the title row */
+/* Version + GitHub star stacked beside the brand */
 #gitlab-mr-integrated-review .thinkreview-version-stack {
   display: inline-flex;
   flex-direction: column;
   align-items: flex-start;
   margin-left: 6px;
-  padding-top: 10px;
+  padding-top: 2px;
   line-height: 1.1;
-  gap: 2px;
+  gap: 6px;
 }
 
 #gitlab-mr-integrated-review .thinkreview-github-btn {
   display: inline-flex;
   align-items: center;
-  gap: 3px;
+  gap: 4px;
   color: rgba(255, 255, 255, 0.85);
   text-decoration: none;
   font-size: 9px;
@@ -2605,11 +2611,8 @@ body[data-theme="high-contrast"] #gitlab-mr-integrated-review .thinkreview-table
   height: 20px;
   margin-right: 8px;
   flex-shrink: 0;
-  align-self: center;
-}
-
-#gitlab-mr-integrated-review .thinkreview-card-title-row > .gl-font-weight-bold {
-  align-self: center;
+  align-self: flex-start;
+  margin-top: 1px;
 }
 
 #gitlab-mr-integrated-review .thinkreview-version-link {

--- a/components/integrated-review.js
+++ b/components/integrated-review.js
@@ -371,6 +371,7 @@ async function createIntegratedReviewPanel(patchUrl) {
   const iconsModule = await import(chrome.runtime.getURL('assets/icons.js'));
   const refreshIconSvg = iconsModule.REFRESH_ICON_SVG;
   const settingsIconSvg = iconsModule.SETTINGS_ICON_SVG;
+  const githubIconSvg = iconsModule.GITHUB_ICON_SVG;
   // Get logo URL
   const logoUrl = chrome.runtime.getURL('images/icon128.png');
   // Create the container for the review panel
@@ -386,7 +387,21 @@ async function createIntegratedReviewPanel(patchUrl) {
           <div class="thinkreview-card-title-row">
             <img src="${logoUrl}" alt="ThinkReview" class="thinkreview-header-logo">
             <span class="gl-font-weight-bold">ThinkReview</span>
-            <a id="extension-version-link" class="thinkreview-version-link" href="https://thinkreview.dev/release-notes" target="_blank" title="View release notes">v<span id="extension-version-text">...</span></a>
+            <span class="thinkreview-version-stack">
+              <a id="extension-version-link" class="thinkreview-version-link" href="https://thinkreview.dev/release-notes" target="_blank" title="View release notes">v<span id="extension-version-text">...</span></a>
+              <a
+                id="thinkreview-github-link"
+                class="thinkreview-github-btn"
+                href="https://github.com/Thinkode/thinkreview-browser-extension"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="ThinkReview on GitHub"
+                title="GitHub"
+              >
+                ${githubIconSvg}
+                <span class="thinkreview-github-label">GitHub</span>
+              </a>
+            </span>
           </div>
           <span id="review-subscription-label" class="thinkreview-header-subscription" aria-label="Current plan"></span>
         </div>
@@ -801,6 +816,20 @@ async function createIntegratedReviewPanel(patchUrl) {
     // No need to update the toggle icon in the header - it stays as a down arrow
   }
   
+  // GitHub link under version — don't minimize panel when opening the repo
+  const githubLink = container.querySelector('#thinkreview-github-link');
+  if (githubLink) {
+    githubLink.addEventListener('click', (e) => {
+      e.stopPropagation();
+    });
+  }
+  const versionLinkEl = container.querySelector('#extension-version-link');
+  if (versionLinkEl) {
+    versionLinkEl.addEventListener('click', (e) => {
+      e.stopPropagation();
+    });
+  }
+
   // Settings gear → inclusive dropdown (Layout + Implement via submenus + all settings)
   const settingsButton = container.querySelector('#thinkreview-settings-btn');
   if (settingsButton) {

--- a/components/integrated-review.js
+++ b/components/integrated-review.js
@@ -372,6 +372,7 @@ async function createIntegratedReviewPanel(patchUrl) {
   const refreshIconSvg = iconsModule.REFRESH_ICON_SVG;
   const settingsIconSvg = iconsModule.SETTINGS_ICON_SVG;
   const githubIconSvg = iconsModule.GITHUB_ICON_SVG;
+  const starIconSvg = iconsModule.STAR_ICON_SVG;
   // Get logo URL
   const logoUrl = chrome.runtime.getURL('images/icon128.png');
   // Create the container for the review panel
@@ -386,7 +387,10 @@ async function createIntegratedReviewPanel(patchUrl) {
         <div class="thinkreview-card-title">
           <div class="thinkreview-card-title-row">
             <img src="${logoUrl}" alt="ThinkReview" class="thinkreview-header-logo">
-            <span class="gl-font-weight-bold">ThinkReview</span>
+            <div class="thinkreview-brand-block">
+              <span class="gl-font-weight-bold">ThinkReview</span>
+              <span id="review-subscription-label" class="thinkreview-header-subscription" aria-label="Current plan"></span>
+            </div>
             <span class="thinkreview-version-stack">
               <a id="extension-version-link" class="thinkreview-version-link" href="https://thinkreview.dev/release-notes" target="_blank" title="View release notes">v<span id="extension-version-text">...</span></a>
               <a
@@ -395,15 +399,15 @@ async function createIntegratedReviewPanel(patchUrl) {
                 href="https://github.com/Thinkode/thinkreview-browser-extension"
                 target="_blank"
                 rel="noopener noreferrer"
-                aria-label="ThinkReview on GitHub"
-                title="GitHub"
+                aria-label="Star ThinkReview on GitHub"
+                title="Star us on GitHub"
               >
                 ${githubIconSvg}
-                <span class="thinkreview-github-label">GitHub</span>
+                ${starIconSvg}
+                <span class="thinkreview-github-label">Star</span>
               </a>
             </span>
           </div>
-          <span id="review-subscription-label" class="thinkreview-header-subscription" aria-label="Current plan"></span>
         </div>
         <div class="thinkreview-header-actions">
           <span class="thinkreview-regenerate-btn-wrapper">

--- a/components/integrated-review.js
+++ b/components/integrated-review.js
@@ -170,6 +170,48 @@ async function initReviewPromptComponent() {
 // Initialize the review prompt component
 initReviewPromptComponent();
 
+/**
+ * Refresh user data and show the store feedback prompt only when the
+ * integrated panel is open and eligibility conditions are met.
+ */
+async function maybeShowReviewPrompt() {
+  if (!reviewPrompt) return;
+
+  const panel = document.getElementById('gitlab-mr-integrated-review');
+  if (!panel || panel.classList.contains('thinkreview-panel-minimized-to-button')) {
+    return;
+  }
+
+  try {
+    const refreshResponse = await chrome.runtime.sendMessage({
+      type: 'REFRESH_USER_DATA_STORAGE'
+    });
+
+    if (refreshResponse.status === 'success') {
+      dbgLog('User data refreshed before feedback check:', {
+        hasEmail: !!refreshResponse.data?.email,
+        todayReviewCount: refreshResponse.data?.todayReviewCount
+      });
+    } else {
+      dbgWarn('Failed to refresh user data:', refreshResponse.error);
+    }
+
+    await reviewPrompt.checkAndShow();
+  } catch (error) {
+    dbgWarn('Error checking review prompt:', error);
+  }
+}
+
+window.maybeShowReviewPrompt = maybeShowReviewPrompt;
+
+function hideReviewPromptWhilePanelClosed() {
+  if (reviewPrompt) {
+    reviewPrompt.hideWhilePanelClosed();
+  } else if (window.reviewPrompt) {
+    window.reviewPrompt.hideWhilePanelClosed();
+  }
+}
+
 // Conversation history
 let conversationHistory = [];
 let currentPatchContent = '';
@@ -601,6 +643,9 @@ async function createIntegratedReviewPanel(patchUrl) {
       // Only minimize to the button, don't toggle
       container.classList.remove('thinkreview-panel-minimized', 'thinkreview-panel-hidden');
       container.classList.add('thinkreview-panel-minimized-to-button');
+
+      // Feedback prompt must not linger while the panel is closed
+      hideReviewPromptWhilePanelClosed();
 
       // Notify content.js to remove docked body margin
       document.dispatchEvent(new CustomEvent('thinkreview:panelminimized'));
@@ -2587,32 +2632,9 @@ async function displayIntegratedReview(
     });
   });
 
-  // Check if we should show the review prompt
-  setTimeout(async () => {
-    if (reviewPrompt) {
-      try {
-        // Refresh user data from server before checking feedback prompt
-        // This ensures we have the latest todayReviewCount and lastFeedbackPromptInteraction
-        const refreshResponse = await chrome.runtime.sendMessage({ 
-          type: 'REFRESH_USER_DATA_STORAGE' 
-        });
-        
-        if (refreshResponse.status === 'success') {
-          // Log only metadata, not full user data which may contain email
-          dbgLog('User data refreshed before feedback check:', {
-            hasEmail: !!refreshResponse.data?.email,
-            todayReviewCount: refreshResponse.data?.todayReviewCount
-          });
-        } else {
-          dbgWarn('Failed to refresh user data:', refreshResponse.error);
-        }
-        
-        // Now check if we should show the prompt (with fresh data in storage)
-        await reviewPrompt.checkAndShow();
-      } catch (error) {
-        // console.warn('Error checking review prompt:', error);
-      }
-    }
+  // Check if we should show the review prompt (only while the panel is open)
+  setTimeout(() => {
+    maybeShowReviewPrompt();
   }, 1000);
 
   // Handle code suggestions tab (modularized)

--- a/components/integrated-review.js
+++ b/components/integrated-review.js
@@ -170,35 +170,52 @@ async function initReviewPromptComponent() {
 // Initialize the review prompt component
 initReviewPromptComponent();
 
+// In-flight guard so overlapping callers (e.g. the post-review timeout firing
+// while toggleReviewPanel is also awaiting the same check) share one refresh
+// instead of issuing duplicate REFRESH_USER_DATA_STORAGE network round-trips.
+let _maybeShowReviewPromptInFlight = null;
+
 /**
  * Refresh user data and show the store feedback prompt only when the
  * integrated panel is open and eligibility conditions are met.
  */
 async function maybeShowReviewPrompt() {
-  if (!reviewPrompt) return;
-
-  const panel = document.getElementById('gitlab-mr-integrated-review');
-  if (!panel || panel.classList.contains('thinkreview-panel-minimized-to-button')) {
-    return;
+  if (_maybeShowReviewPromptInFlight) {
+    return _maybeShowReviewPromptInFlight;
   }
 
-  try {
-    const refreshResponse = await chrome.runtime.sendMessage({
-      type: 'REFRESH_USER_DATA_STORAGE'
-    });
+  _maybeShowReviewPromptInFlight = (async () => {
+    if (!reviewPrompt) return;
 
-    if (refreshResponse.status === 'success') {
-      dbgLog('User data refreshed before feedback check:', {
-        hasEmail: !!refreshResponse.data?.email,
-        todayReviewCount: refreshResponse.data?.todayReviewCount
-      });
-    } else {
-      dbgWarn('Failed to refresh user data:', refreshResponse.error);
+    const panel = document.getElementById('gitlab-mr-integrated-review');
+    if (!panel || panel.classList.contains('thinkreview-panel-minimized-to-button')) {
+      return;
     }
 
-    await reviewPrompt.checkAndShow();
-  } catch (error) {
-    dbgWarn('Error checking review prompt:', error);
+    try {
+      const refreshResponse = await chrome.runtime.sendMessage({
+        type: 'REFRESH_USER_DATA_STORAGE'
+      });
+
+      if (refreshResponse.status === 'success') {
+        dbgLog('User data refreshed before feedback check:', {
+          hasEmail: !!refreshResponse.data?.email,
+          todayReviewCount: refreshResponse.data?.todayReviewCount
+        });
+      } else {
+        dbgWarn('Failed to refresh user data:', refreshResponse.error);
+      }
+
+      await reviewPrompt.checkAndShow();
+    } catch (error) {
+      dbgWarn('Error checking review prompt:', error);
+    }
+  })();
+
+  try {
+    await _maybeShowReviewPromptInFlight;
+  } finally {
+    _maybeShowReviewPromptInFlight = null;
   }
 }
 

--- a/components/popup-modules/panel-settings-tour.js
+++ b/components/popup-modules/panel-settings-tour.js
@@ -611,12 +611,40 @@ function _runTour(panelEl) {
 }
 
 /**
- * Start the panel settings tour on first expand if the user hasn't seen it.
+ * Whether the user is signed in (extension OAuth or webapp Firebase auth).
+ * Mirrors the checks used in content.js / popup.js.
+ * @returns {Promise<boolean>}
+ */
+async function _isUserLoggedIn() {
+  try {
+    const result = await chrome.storage.local.get(['user', 'userData']);
+    if (result.userData && result.userData.email) return true;
+    if (result.user) {
+      try {
+        const userData = typeof result.user === 'string' ? JSON.parse(result.user) : result.user;
+        return !!(userData && userData.email);
+      } catch (_) {
+        return false;
+      }
+    }
+    return false;
+  } catch (e) {
+    dbgWarn('Failed to read login state for panel settings tour:', e);
+    return false;
+  }
+}
+
+/**
+ * Start the panel settings tour on first expand if the user is logged in
+ * and hasn't seen it yet. Not marked as seen while logged out, so it can
+ * still appear after the user signs in.
  * @param {HTMLElement} panelEl
  */
 export async function maybeStartPanelSettingsTour(panelEl) {
   if (!panelEl) return;
   if (document.getElementById(TOUR_ROOT_ID)) return;
+
+  if (!(await _isUserLoggedIn())) return;
 
   try {
     const result = await chrome.storage.local.get([PANEL_SETTINGS_TOUR_SEEN_KEY]);
@@ -637,6 +665,9 @@ export async function maybeStartPanelSettingsTour(panelEl) {
 
   await _delay(700);
   if (abort.signal.aborted) return;
+
+  // Re-check after the wait — user may have signed out, or another tab marked seen
+  if (!(await _isUserLoggedIn())) return;
 
   try {
     const again = await chrome.storage.local.get([PANEL_SETTINGS_TOUR_SEEN_KEY]);

--- a/components/review-prompt/review-prompt.css
+++ b/components/review-prompt/review-prompt.css
@@ -1,6 +1,6 @@
 /**
  * Review Prompt Component Styles
- * Modular CSS for the review prompt functionality
+ * Compact inline CTA + two-step store feedback popup
  */
 
 /* Review Prompt Container */
@@ -8,7 +8,6 @@
   margin-top: 8px;
 }
 
-/* Alert Styles */
 #review-prompt .gl-alert {
   padding: 10px 12px;
   border-radius: 8px;
@@ -32,86 +31,52 @@
   margin-bottom: 4px;
 }
 
-/* Modern Review Prompt */
-#review-prompt .review-prompt-modern {
+/* Compact inline CTA */
+#review-prompt .review-prompt-compact {
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   border: none;
   border-radius: 8px;
   color: white;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.12);
+  padding: 10px 12px;
 }
 
-#review-prompt .review-prompt-header {
+#review-prompt .review-prompt-compact-inner {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin-bottom: 10px;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
 }
 
-#review-prompt .review-prompt-icon {
-  font-size: 22px;
-  line-height: 1;
+#review-prompt .review-prompt-compact-copy {
+  flex: 1 1 180px;
+  min-width: 0;
 }
 
-#review-prompt .review-prompt-subtitle {
+#review-prompt .review-prompt-compact-subtitle {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+#review-prompt .review-prompt-compact-question {
   margin: 2px 0 0 0;
+  font-size: 11px;
   opacity: 0.9;
-  font-size: 12px;
+  line-height: 1.35;
 }
 
-#review-prompt .review-prompt-content {
-  padding-top: 4px;
-}
-
-#review-prompt .review-prompt-question {
-  font-size: 13px;
-  font-weight: 500;
-  margin-bottom: 10px;
-  text-align: center;
-}
-
-/* GitHub Link */
-#review-prompt .review-prompt-github-link {
-  margin: 8px 0 8px 0;
-  text-align: center;
-}
-
-#review-prompt .review-prompt-github-link a {
-  color: rgba(255, 255, 255, 0.9);
-  text-decoration: none;
-  font-size: 12px;
-  font-weight: 500;
-  transition: all 0.2s ease;
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 4px 10px;
-  border-radius: 4px;
-  background-color: rgba(255, 255, 255, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-}
-
-#review-prompt .review-prompt-github-link a:hover {
-  color: white;
-  background-color: rgba(255, 255, 255, 0.2);
-  border-color: rgba(255, 255, 255, 0.4);
-  transform: translateY(-1px);
-}
-
-#review-prompt .review-prompt-github-link a:active {
-  transform: translateY(0);
-}
-
-/* Modern Button Styles */
-#review-prompt .review-prompt-actions {
+#review-prompt .review-prompt-compact-actions {
   display: flex;
-  justify-content: center;
+  align-items: center;
   gap: 8px;
-  margin-top: 10px;
+  flex-shrink: 0;
 }
 
 #review-prompt .review-prompt-btn {
-  padding: 6px 14px;
+  padding: 6px 12px;
   border: 1px solid rgba(255, 255, 255, 0.3);
   border-radius: 6px;
   font-size: 12px;
@@ -125,108 +90,33 @@
   background-color: transparent;
   color: white;
   user-select: none;
+  white-space: nowrap;
 }
 
 #review-prompt .review-prompt-btn-secondary {
   background-color: rgba(255, 255, 255, 0.1);
   border-color: rgba(255, 255, 255, 0.3);
-  color: rgba(255, 255, 255, 0.9);
+  color: rgba(255, 255, 255, 0.95);
 }
 
 #review-prompt .review-prompt-btn-secondary:hover {
   background-color: rgba(255, 255, 255, 0.2);
   border-color: rgba(255, 255, 255, 0.5);
   color: white;
-  transform: translateY(-1px);
-}
-
-#review-prompt .review-prompt-btn-secondary:active {
-  transform: translateY(0);
 }
 
 #review-prompt .review-prompt-btn-primary {
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  border-color: rgba(255, 255, 255, 0.5);
-  border-width: 1px;
-  color: white;
+  background: rgba(255, 255, 255, 0.95);
+  border-color: rgba(255, 255, 255, 0.95);
+  color: #5a45b0;
   font-weight: 600;
 }
 
-#review-prompt .review-prompt-btn-primary:disabled {
-  background: rgba(255, 255, 255, 0.1);
-  border-color: rgba(255, 255, 255, 0.2);
-  color: rgba(255, 255, 255, 0.5);
-  cursor: not-allowed;
-  transform: none;
+#review-prompt .review-prompt-btn-primary:hover {
+  background: #ffffff;
+  color: #4a3799;
 }
 
-#review-prompt .review-prompt-btn-primary:enabled:hover,
-#review-prompt .review-prompt-btn-primary.enabled:hover {
-  background: linear-gradient(135deg, #5a6fd8 0%, #6a4190 100%);
-  border-color: rgba(255, 255, 255, 0.7);
-  transform: translateY(-2px);
-  box-shadow: 0 4px 20px rgba(102, 126, 234, 0.4);
-}
-
-#review-prompt .review-prompt-btn-primary:enabled:active,
-#review-prompt .review-prompt-btn-primary.enabled:active {
-  transform: translateY(0);
-}
-
-/* Legacy button styles for compatibility */
-#review-prompt .gl-btn {
-  padding: 6px 12px;
-  border: 1px solid #e1e4e8;
-  border-radius: 4px;
-  font-size: 12px;
-  font-weight: 500;
-  cursor: pointer;
-  text-decoration: none;
-  display: inline-block;
-  transition: all 0.2s ease;
-  background-color: #f6f8fa;
-  color: #24292e;
-  user-select: none;
-}
-
-#review-prompt .gl-btn-default {
-  background-color: #f6f8fa;
-  border-color: #e1e4e8;
-  color: #24292e;
-}
-
-#review-prompt .gl-btn-default:hover {
-  background-color: #e1e4e8;
-  border-color: #d1d5da;
-}
-
-#review-prompt .gl-btn-sm {
-  padding: 4px 8px;
-  font-size: 11px;
-}
-
-/* Layout Utilities */
-#review-prompt .gl-display-flex {
-  display: flex;
-}
-
-#review-prompt .gl-align-items-center {
-  align-items: center;
-}
-
-#review-prompt .gl-justify-content-center {
-  justify-content: center;
-}
-
-#review-prompt .gl-gap-2 {
-  gap: 8px;
-}
-
-#review-prompt .gl-gap-3 {
-  gap: 12px;
-}
-
-/* Spacing Utilities */
 #review-prompt .gl-mt-3 {
   margin-top: 12px;
 }
@@ -235,32 +125,12 @@
   margin-top: 16px;
 }
 
-#review-prompt .gl-mb-3 {
-  margin-bottom: 12px;
-}
-
-#review-prompt .gl-mr-3 {
-  margin-right: 12px;
-}
-
-#review-prompt .gl-p-3 {
-  padding: 12px;
-}
-
-#review-prompt .gl-mt-2 {
-  margin-top: 8px;
-}
-
-#review-prompt .gl-mb-2 {
-  margin-bottom: 8px;
-}
-
 /* Thank You Message */
 .review-thank-you-message {
-  animation: fadeIn 0.3s ease-in-out;
+  animation: reviewPromptFadeIn 0.3s ease-in-out;
 }
 
-@keyframes fadeIn {
+@keyframes reviewPromptFadeIn {
   from {
     opacity: 0;
     transform: translateY(-10px);
@@ -271,35 +141,235 @@
   }
 }
 
-/* Responsive Design */
+/* Two-step store feedback popup */
+.thinkreview-store-feedback-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: var(--thinkreview-z-modal-overlay, 100000);
+  animation: reviewPromptFadeIn 0.2s ease;
+}
+
+.thinkreview-store-feedback-popup {
+  background-color: #2d2d2d;
+  border: 2px solid #6b4fbb;
+  border-radius: 12px;
+  width: 90%;
+  max-width: 500px;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  animation: reviewPromptSlideUp 0.25s ease;
+}
+
+@keyframes reviewPromptSlideUp {
+  from {
+    transform: translateY(16px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+.thinkreview-store-feedback-header {
+  padding: 16px 20px;
+  border-bottom: 1px solid #404040;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.thinkreview-store-feedback-header h3 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: #ffffff;
+}
+
+.thinkreview-store-feedback-close {
+  background: none;
+  border: none;
+  color: #cccccc;
+  font-size: 28px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+}
+
+.thinkreview-store-feedback-close:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: #ffffff;
+}
+
+.thinkreview-store-feedback-body {
+  padding: 16px 20px;
+  overflow-y: auto;
+  color: #e6e6e6;
+}
+
+.thinkreview-store-feedback-body p {
+  margin: 0 0 12px 0;
+  font-size: 14px;
+  line-height: 1.45;
+}
+
+.thinkreview-store-feedback-label {
+  display: block;
+  font-size: 12px;
+  color: #bdbdbd;
+  margin-bottom: 6px;
+}
+
+.thinkreview-store-feedback-textarea {
+  width: 100%;
+  box-sizing: border-box;
+  min-height: 110px;
+  resize: vertical;
+  border-radius: 8px;
+  border: 1px solid #555;
+  background: #1f1f1f;
+  color: #ffffff;
+  padding: 10px 12px;
+  font-size: 13px;
+  line-height: 1.4;
+  font-family: inherit;
+}
+
+.thinkreview-store-feedback-textarea:focus {
+  outline: none;
+  border-color: #6b4fbb;
+}
+
+.thinkreview-store-feedback-char-count {
+  margin-top: 6px;
+  font-size: 11px;
+  color: #9e9e9e;
+  text-align: right;
+}
+
+.thinkreview-store-feedback-char-count--warn {
+  color: #ffb74d;
+}
+
+.thinkreview-store-feedback-reward {
+  margin: 0 0 12px 0;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: rgba(107, 79, 187, 0.25);
+  border: 1px solid rgba(107, 79, 187, 0.55);
+  color: #f3eefc;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.thinkreview-store-feedback-copy-btn {
+  margin-top: 8px;
+  background: transparent;
+  border: 1px solid #666;
+  color: #ddd;
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.thinkreview-store-feedback-copy-btn:hover {
+  border-color: #999;
+  color: #fff;
+}
+
+.thinkreview-store-feedback-error {
+  margin-top: 10px;
+  color: #ff8a80;
+  font-size: 12px;
+}
+
+.thinkreview-store-feedback-footer {
+  padding: 12px 20px 16px;
+  border-top: 1px solid #404040;
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.thinkreview-store-feedback-later-btn,
+.thinkreview-store-feedback-primary-btn {
+  padding: 8px 14px;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+
+.thinkreview-store-feedback-later-btn {
+  background: transparent;
+  border-color: #666;
+  color: #ddd;
+}
+
+.thinkreview-store-feedback-later-btn:hover {
+  border-color: #999;
+  color: #fff;
+}
+
+.thinkreview-store-feedback-primary-btn {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: #fff;
+  border-color: rgba(255, 255, 255, 0.25);
+  font-weight: 600;
+}
+
+.thinkreview-store-feedback-primary-btn:hover:not(:disabled) {
+  filter: brightness(1.05);
+}
+
+.thinkreview-store-feedback-primary-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
 @media (max-width: 480px) {
-  #review-prompt .gl-btn-sm {
-    padding: 3px 6px;
-    font-size: 10px;
+  #review-prompt .review-prompt-compact-inner {
+    flex-direction: column;
+    align-items: stretch;
   }
-  
-  #review-prompt .gl-gap-3 {
-    gap: 8px;
+
+  #review-prompt .review-prompt-compact-actions {
+    width: 100%;
+  }
+
+  #review-prompt .review-prompt-btn {
+    flex: 1;
   }
 }
 
-/* High Contrast Mode Support */
-@media (prefers-contrast: high) {
-  #review-prompt .gl-btn {
-    border-width: 2px;
-  }
-}
-
-/* Reduced Motion Support */
 @media (prefers-reduced-motion: reduce) {
-  .review-thank-you-message {
+  .review-thank-you-message,
+  .thinkreview-store-feedback-overlay,
+  .thinkreview-store-feedback-popup {
     animation: none;
   }
 }
 
-/* Print Styles */
 @media print {
-  #review-prompt {
+  #review-prompt,
+  .thinkreview-store-feedback-overlay {
     display: none !important;
   }
 }

--- a/components/review-prompt/review-prompt.css
+++ b/components/review-prompt/review-prompt.css
@@ -267,14 +267,56 @@
 }
 
 .thinkreview-store-feedback-reward {
-  margin: 0 0 12px 0;
-  padding: 10px 12px;
-  border-radius: 8px;
-  background: rgba(107, 79, 187, 0.25);
-  border: 1px solid rgba(107, 79, 187, 0.55);
-  color: #f3eefc;
-  font-size: 13px;
-  line-height: 1.4;
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  margin: 0 0 16px 0;
+  padding: 14px 14px 14px 12px;
+  border-radius: 10px;
+  background:
+    radial-gradient(120% 140% at 0% 0%, rgba(255, 214, 102, 0.22) 0%, transparent 45%),
+    linear-gradient(135deg, rgba(102, 126, 234, 0.55) 0%, rgba(118, 75, 162, 0.72) 100%);
+  border: 1px solid rgba(196, 181, 253, 0.55);
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.04) inset,
+    0 8px 24px rgba(102, 126, 234, 0.28);
+  color: #ffffff;
+}
+
+.thinkreview-store-feedback-reward-icon {
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: 999px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(145deg, #ffe08a 0%, #f5c242 100%);
+  color: #5a3d00;
+  box-shadow: 0 2px 8px rgba(245, 194, 66, 0.45);
+}
+
+.thinkreview-store-feedback-reward-copy {
+  min-width: 0;
+  flex: 1;
+}
+
+.thinkreview-store-feedback-reward-label {
+  display: inline-block;
+  margin-bottom: 4px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #ffe08a;
+}
+
+.thinkreview-store-feedback-reward-message {
+  margin: 0 !important;
+  font-size: 14px !important;
+  font-weight: 600;
+  line-height: 1.45 !important;
+  color: #ffffff;
 }
 
 .thinkreview-store-feedback-copy-btn {

--- a/components/review-prompt/review-prompt.css
+++ b/components/review-prompt/review-prompt.css
@@ -266,6 +266,40 @@
   color: #ffb74d;
 }
 
+.thinkreview-store-feedback-reward-hint {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin: 0 0 12px 0;
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: rgba(102, 126, 234, 0.16);
+  border: 1px solid rgba(196, 181, 253, 0.35);
+  color: #e8e0ff;
+}
+
+.thinkreview-store-feedback-reward-hint-label {
+  flex-shrink: 0;
+  margin-top: 1px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: rgba(255, 224, 138, 0.18);
+  border: 1px solid rgba(255, 224, 138, 0.45);
+  color: #ffe08a;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  line-height: 1.4;
+}
+
+.thinkreview-store-feedback-reward-hint-text {
+  min-width: 0;
+  font-size: 12px;
+  line-height: 1.4;
+  color: #f0ebff;
+}
+
 .thinkreview-store-feedback-reward {
   display: flex;
   align-items: flex-start;

--- a/components/review-prompt/review-prompt.js
+++ b/components/review-prompt/review-prompt.js
@@ -31,6 +31,7 @@ class ReviewPrompt {
     this.pendingFeedbackText = '';
     this.popupOverlay = null;
     this.popupStep = 1;
+    this.popupEventsAbort = null;
   }
 
   /**
@@ -477,20 +478,54 @@ class ReviewPrompt {
   }
 
   /**
-   * Open the two-step feedback popup
-   * @param {1|2} step
+   * Ensure a single overlay element exists and is attached to the document.
+   * Reused across step transitions to avoid remounting the shell.
+   * @returns {HTMLElement}
    */
-  openPopup(step = 1) {
-    this.closePopup({ trackLater: false });
-    this.popupStep = step;
+  ensurePopupOverlay() {
+    if (this.popupOverlay && this.popupOverlay.isConnected) {
+      return this.popupOverlay;
+    }
+
+    const orphan = document.getElementById('thinkreview-store-feedback-overlay');
+    if (orphan) orphan.remove();
 
     const overlay = document.createElement('div');
     overlay.id = 'thinkreview-store-feedback-overlay';
     overlay.className = 'thinkreview-store-feedback-overlay';
-    overlay.innerHTML = this.buildPopupHtml(step);
     document.body.appendChild(overlay);
     this.popupOverlay = overlay;
+    return overlay;
+  }
 
+  /**
+   * Abort any listeners bound to the current popup content.
+   */
+  clearPopupEvents() {
+    if (this.popupEventsAbort) {
+      this.popupEventsAbort.abort();
+      this.popupEventsAbort = null;
+    }
+  }
+
+  /**
+   * Open / advance the two-step feedback popup.
+   * Reuses the overlay shell; only the step content is replaced.
+   * @param {1|2} step
+   */
+  openPopup(step = 1) {
+    this.popupStep = step;
+    const overlay = this.ensurePopupOverlay();
+    this.renderPopupStep(overlay, step);
+  }
+
+  /**
+   * @param {HTMLElement} overlay
+   * @param {1|2} step
+   */
+  renderPopupStep(overlay, step) {
+    this.clearPopupEvents();
+    overlay.innerHTML = this.buildPopupHtml(step);
     this.bindPopupEvents(overlay, step);
 
     if (step === 1) {
@@ -571,25 +606,48 @@ class ReviewPrompt {
   }
 
   /**
+   * Bind overlay listeners with AbortController so they are removed on step change / close.
+   * Click handling is delegated from the overlay shell.
    * @param {HTMLElement} overlay
    * @param {1|2} step
    */
   bindPopupEvents(overlay, step) {
-    const closeBtn = overlay.querySelector('.thinkreview-store-feedback-close');
-    if (closeBtn) {
-      closeBtn.addEventListener('click', () => this.closePopup({ trackLater: false }));
-    }
+    this.clearPopupEvents();
+    this.popupEventsAbort = new AbortController();
+    const { signal } = this.popupEventsAbort;
 
     overlay.addEventListener('click', (e) => {
       if (e.target === overlay) {
         this.closePopup({ trackLater: false });
+        return;
       }
-    });
 
-    const laterBtn = overlay.querySelector('.thinkreview-store-feedback-later-btn');
-    if (laterBtn) {
-      laterBtn.addEventListener('click', () => this.dismiss());
-    }
+      if (e.target.closest('.thinkreview-store-feedback-close')) {
+        this.closePopup({ trackLater: false });
+        return;
+      }
+
+      if (e.target.closest('.thinkreview-store-feedback-later-btn')) {
+        this.dismiss();
+        return;
+      }
+
+      const copyBtn = e.target.closest('.thinkreview-store-feedback-copy-btn');
+      if (copyBtn) {
+        this.handleCopyFeedback(copyBtn, overlay);
+        return;
+      }
+
+      const primaryBtn = e.target.closest('.thinkreview-store-feedback-primary-btn');
+      if (primaryBtn && !primaryBtn.disabled) {
+        if (step === 1) {
+          const textarea = overlay.querySelector('#thinkreview-store-feedback-textarea');
+          this.handleFeedbackSubmit(textarea ? textarea.value : '');
+        } else {
+          this.handleStoreRedirect();
+        }
+      }
+    }, { signal });
 
     if (step === 1) {
       const textarea = overlay.querySelector('#thinkreview-store-feedback-textarea');
@@ -601,39 +659,32 @@ class ReviewPrompt {
           this.updateCharCount(textarea, charCount);
           submitBtn.disabled = textarea.value.trim().length === 0;
         };
-        textarea.addEventListener('input', onInput);
+        textarea.addEventListener('input', onInput, { signal });
         onInput();
-
-        submitBtn.addEventListener('click', () => {
-          this.handleFeedbackSubmit(textarea.value);
-        });
       }
-      return;
     }
+  }
 
-    const copyBtn = overlay.querySelector('.thinkreview-store-feedback-copy-btn');
-    if (copyBtn) {
-      copyBtn.addEventListener('click', async () => {
-        try {
-          await navigator.clipboard.writeText(this.pendingFeedbackText || '');
-          copyBtn.textContent = 'Copied!';
-          setTimeout(() => {
-            copyBtn.textContent = 'Copy feedback';
-          }, 1500);
-        } catch (err) {
-          dbgWarn('Clipboard copy failed:', err);
-          const preview = overlay.querySelector('#thinkreview-store-feedback-preview');
-          if (preview) {
-            preview.focus();
-            preview.select();
-          }
+  /**
+   * @param {HTMLElement} copyBtn
+   * @param {HTMLElement} overlay
+   */
+  async handleCopyFeedback(copyBtn, overlay) {
+    try {
+      await navigator.clipboard.writeText(this.pendingFeedbackText || '');
+      copyBtn.textContent = 'Copied!';
+      setTimeout(() => {
+        if (copyBtn.isConnected) {
+          copyBtn.textContent = 'Copy feedback';
         }
-      });
-    }
-
-    const storeBtn = overlay.querySelector('.thinkreview-store-feedback-primary-btn');
-    if (storeBtn) {
-      storeBtn.addEventListener('click', () => this.handleStoreRedirect());
+      }, 1500);
+    } catch (err) {
+      dbgWarn('Clipboard copy failed:', err);
+      const preview = overlay.querySelector('#thinkreview-store-feedback-preview');
+      if (preview) {
+        preview.focus();
+        preview.select();
+      }
     }
   }
 
@@ -659,6 +710,8 @@ class ReviewPrompt {
    * @param {{ trackLater?: boolean }} options
    */
   closePopup(options = {}) {
+    this.clearPopupEvents();
+
     if (this.popupOverlay) {
       this.popupOverlay.remove();
       this.popupOverlay = null;

--- a/components/review-prompt/review-prompt.js
+++ b/components/review-prompt/review-prompt.js
@@ -1,32 +1,38 @@
-import { dbgLog, dbgWarn, dbgError } from '../../utils/logger.js';
+import { dbgLog, dbgWarn } from '../../utils/logger.js';
 /**
  * Review Prompt Component
- * Modular component for handling user feedback prompts after generating reviews
+ * Compact inline CTA + two-step popup for store feedback
  */
-// Configuration
 const REVIEW_PROMPT_CONFIG = {
   threshold: 5, // Show prompt after 5 total reviews
   chromeStoreUrl: 'https://chromewebstore.google.com/detail/thinkreview-ai-code-revie/bpgkhgbchmlmpjjpmlaiejhnnbkdjdjn/reviews',
   firefoxStoreUrl: 'https://addons.mozilla.org/firefox/addon/thinkreview-code-review/reviews/',
-  feedbackUrl: 'https://thinkreview.dev/extension-feedback.html', // Updated to new extension-specific feedback form
+  feedbackUrl: 'https://thinkreview.dev/extension-feedback.html',
   // Only suppress the prompt for submits on/after this date (older submits are ignored)
   submitSuppressCutoffDate: '2026-06-07',
+  maxFeedbackLength: 2000,
   storageKeys: {
     reviewCount: 'reviewCount',
     todayReviewCount: 'todayReviewCount'
-    // Note: We no longer use localStorage/sessionStorage flags
-    // The source of truth is Firestore's lastFeedbackPromptInteraction
-    // which is cached in chrome.storage.local
   }
 };
+
+const DEFAULT_SUBTITLE = "We'd love to hear your feedback about ThinkReview";
+const DEFAULT_QUESTION = 'Would you mind leaving us a quick review?';
+const DEFAULT_REWARD_MESSAGE =
+  'Post your review on the Chrome Web Store or Firefox Add-ons and get 1 month of ThinkReview Lite free.';
 
 class ReviewPrompt {
   constructor(config = {}) {
     this.config = { ...REVIEW_PROMPT_CONFIG, ...config };
     this.isInitialized = false;
     this.eventListeners = new Map();
-    this.messages = null; // Cache for fetched messages
-    this.messagesFetchPromise = null; // Promise to prevent concurrent fetches
+    this.messages = null;
+    this.messagesFetchPromise = null;
+    this.popupAutoOpenedForShow = false;
+    this.pendingFeedbackText = '';
+    this.popupOverlay = null;
+    this.popupStep = 1;
   }
 
   /**
@@ -41,7 +47,7 @@ class ReviewPrompt {
 
     this.containerId = containerId;
     this.isInitialized = true;
-    
+
     dbgLog('Initialized with config:', this.config);
   }
 
@@ -58,6 +64,13 @@ class ReviewPrompt {
   }
 
   /**
+   * @returns {'chrome'|'firefox'}
+   */
+  getBrowserLabel() {
+    return this.isFirefoxBrowser() ? 'firefox' : 'chrome';
+  }
+
+  /**
    * Store review URL for the current browser.
    * @returns {string}
    */
@@ -65,6 +78,14 @@ class ReviewPrompt {
     return this.isFirefoxBrowser()
       ? this.config.firefoxStoreUrl
       : this.config.chromeStoreUrl;
+  }
+
+  /**
+   * Human-readable store name for copy.
+   * @returns {string}
+   */
+  getStoreDisplayName() {
+    return this.isFirefoxBrowser() ? 'Firefox Add-ons' : 'the Chrome Web Store';
   }
 
   /**
@@ -79,7 +100,6 @@ class ReviewPrompt {
 
   /**
    * Whether a prior submit should permanently hide the feedback prompt.
-   * Submissions before submitSuppressCutoffDate are ignored so users see the updated prompt.
    * @param {Object} lastFeedbackPromptInteraction
    * @returns {boolean}
    */
@@ -108,57 +128,48 @@ class ReviewPrompt {
 
   /**
    * Check if the review prompt should be shown
-   * @param {number} reviewCount - Current number of reviews generated
-   * @param {Object} lastFeedbackPromptInteraction - Last feedback prompt interaction data from Firestore
-   * @returns {boolean} - True if prompt should be shown
+   * @param {number} reviewCount
+   * @param {Object} lastFeedbackPromptInteraction
+   * @returns {boolean}
    */
   shouldShow(reviewCount, lastFeedbackPromptInteraction = null) {
-    // Check lastFeedbackPromptInteraction from Firestore (source of truth)
     if (lastFeedbackPromptInteraction && lastFeedbackPromptInteraction.action) {
       dbgLog('Last feedback prompt interaction from Firestore:', lastFeedbackPromptInteraction);
-      
-      // If action was "submit", only hide for submissions on/after the cutoff date
+
       if (this.shouldSuppressForSubmit(lastFeedbackPromptInteraction)) {
         return false;
       }
-      
-      // If action was "later", only show if more than 7 days have passed
+
       if (lastFeedbackPromptInteraction.action === 'later' && lastFeedbackPromptInteraction.date) {
         const lastInteractionDate = new Date(lastFeedbackPromptInteraction.date);
         const today = new Date();
         const daysSinceLastInteraction = Math.floor((today - lastInteractionDate) / (1000 * 60 * 60 * 24));
-        
+
         dbgLog('Days since last "later" interaction:', daysSinceLastInteraction);
-        
+
         if (daysSinceLastInteraction <= 7) {
           dbgLog('Not showing prompt: Less than 7 days since "later" (', daysSinceLastInteraction, 'days)');
           return false;
-        } else {
-          dbgLog('More than 7 days since "later", will check other conditions');
         }
+        dbgLog('More than 7 days since "later", will check other conditions');
       }
-      
-      // If action was "never", never show the prompt
+
       if (lastFeedbackPromptInteraction.action === 'never') {
         dbgLog('Not showing prompt: User selected "never ask again" in Firestore');
         return false;
       }
     }
-    
-    // Show prompt when review count reaches the threshold
+
     const shouldShow = reviewCount >= this.config.threshold;
     dbgLog('Should show prompt:', shouldShow, '(count:', reviewCount, '>=', this.config.threshold, ')');
     return shouldShow;
   }
 
   /**
-   * Get the total review count from storage
-   * @returns {Promise<number>} - Total review count across all time
+   * @returns {Promise<number>}
    */
   async getCurrentReviewCount() {
     return new Promise((resolve) => {
-      // Get total reviewCount from storage (not daily count)
-      // This is kept up-to-date by the background service and incremented after each review
       chrome.storage.local.get([this.config.storageKeys.reviewCount], (result) => {
         const count = result[this.config.storageKeys.reviewCount] || 0;
         dbgLog('Got total reviewCount from storage:', count);
@@ -169,29 +180,27 @@ class ReviewPrompt {
 
   /**
    * Check and show the review prompt if conditions are met
-   * @returns {Promise<boolean>} - True if prompt was shown
+   * @returns {Promise<boolean>}
    */
   async checkAndShow() {
     try {
       const reviewCount = await this.getCurrentReviewCount();
       dbgLog('Total review count:', reviewCount, '| Threshold:', this.config.threshold);
-      
-      // Get lastFeedbackPromptInteraction from storage
+
       const lastFeedbackPromptInteraction = await new Promise((resolve) => {
         chrome.storage.local.get(['lastFeedbackPromptInteraction'], (result) => {
           resolve(result.lastFeedbackPromptInteraction || null);
         });
       });
       dbgLog('Last feedback prompt interaction from storage:', lastFeedbackPromptInteraction);
-      
+
       if (this.shouldShow(reviewCount, lastFeedbackPromptInteraction)) {
         dbgLog('Conditions met, showing prompt');
         await this.show(reviewCount);
         return true;
-      } else {
-        dbgLog('Conditions not met, not showing prompt');
       }
-      
+
+      dbgLog('Conditions not met, not showing prompt');
       return false;
     } catch (error) {
       dbgWarn('Error checking review prompt:', error);
@@ -200,8 +209,8 @@ class ReviewPrompt {
   }
 
   /**
-   * Show the review prompt
-   * @param {number} reviewCount - The current review count to display
+   * Show compact CTA and auto-open the two-step popup once per show cycle.
+   * @param {number} reviewCount
    */
   async show(reviewCount = this.config.threshold) {
     const container = document.getElementById(this.containerId);
@@ -210,35 +219,33 @@ class ReviewPrompt {
       return;
     }
 
-    // Fetch messages asynchronously (will use cache if already fetched)
-    // This is non-blocking - if fetch fails, will use fallback messages
     try {
       await this.fetchMessages();
     } catch (error) {
       dbgWarn('Failed to fetch messages, using fallbacks:', error);
-      // Continue with fallback messages
     }
 
-    // Create the prompt HTML if it doesn't exist
     let promptElement = container.querySelector('#review-prompt');
     if (!promptElement) {
       promptElement = this.createPromptElement(reviewCount);
-      
-      // Add to the end of the container (original working approach)
       container.appendChild(promptElement);
+    } else {
+      this.refreshInlineCtaCopy(promptElement);
     }
 
-    // Show the prompt
     promptElement.classList.remove('gl-hidden');
-    
-    // Add event listeners
     this.addEventListeners(promptElement);
-    
+
+    if (!this.popupAutoOpenedForShow) {
+      this.popupAutoOpenedForShow = true;
+      this.openPopup(1);
+    }
+
     dbgLog('Prompt shown');
   }
 
   /**
-   * Hide the review prompt
+   * Hide the compact inline CTA
    */
   hide() {
     const promptElement = document.getElementById('review-prompt');
@@ -249,8 +256,8 @@ class ReviewPrompt {
 
   /**
    * Escape HTML to prevent XSS
-   * @param {string} text - Text to escape
-   * @returns {string} - Escaped HTML
+   * @param {string} text
+   * @returns {string}
    */
   escapeHtml(text) {
     const div = document.createElement('div');
@@ -258,102 +265,101 @@ class ReviewPrompt {
     return div.innerHTML;
   }
 
+  getSubtitle() {
+    return (this.messages && this.messages.subtitle) ? this.messages.subtitle : DEFAULT_SUBTITLE;
+  }
+
+  getQuestion() {
+    return (this.messages && this.messages.question) ? this.messages.question : DEFAULT_QUESTION;
+  }
+
+  isRewardEnabled() {
+    return !!(this.messages && this.messages.rewardEnabled === true);
+  }
+
+  getRewardMessage() {
+    if (!this.isRewardEnabled()) return '';
+    if (this.messages && typeof this.messages.rewardMessage === 'string' && this.messages.rewardMessage.trim()) {
+      return this.messages.rewardMessage.trim();
+    }
+    return DEFAULT_REWARD_MESSAGE;
+  }
+
   /**
-   * Create the review prompt HTML element
-   * @param {number} reviewCount - The current review count to display
-   * @returns {HTMLElement} - The prompt element
+   * Compact inline CTA
+   * @returns {HTMLElement}
    */
-  createPromptElement(reviewCount = this.config.threshold) {
-    // Fallback messages (hardcoded defaults)
-    const DEFAULT_SUBTITLE = "We'd love to hear your feedback about ThinkReview";
-    const DEFAULT_QUESTION = "Would you mind leaving us a quick review?";
-    
-    // Use fetched messages if available, otherwise use fallbacks
-    const subtitle = (this.messages && this.messages.subtitle) ? this.messages.subtitle : DEFAULT_SUBTITLE;
-    const question = (this.messages && this.messages.question) ? this.messages.question : DEFAULT_QUESTION;
-    
-    // Escape HTML to prevent XSS
-    const escapedSubtitle = this.escapeHtml(subtitle);
-    const escapedQuestion = this.escapeHtml(question);
-    
+  createPromptElement() {
+    const subtitle = this.escapeHtml(this.getSubtitle());
+    const question = this.escapeHtml(this.getQuestion());
+
     const promptDiv = document.createElement('div');
     promptDiv.id = 'review-prompt';
     promptDiv.className = 'gl-hidden';
     promptDiv.innerHTML = `
-      <div class="gl-alert gl-alert-info gl-mt-4 review-prompt-modern">
-        <div class="gl-alert-content">
-          <div class="review-prompt-header">
-            <div class="review-prompt-icon">🎉</div>
-            <div>
-              <p class="review-prompt-subtitle">${escapedSubtitle}</p>
-            </div>
+      <div class="gl-alert gl-alert-info gl-mt-4 review-prompt-compact">
+        <div class="gl-alert-content review-prompt-compact-inner">
+          <div class="review-prompt-compact-copy">
+            <p class="review-prompt-compact-subtitle">${subtitle}</p>
+            <p class="review-prompt-compact-question">${question}</p>
           </div>
-          
-          <div class="review-prompt-content">
-            <p class="review-prompt-question">${escapedQuestion}</p>
-            
-            <div class="review-prompt-github-link">
-              <a href="https://github.com/Thinkode/thinkreview-browser-extension" target="_blank" rel="noopener noreferrer">
-                Star our Repo on Github
-              </a>
-            </div>
-            
-            <div class="review-prompt-actions">
-              <button id="review-prompt-dismiss" class="review-prompt-btn review-prompt-btn-secondary">Maybe Later</button>
-              <button id="review-prompt-submit" class="review-prompt-btn review-prompt-btn-primary">Leave a Review</button>
-            </div>
+          <div class="review-prompt-compact-actions">
+            <button type="button" id="review-prompt-open" class="review-prompt-btn review-prompt-btn-primary">
+              Share feedback
+            </button>
+            <button type="button" id="review-prompt-dismiss" class="review-prompt-btn review-prompt-btn-secondary">
+              Maybe Later
+            </button>
           </div>
         </div>
       </div>
     `;
-    
+
     return promptDiv;
   }
 
+  refreshInlineCtaCopy(promptElement) {
+    const subtitleEl = promptElement.querySelector('.review-prompt-compact-subtitle');
+    const questionEl = promptElement.querySelector('.review-prompt-compact-question');
+    if (subtitleEl) subtitleEl.textContent = this.getSubtitle();
+    if (questionEl) questionEl.textContent = this.getQuestion();
+  }
+
   /**
-   * Add event listeners to the prompt
-   * @param {HTMLElement} promptElement - The prompt element
+   * @param {HTMLElement} promptElement
    */
   addEventListeners(promptElement) {
-    // Remove existing listeners to prevent duplicates
     this.removeEventListeners(promptElement);
 
-    // Dismiss button
     const dismissBtn = promptElement.querySelector('#review-prompt-dismiss');
     if (dismissBtn) {
       const listener = (e) => {
         e.preventDefault();
         this.dismiss();
       };
-      
       dismissBtn.addEventListener('click', listener);
       this.eventListeners.set(dismissBtn, listener);
     }
 
-    // Submit button
-    const submitBtn = promptElement.querySelector('#review-prompt-submit');
-    if (submitBtn) {
+    const openBtn = promptElement.querySelector('#review-prompt-open');
+    if (openBtn) {
       const listener = (e) => {
         e.preventDefault();
-        this.handleSubmit();
+        this.openPopup(1);
       };
-      
-      submitBtn.addEventListener('click', listener);
-      this.eventListeners.set(submitBtn, listener);
+      openBtn.addEventListener('click', listener);
+      this.eventListeners.set(openBtn, listener);
     }
   }
 
   /**
-   * Remove event listeners from the prompt
-   * @param {HTMLElement} promptElement - The prompt element
+   * @param {HTMLElement} promptElement
    */
   removeEventListeners(promptElement) {
     this.eventListeners.forEach((listeners, element) => {
       if (typeof listeners === 'function') {
-        // Old style single listener
         element.removeEventListener('click', listeners);
       } else if (typeof listeners === 'object') {
-        // New style multiple listeners
         if (listeners.mouseEnterListener) {
           element.removeEventListener('mouseenter', listeners.mouseEnterListener);
         }
@@ -369,95 +375,371 @@ class ReviewPrompt {
   }
 
   /**
-   * Handle user choosing to leave a review
+   * Open the two-step feedback popup
+   * @param {1|2} step
    */
-  async handleSubmit() {
-    dbgLog('User chose to leave a review');
-    
-    this.hide();
-    
+  openPopup(step = 1) {
+    this.closePopup({ trackLater: false });
+    this.popupStep = step;
+
+    const overlay = document.createElement('div');
+    overlay.id = 'thinkreview-store-feedback-overlay';
+    overlay.className = 'thinkreview-store-feedback-overlay';
+    overlay.innerHTML = this.buildPopupHtml(step);
+    document.body.appendChild(overlay);
+    this.popupOverlay = overlay;
+
+    this.bindPopupEvents(overlay, step);
+
+    if (step === 1) {
+      const textarea = overlay.querySelector('#thinkreview-store-feedback-textarea');
+      if (textarea) {
+        if (this.pendingFeedbackText) {
+          textarea.value = this.pendingFeedbackText;
+          this.updateCharCount(overlay);
+        }
+        setTimeout(() => textarea.focus(), 100);
+      }
+    }
+  }
+
+  /**
+   * @param {1|2} step
+   * @returns {string}
+   */
+  buildPopupHtml(step) {
+    const storeName = this.escapeHtml(this.getStoreDisplayName());
+    if (step === 2) {
+      const feedbackPreview = this.escapeHtml(this.pendingFeedbackText || '');
+      const rewardEnabled = this.isRewardEnabled();
+      const rewardMessage = this.escapeHtml(this.getRewardMessage());
+      const rewardBlock = rewardEnabled && rewardMessage
+        ? `<div class="thinkreview-store-feedback-reward">${rewardMessage}</div>`
+        : '';
+
+      return `
+        <div class="thinkreview-store-feedback-popup" role="dialog" aria-modal="true">
+          <div class="thinkreview-store-feedback-header">
+            <h3>One last step</h3>
+            <button type="button" class="thinkreview-store-feedback-close" title="Close" aria-label="Close">×</button>
+          </div>
+          <div class="thinkreview-store-feedback-body">
+            <p>Spend about 10 seconds posting this feedback on ${storeName}.</p>
+            ${rewardBlock}
+            <label class="thinkreview-store-feedback-label" for="thinkreview-store-feedback-preview">Your feedback (copy &amp; paste)</label>
+            <textarea
+              id="thinkreview-store-feedback-preview"
+              class="thinkreview-store-feedback-textarea"
+              readonly
+              rows="5"
+            >${feedbackPreview}</textarea>
+            <button type="button" class="thinkreview-store-feedback-copy-btn">Copy feedback</button>
+          </div>
+          <div class="thinkreview-store-feedback-footer">
+            <button type="button" class="thinkreview-store-feedback-later-btn">Maybe Later</button>
+            <button type="button" class="thinkreview-store-feedback-primary-btn">Post on ${storeName}</button>
+          </div>
+        </div>
+      `;
+    }
+
+    return `
+      <div class="thinkreview-store-feedback-popup" role="dialog" aria-modal="true">
+        <div class="thinkreview-store-feedback-header">
+          <h3>Share your feedback</h3>
+          <button type="button" class="thinkreview-store-feedback-close" title="Close" aria-label="Close">×</button>
+        </div>
+        <div class="thinkreview-store-feedback-body">
+          <p>What did you like, or what should we improve? Your note helps us keep ThinkReview free and open source.</p>
+          <textarea
+            id="thinkreview-store-feedback-textarea"
+            class="thinkreview-store-feedback-textarea"
+            placeholder="Write a short review of your experience..."
+            maxlength="${this.config.maxFeedbackLength}"
+            rows="5"
+          ></textarea>
+          <div class="thinkreview-store-feedback-char-count">0/${this.config.maxFeedbackLength}</div>
+        </div>
+        <div class="thinkreview-store-feedback-footer">
+          <button type="button" class="thinkreview-store-feedback-later-btn">Maybe Later</button>
+          <button type="button" class="thinkreview-store-feedback-primary-btn" disabled>Submit feedback</button>
+        </div>
+      </div>
+    `;
+  }
+
+  /**
+   * @param {HTMLElement} overlay
+   * @param {1|2} step
+   */
+  bindPopupEvents(overlay, step) {
+    const closeBtn = overlay.querySelector('.thinkreview-store-feedback-close');
+    if (closeBtn) {
+      closeBtn.addEventListener('click', () => this.closePopup({ trackLater: false }));
+    }
+
+    overlay.addEventListener('click', (e) => {
+      if (e.target === overlay) {
+        this.closePopup({ trackLater: false });
+      }
+    });
+
+    const laterBtn = overlay.querySelector('.thinkreview-store-feedback-later-btn');
+    if (laterBtn) {
+      laterBtn.addEventListener('click', () => this.dismiss());
+    }
+
+    if (step === 1) {
+      const textarea = overlay.querySelector('#thinkreview-store-feedback-textarea');
+      const submitBtn = overlay.querySelector('.thinkreview-store-feedback-primary-btn');
+
+      if (textarea && submitBtn) {
+        const onInput = () => {
+          this.updateCharCount(overlay);
+          submitBtn.disabled = textarea.value.trim().length === 0;
+        };
+        textarea.addEventListener('input', onInput);
+        onInput();
+
+        submitBtn.addEventListener('click', () => {
+          this.handleFeedbackSubmit(textarea.value);
+        });
+      }
+      return;
+    }
+
+    const copyBtn = overlay.querySelector('.thinkreview-store-feedback-copy-btn');
+    if (copyBtn) {
+      copyBtn.addEventListener('click', async () => {
+        try {
+          await navigator.clipboard.writeText(this.pendingFeedbackText || '');
+          copyBtn.textContent = 'Copied!';
+          setTimeout(() => {
+            copyBtn.textContent = 'Copy feedback';
+          }, 1500);
+        } catch (err) {
+          dbgWarn('Clipboard copy failed:', err);
+          const preview = overlay.querySelector('#thinkreview-store-feedback-preview');
+          if (preview) {
+            preview.focus();
+            preview.select();
+          }
+        }
+      });
+    }
+
+    const storeBtn = overlay.querySelector('.thinkreview-store-feedback-primary-btn');
+    if (storeBtn) {
+      storeBtn.addEventListener('click', () => this.handleStoreRedirect());
+    }
+  }
+
+  /**
+   * @param {HTMLElement} overlay
+   */
+  updateCharCount(overlay) {
+    const textarea = overlay.querySelector('#thinkreview-store-feedback-textarea');
+    const charCount = overlay.querySelector('.thinkreview-store-feedback-char-count');
+    if (!textarea || !charCount) return;
+
+    const length = textarea.value.length;
+    const max = this.config.maxFeedbackLength;
+    charCount.textContent = `${length}/${max}`;
+    if (length > max * 0.9) {
+      charCount.classList.add('thinkreview-store-feedback-char-count--warn');
+    } else {
+      charCount.classList.remove('thinkreview-store-feedback-char-count--warn');
+    }
+  }
+
+  /**
+   * Close popup without dismissing the CTA unless requested.
+   * @param {{ trackLater?: boolean }} options
+   */
+  closePopup(options = {}) {
+    if (this.popupOverlay) {
+      this.popupOverlay.remove();
+      this.popupOverlay = null;
+    } else {
+      const existing = document.getElementById('thinkreview-store-feedback-overlay');
+      if (existing) existing.remove();
+    }
+
+    if (options.trackLater) {
+      this.dismiss();
+    }
+  }
+
+  /**
+   * Step 1: send feedback to backend, then advance to step 2.
+   * @param {string} feedbackText
+   */
+  async handleFeedbackSubmit(feedbackText) {
+    const text = (feedbackText || '').trim();
+    if (!text) return;
+
+    const overlay = this.popupOverlay;
+    const submitBtn = overlay && overlay.querySelector('.thinkreview-store-feedback-primary-btn');
+    if (submitBtn) {
+      submitBtn.disabled = true;
+      submitBtn.textContent = 'Submitting...';
+    }
+
+    try {
+      await this.ensureCloudService();
+      const email = await this.getUserEmail();
+      if (!email) {
+        throw new Error('No user email available');
+      }
+
+      await window.CloudService.submitExtensionFeedback(email, text, {
+        source: 'extension_review_prompt',
+        browser: this.getBrowserLabel()
+      });
+
+      this.pendingFeedbackText = text;
+
+      // Keep local dismiss cache in sync with backend action: 'feedback'
+      chrome.storage.local.set({
+        lastFeedbackPromptInteraction: {
+          action: 'feedback',
+          feedbackText: text,
+          date: new Date().toISOString()
+        }
+      });
+
+      this.openPopup(2);
+      this.emit('feedback-submitted', { reviewCount: await this.getCurrentReviewCount() });
+    } catch (error) {
+      dbgWarn('Failed to submit extension feedback:', error);
+      if (submitBtn) {
+        submitBtn.disabled = false;
+        submitBtn.textContent = 'Submit feedback';
+      }
+      this.showInlineError(overlay, 'Could not send feedback. Please try again.');
+    }
+  }
+
+  /**
+   * @param {HTMLElement|null} overlay
+   * @param {string} message
+   */
+  showInlineError(overlay, message) {
+    if (!overlay) return;
+    let err = overlay.querySelector('.thinkreview-store-feedback-error');
+    if (!err) {
+      err = document.createElement('div');
+      err.className = 'thinkreview-store-feedback-error';
+      const body = overlay.querySelector('.thinkreview-store-feedback-body');
+      if (body) body.appendChild(err);
+    }
+    err.textContent = message;
+  }
+
+  /**
+   * Step 2: open store reviews page and suppress future prompts.
+   */
+  async handleStoreRedirect() {
+    dbgLog('User chose to leave a store review');
+
     const redirectUrl = this.getStoreReviewUrl();
     window.open(redirectUrl, '_blank');
+
+    this.closePopup({ trackLater: false });
+    this.hide();
+    this.popupAutoOpenedForShow = false;
     this.showThankYouMessage(this.getStoreReviewThankYouMessage());
-    
+
+    chrome.storage.local.set({
+      lastFeedbackPromptInteraction: {
+        action: 'submit',
+        feedbackText: this.pendingFeedbackText || null,
+        date: new Date().toISOString()
+      }
+    });
+
     this.trackReviewPromptInteraction('submit', null, redirectUrl)
-      .catch(error => {
+      .catch((error) => {
         dbgWarn('Background tracking failed:', error);
       });
-    
-    this.emit('rated', { reviewCount: this.getCurrentReviewCount() });
+
+    const reviewCount = await this.getCurrentReviewCount();
+    this.emit('rated', { reviewCount });
   }
 
   /**
-   * Dismiss the review prompt (user clicked "Maybe Later")
+   * Dismiss CTA + popup (Maybe Later)
    */
   dismiss() {
+    this.closePopup({ trackLater: false });
     this.hide();
+    this.popupAutoOpenedForShow = false;
     dbgLog('Prompt dismissed - tracking "later" action in Firestore');
-    
-    // Emit custom event
+
     this.emit('dismissed', { permanent: false });
-    
-    // Track the interaction with the cloud function in the background (non-blocking)
-    // This updates Firestore with action='later' and current date
-    // Next time user data is fetched, it will check if 7 days have passed
+
+    chrome.storage.local.set({
+      lastFeedbackPromptInteraction: {
+        action: 'later',
+        date: new Date().toISOString()
+      }
+    });
+
     this.trackReviewPromptInteraction('later')
-      .catch(error => {
-        // Silently handle errors to avoid affecting user experience
+      .catch((error) => {
         dbgWarn('Background tracking failed:', error);
       });
   }
 
   /**
-   * Dismiss the review prompt permanently (user clicked "Never")
+   * Permanently dismiss
    */
   dismissPermanently() {
+    this.closePopup({ trackLater: false });
     this.hide();
+    this.popupAutoOpenedForShow = false;
     dbgLog('Prompt dismissed permanently - tracking "never" action in Firestore');
-    
-    // Emit custom event
+
     this.emit('dismissed', { permanent: true });
-    
-    // Track the interaction with the cloud function in the background (non-blocking)
-    // This updates Firestore with action='never'
-    // User will never be prompted again on any device
+
+    chrome.storage.local.set({
+      lastFeedbackPromptInteraction: {
+        action: 'never',
+        date: new Date().toISOString()
+      }
+    });
+
     this.trackReviewPromptInteraction('never')
-      .catch(error => {
-        // Silently handle errors to avoid affecting user experience
+      .catch((error) => {
         dbgWarn('Background tracking failed:', error);
       });
   }
 
   /**
-   * Show a thank you message after rating
-   * @param {string} message - Message to display
+   * @param {string} message
    */
   showThankYouMessage(message) {
     const container = document.getElementById(this.containerId);
     if (!container) return;
 
-    // Remove existing thank you message
     const existingMessage = container.querySelector('.review-thank-you-message');
     if (existingMessage) {
       existingMessage.remove();
     }
 
-    // Create new thank you message
     const thankYouDiv = document.createElement('div');
     thankYouDiv.className = 'gl-alert gl-alert-success gl-mt-3 review-thank-you-message';
     thankYouDiv.innerHTML = `
       <div class="gl-alert-content">
-        <div class="gl-alert-title">Thank you! 🙏</div>
-        <div>${message}</div>
+        <div class="gl-alert-title">Thank you!</div>
+        <div>${this.escapeHtml(message)}</div>
       </div>
     `;
-    
-    // Insert after the review prompt
+
     const reviewPrompt = container.querySelector('#review-prompt');
     if (reviewPrompt && reviewPrompt.parentNode) {
       reviewPrompt.parentNode.insertBefore(thankYouDiv, reviewPrompt.nextSibling);
-      
-      // Remove the message after 5 seconds
+
       setTimeout(() => {
         if (thankYouDiv.parentNode) {
           thankYouDiv.parentNode.removeChild(thankYouDiv);
@@ -466,85 +748,49 @@ class ReviewPrompt {
     }
   }
 
-  /**
-   * Reset all dismissal preferences (for testing)
-   * Note: This only clears the local cache
-   * The source of truth is in Firestore (lastFeedbackPromptInteraction)
-   * To truly reset, you need to update Firestore via the cloud function
-   */
   resetPreferences() {
+    this.popupAutoOpenedForShow = false;
     chrome.storage.local.remove(['lastFeedbackPromptInteraction'], () => {
       dbgLog('Local cache cleared - will be refreshed on next user data fetch');
     });
   }
 
-  /**
-   * Force show the prompt (for testing)
-   */
   forceShow() {
     dbgLog('Force showing prompt');
+    this.popupAutoOpenedForShow = false;
     this.show();
   }
 
-  /**
-   * Comprehensive debugging function
-   */
   async debugInfo() {
     dbgLog('=== ReviewPrompt Debug Info ===');
     dbgLog('Configuration:', this.config);
     dbgLog('Initialized:', this.isInitialized);
     dbgLog('Container ID:', this.containerId);
-    
+    dbgLog('Messages:', this.messages);
+
     const container = document.getElementById(this.containerId);
     dbgLog('Container found:', !!container);
-    
+
     const reviewCount = await this.getCurrentReviewCount();
     dbgLog('Current review count:', reviewCount);
-    
-    // Get lastFeedbackPromptInteraction from storage
+
     const lastFeedbackPromptInteraction = await new Promise((resolve) => {
       chrome.storage.local.get(['lastFeedbackPromptInteraction'], (result) => {
         resolve(result.lastFeedbackPromptInteraction || null);
       });
     });
     dbgLog('Last feedback prompt interaction:', lastFeedbackPromptInteraction);
-    
+
     const shouldShow = this.shouldShow(reviewCount, lastFeedbackPromptInteraction);
     dbgLog('Should show:', shouldShow);
-    
-    // Check storage directly
-    chrome.storage.local.get([this.config.storageKeys.reviewCount], (result) => {
-      dbgLog('Storage result:', result);
-    });
-    
-    // Check CloudService
-    dbgLog('CloudService available:', !!window.CloudService);
-    if (window.CloudService) {
-      try {
-        const cloudCount = await window.CloudService.getReviewCount();
-        dbgLog('CloudService review count:', cloudCount);
-      } catch (error) {
-        dbgLog('CloudService error:', error);
-      }
-    }
-    
     dbgLog('=== End Debug Info ===');
   }
 
-  /**
-   * Update configuration
-   * @param {Object} newConfig - New configuration options
-   */
   updateConfig(newConfig) {
     this.config = { ...this.config, ...newConfig };
     dbgLog('Configuration updated:', this.config);
   }
 
-  /**
-   * Emit custom events
-   * @param {string} eventName - Event name
-   * @param {Object} data - Event data
-   */
   emit(eventName, data) {
     const event = new CustomEvent(`review-prompt:${eventName}`, {
       detail: data,
@@ -553,104 +799,80 @@ class ReviewPrompt {
     document.dispatchEvent(event);
   }
 
+  async ensureCloudService() {
+    if (window.CloudService) return;
+    const module = await import(chrome.runtime.getURL('services/cloud-service.js'));
+    window.CloudService = module.CloudService;
+    dbgLog('CloudService loaded dynamically');
+  }
+
   /**
-   * Track review prompt interaction with the cloud function
-   * @param {string} action - The action taken ('submit', 'later', or 'never')
-   * @param {number} [rating] - Optional rating if action is 'submit'
-   * @param {string} [redirectUrl] - The URL user was redirected to if action is 'submit'
+   * @param {string} action
+   * @param {number|null} rating
+   * @param {string|null} redirectUrl
    */
   async trackReviewPromptInteraction(action, rating = null, redirectUrl = null) {
     try {
       dbgLog('Tracking interaction:', { action, rating, redirectUrl });
-      
-      // Get user email from storage
+
       const email = await this.getUserEmail();
-      
       if (!email) {
         dbgWarn('Cannot track interaction: No user email available');
         return;
       }
-      
-      // Ensure CloudService is available
-      if (!window.CloudService) {
-        try {
-          // Try to import CloudService dynamically
-          const module = await import(chrome.runtime.getURL('services/cloud-service.js'));
-          window.CloudService = module.CloudService;
-          dbgLog('CloudService loaded dynamically');
-        } catch (importError) {
-          dbgWarn('Failed to load CloudService:', importError);
-          throw new Error('CloudService not available');
-        }
-      }
-      
-      // Use CloudService to track the interaction (follows architecture pattern)
+
+      await this.ensureCloudService();
       const data = await window.CloudService.trackReviewPromptInteraction(email, action, rating, redirectUrl);
       dbgLog('Interaction tracked successfully via CloudService:', data);
-      
     } catch (error) {
       dbgWarn('Error tracking interaction:', error);
-      // Don't throw the error to avoid disrupting the user experience
     }
   }
 
   /**
-   * Fetch review prompt messages from cloud function
-   * @returns {Promise<Object|null>} - Promise that resolves with messages object { subtitle, question } or null if failed
+   * @returns {Promise<Object|null>}
    */
   async fetchMessages() {
-    // Return cached messages if available
     if (this.messages) {
       dbgLog('Using cached messages');
       return this.messages;
     }
 
-    // If already fetching, return the existing promise
     if (this.messagesFetchPromise) {
       dbgLog('Already fetching messages, waiting...');
       return this.messagesFetchPromise;
     }
 
-    // Create new fetch promise
     this.messagesFetchPromise = (async () => {
       try {
         dbgLog('Fetching messages from cloud function');
-        
-        // Get user email
+
         const email = await this.getUserEmail();
         if (!email) {
           dbgWarn('Cannot fetch messages: No user email available');
           return null;
         }
 
-        // Ensure CloudService is available
-        if (!window.CloudService) {
-          try {
-            const module = await import(chrome.runtime.getURL('services/cloud-service.js'));
-            window.CloudService = module.CloudService;
-            dbgLog('CloudService loaded dynamically');
-          } catch (importError) {
-            dbgWarn('Failed to load CloudService:', importError);
-            return null;
-          }
+        await this.ensureCloudService();
+        const messages = await window.CloudService.getReviewPromptMessages(email);
+
+        if (messages && messages.subtitle && messages.question) {
+          this.messages = {
+            subtitle: messages.subtitle,
+            question: messages.question,
+            rewardEnabled: messages.rewardEnabled === true,
+            rewardMessage: typeof messages.rewardMessage === 'string' ? messages.rewardMessage : ''
+          };
+          dbgLog('Messages fetched successfully:', this.messages);
+          return this.messages;
         }
 
-        // Fetch messages via CloudService
-        const messages = await window.CloudService.getReviewPromptMessages(email);
-        
-        if (messages && messages.subtitle && messages.question) {
-          this.messages = messages;
-          dbgLog('Messages fetched successfully:', messages);
-          return messages;
-        } else {
-          dbgWarn('Invalid messages format received');
-          return null;
-        }
+        dbgWarn('Invalid messages format received');
+        return null;
       } catch (error) {
         dbgWarn('Error fetching messages:', error);
         return null;
       } finally {
-        // Clear the fetch promise
         this.messagesFetchPromise = null;
       }
     })();
@@ -659,24 +881,20 @@ class ReviewPrompt {
   }
 
   /**
-   * Get user email from storage or Chrome identity API
-   * @returns {Promise<string|null>} - Promise that resolves with the user's email
+   * @returns {Promise<string|null>}
    */
   async getUserEmail() {
     try {
-      // First try to get from storage
       const storageData = await new Promise((resolve) => {
         chrome.storage.local.get(['userData', 'user'], (result) => {
           resolve(result);
         });
       });
-      
-      // Check userData first
+
       if (storageData.userData && storageData.userData.email) {
         return storageData.userData.email;
       }
-      
-      // Check user field (might be JSON string)
+
       if (storageData.user) {
         try {
           const parsedUser = JSON.parse(storageData.user);
@@ -687,8 +905,7 @@ class ReviewPrompt {
           dbgWarn('Failed to parse user data:', parseError);
         }
       }
-      
-      // Fallback to Chrome identity API
+
       const userInfo = await new Promise((resolve, reject) => {
         chrome.identity.getProfileUserInfo({ accountStatus: 'ANY' }, (userInfo) => {
           if (chrome.runtime.lastError) {
@@ -698,31 +915,27 @@ class ReviewPrompt {
           }
         });
       });
-      
+
       return userInfo?.email || null;
-      
     } catch (error) {
       dbgWarn('Error getting user email:', error);
       return null;
     }
   }
 
-  /**
-   * Destroy the component and clean up
-   */
   destroy() {
+    this.closePopup({ trackLater: false });
     this.hide();
     this.removeEventListeners(document.getElementById('review-prompt'));
     this.eventListeners.clear();
     this.isInitialized = false;
+    this.popupAutoOpenedForShow = false;
     dbgLog('Component destroyed');
   }
 }
 
-// Export the class
 export { ReviewPrompt };
 
-// Also make it available globally for backward compatibility
 if (typeof window !== 'undefined') {
   window.ReviewPrompt = ReviewPrompt;
-} 
+}

--- a/components/review-prompt/review-prompt.js
+++ b/components/review-prompt/review-prompt.js
@@ -179,11 +179,25 @@ class ReviewPrompt {
   }
 
   /**
+   * Whether the integrated review panel is currently open (not minimized to the button).
+   * @returns {boolean}
+   */
+  isIntegratedPanelOpen() {
+    const panel = document.getElementById('gitlab-mr-integrated-review');
+    return !!(panel && !panel.classList.contains('thinkreview-panel-minimized-to-button'));
+  }
+
+  /**
    * Check and show the review prompt if conditions are met
    * @returns {Promise<boolean>}
    */
   async checkAndShow() {
     try {
+      if (!this.isIntegratedPanelOpen()) {
+        dbgLog('Not showing prompt: integrated panel is closed/minimized');
+        return false;
+      }
+
       const reviewCount = await this.getCurrentReviewCount();
       dbgLog('Total review count:', reviewCount, '| Threshold:', this.config.threshold);
 
@@ -213,6 +227,11 @@ class ReviewPrompt {
    * @param {number} reviewCount
    */
   async show(reviewCount = this.config.threshold) {
+    if (!this.isIntegratedPanelOpen()) {
+      dbgLog('Skipping show: integrated panel is closed/minimized');
+      return;
+    }
+
     const container = document.getElementById(this.containerId);
     if (!container) {
       dbgWarn('Container not found:', this.containerId);
@@ -223,6 +242,12 @@ class ReviewPrompt {
       await this.fetchMessages();
     } catch (error) {
       dbgWarn('Failed to fetch messages, using fallbacks:', error);
+    }
+
+    // Panel may have been closed while messages were loading
+    if (!this.isIntegratedPanelOpen()) {
+      dbgLog('Skipping show after fetch: integrated panel closed');
+      return;
     }
 
     let promptElement = container.querySelector('#review-prompt');
@@ -252,6 +277,15 @@ class ReviewPrompt {
     if (promptElement) {
       promptElement.classList.add('gl-hidden');
     }
+  }
+
+  /**
+   * Hide CTA and close the body overlay when the integrated panel closes.
+   * Does not track a "later" dismissal.
+   */
+  hideWhilePanelClosed() {
+    this.hide();
+    this.closePopup({ trackLater: false });
   }
 
   /**

--- a/components/review-prompt/review-prompt.js
+++ b/components/review-prompt/review-prompt.js
@@ -623,7 +623,7 @@ class ReviewPrompt {
       }
 
       if (e.target.closest('.thinkreview-store-feedback-close')) {
-        this.closePopup({ trackLater: false });
+        this.dismiss();
         return;
       }
 

--- a/components/review-prompt/review-prompt.js
+++ b/components/review-prompt/review-prompt.js
@@ -582,7 +582,7 @@ class ReviewPrompt {
     return `
       <div class="thinkreview-store-feedback-popup" role="dialog" aria-modal="true">
         <div class="thinkreview-store-feedback-header">
-          <h3>Share your feedback</h3>
+          <h3>What do you think of ThinkReview so far?</h3>
           <button type="button" class="thinkreview-store-feedback-close" title="Close" aria-label="Close">×</button>
         </div>
         <div class="thinkreview-store-feedback-body">

--- a/components/review-prompt/review-prompt.js
+++ b/components/review-prompt/review-prompt.js
@@ -495,10 +495,11 @@ class ReviewPrompt {
 
     if (step === 1) {
       const textarea = overlay.querySelector('#thinkreview-store-feedback-textarea');
+      const charCount = overlay.querySelector('.thinkreview-store-feedback-char-count');
       if (textarea) {
         if (this.pendingFeedbackText) {
           textarea.value = this.pendingFeedbackText;
-          this.updateCharCount(overlay);
+          this.updateCharCount(textarea, charCount);
         }
         setTimeout(() => textarea.focus(), 100);
       }
@@ -592,11 +593,12 @@ class ReviewPrompt {
 
     if (step === 1) {
       const textarea = overlay.querySelector('#thinkreview-store-feedback-textarea');
+      const charCount = overlay.querySelector('.thinkreview-store-feedback-char-count');
       const submitBtn = overlay.querySelector('.thinkreview-store-feedback-primary-btn');
 
       if (textarea && submitBtn) {
         const onInput = () => {
-          this.updateCharCount(overlay);
+          this.updateCharCount(textarea, charCount);
           submitBtn.disabled = textarea.value.trim().length === 0;
         };
         textarea.addEventListener('input', onInput);
@@ -636,11 +638,10 @@ class ReviewPrompt {
   }
 
   /**
-   * @param {HTMLElement} overlay
+   * @param {HTMLTextAreaElement|null} textarea
+   * @param {HTMLElement|null} charCount
    */
-  updateCharCount(overlay) {
-    const textarea = overlay.querySelector('#thinkreview-store-feedback-textarea');
-    const charCount = overlay.querySelector('.thinkreview-store-feedback-char-count');
+  updateCharCount(textarea, charCount) {
     if (!textarea || !charCount) return;
 
     const length = textarea.value.length;

--- a/components/review-prompt/review-prompt.js
+++ b/components/review-prompt/review-prompt.js
@@ -19,8 +19,6 @@ const REVIEW_PROMPT_CONFIG = {
 
 const DEFAULT_SUBTITLE = "We'd love to hear your feedback about ThinkReview";
 const DEFAULT_QUESTION = 'Would you mind leaving us a quick review?';
-const DEFAULT_REWARD_MESSAGE =
-  'Post your review on the Chrome Web Store or Firefox Add-ons and get 1 month of ThinkReview Lite free.';
 
 class ReviewPrompt {
   constructor(config = {}) {
@@ -333,16 +331,60 @@ class ReviewPrompt {
     return (this.messages && this.messages.question) ? this.messages.question : DEFAULT_QUESTION;
   }
 
-  isRewardEnabled() {
-    return !!(this.messages && this.messages.rewardEnabled === true);
+  /**
+   * Reward copy from Remote Config only — no local fallback.
+   * @returns {string}
+   */
+  getRewardMessage() {
+    if (!this.messages || typeof this.messages.rewardMessage !== 'string') {
+      return '';
+    }
+    return this.messages.rewardMessage.trim();
   }
 
-  getRewardMessage() {
+  /**
+   * Show reward UI only when Remote Config enabled it and supplied rewardMessage.
+   * @returns {boolean}
+   */
+  isRewardEnabled() {
+    return !!(this.messages && this.messages.rewardEnabled === true && this.getRewardMessage());
+  }
+
+  /**
+   * Compact step-1 hint markup when a Remote Config reward is available.
+   * @returns {string}
+   */
+  buildRewardHintHtml() {
     if (!this.isRewardEnabled()) return '';
-    if (this.messages && typeof this.messages.rewardMessage === 'string' && this.messages.rewardMessage.trim()) {
-      return this.messages.rewardMessage.trim();
-    }
-    return DEFAULT_REWARD_MESSAGE;
+    const rewardMessage = this.escapeHtml(this.getRewardMessage());
+    return `
+      <div class="thinkreview-store-feedback-reward-hint" role="note">
+        <span class="thinkreview-store-feedback-reward-hint-label">Reward</span>
+        <span class="thinkreview-store-feedback-reward-hint-text">${rewardMessage}</span>
+      </div>
+    `;
+  }
+
+  /**
+   * Full step-2 reward callout when a Remote Config reward is available.
+   * @returns {string}
+   */
+  buildRewardBlockHtml() {
+    if (!this.isRewardEnabled()) return '';
+    const rewardMessage = this.escapeHtml(this.getRewardMessage());
+    return `
+      <div class="thinkreview-store-feedback-reward" role="status">
+        <div class="thinkreview-store-feedback-reward-icon" aria-hidden="true">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M12 3l2.4 4.86L20 8.7l-4 3.9.94 5.5L12 15.9 7.06 18.1 8 12.6 4 8.7l5.6-.84L12 3z" fill="currentColor"/>
+          </svg>
+        </div>
+        <div class="thinkreview-store-feedback-reward-copy">
+          <span class="thinkreview-store-feedback-reward-label">Reward unlocked</span>
+          <p class="thinkreview-store-feedback-reward-message">${rewardMessage}</p>
+        </div>
+      </div>
+    `;
   }
 
   /**
@@ -471,21 +513,7 @@ class ReviewPrompt {
     const storeName = this.escapeHtml(this.getStoreDisplayName());
     if (step === 2) {
       const feedbackPreview = this.escapeHtml(this.pendingFeedbackText || '');
-      const rewardEnabled = this.isRewardEnabled();
-      const rewardMessage = this.escapeHtml(this.getRewardMessage());
-      const rewardBlock = rewardEnabled && rewardMessage
-        ? `<div class="thinkreview-store-feedback-reward" role="status">
-            <div class="thinkreview-store-feedback-reward-icon" aria-hidden="true">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path d="M12 3l2.4 4.86L20 8.7l-4 3.9.94 5.5L12 15.9 7.06 18.1 8 12.6 4 8.7l5.6-.84L12 3z" fill="currentColor"/>
-              </svg>
-            </div>
-            <div class="thinkreview-store-feedback-reward-copy">
-              <span class="thinkreview-store-feedback-reward-label">Reward unlocked</span>
-              <p class="thinkreview-store-feedback-reward-message">${rewardMessage}</p>
-            </div>
-          </div>`
-        : '';
+      const rewardBlock = this.buildRewardBlockHtml();
 
       return `
         <div class="thinkreview-store-feedback-popup" role="dialog" aria-modal="true">
@@ -513,6 +541,8 @@ class ReviewPrompt {
       `;
     }
 
+    const rewardHint = this.buildRewardHintHtml();
+
     return `
       <div class="thinkreview-store-feedback-popup" role="dialog" aria-modal="true">
         <div class="thinkreview-store-feedback-header">
@@ -521,6 +551,7 @@ class ReviewPrompt {
         </div>
         <div class="thinkreview-store-feedback-body">
           <p>What did you like, or what should we improve? Your note helps us keep ThinkReview free and open source.</p>
+          ${rewardHint}
           <textarea
             id="thinkreview-store-feedback-textarea"
             class="thinkreview-store-feedback-textarea"

--- a/components/review-prompt/review-prompt.js
+++ b/components/review-prompt/review-prompt.js
@@ -32,6 +32,8 @@ class ReviewPrompt {
     this.popupOverlay = null;
     this.popupStep = 1;
     this.popupEventsAbort = null;
+    /** @type {symbol|null} Invalidated when popup closes so stale submits cannot reopen UI */
+    this.activeSubmitRequest = null;
   }
 
   /**
@@ -706,10 +708,24 @@ class ReviewPrompt {
   }
 
   /**
+   * Whether a submit request may still mutate UI (popup still open + panel visible).
+   * @param {symbol} requestId
+   * @returns {boolean}
+   */
+  isSubmitRequestActive(requestId) {
+    return (
+      this.activeSubmitRequest === requestId &&
+      this.isIntegratedPanelOpen() &&
+      !!(this.popupOverlay && this.popupOverlay.isConnected)
+    );
+  }
+
+  /**
    * Close popup without dismissing the CTA unless requested.
    * @param {{ trackLater?: boolean }} options
    */
   closePopup(options = {}) {
+    this.activeSubmitRequest = null;
     this.clearPopupEvents();
 
     if (this.popupOverlay) {
@@ -733,6 +749,9 @@ class ReviewPrompt {
     const text = (feedbackText || '').trim();
     if (!text) return;
 
+    const requestId = Symbol('feedbackSubmit');
+    this.activeSubmitRequest = requestId;
+
     const overlay = this.popupOverlay;
     const submitBtn = overlay && overlay.querySelector('.thinkreview-store-feedback-primary-btn');
     if (submitBtn) {
@@ -742,7 +761,16 @@ class ReviewPrompt {
 
     try {
       await this.ensureCloudService();
+      if (!this.isSubmitRequestActive(requestId)) {
+        dbgLog('Ignoring feedback submit result: popup closed or panel minimized during request');
+        return;
+      }
+
       const email = await this.getUserEmail();
+      if (!this.isSubmitRequestActive(requestId)) {
+        dbgLog('Ignoring feedback submit result: popup closed or panel minimized during request');
+        return;
+      }
       if (!email) {
         throw new Error('No user email available');
       }
@@ -751,6 +779,11 @@ class ReviewPrompt {
         source: 'extension_review_prompt',
         browser: this.getBrowserLabel()
       });
+
+      if (!this.isSubmitRequestActive(requestId)) {
+        dbgLog('Ignoring feedback submit result: popup closed or panel minimized during request');
+        return;
+      }
 
       this.pendingFeedbackText = text;
 
@@ -767,6 +800,7 @@ class ReviewPrompt {
       this.emit('feedback-submitted', { reviewCount: await this.getCurrentReviewCount() });
     } catch (error) {
       dbgWarn('Failed to submit extension feedback:', error);
+      if (!this.isSubmitRequestActive(requestId)) return;
       if (submitBtn) {
         submitBtn.disabled = false;
         submitBtn.textContent = 'Submit feedback';

--- a/components/review-prompt/review-prompt.js
+++ b/components/review-prompt/review-prompt.js
@@ -8,8 +8,8 @@ const REVIEW_PROMPT_CONFIG = {
   chromeStoreUrl: 'https://chromewebstore.google.com/detail/thinkreview-ai-code-revie/bpgkhgbchmlmpjjpmlaiejhnnbkdjdjn/reviews',
   firefoxStoreUrl: 'https://addons.mozilla.org/firefox/addon/thinkreview-code-review/reviews/',
   feedbackUrl: 'https://thinkreview.dev/extension-feedback.html',
-  // Only suppress the prompt for submits on/after this date (older submits are ignored)
-  submitSuppressCutoffDate: '2026-06-07',
+  // Re-ask after a prior submit/feedback once this many months have passed
+  submitSuppressMonths: 3,
   maxFeedbackLength: 2000,
   storageKeys: {
     reviewCount: 'reviewCount',
@@ -99,28 +99,54 @@ class ReviewPrompt {
   }
 
   /**
-   * Whether a prior submit should permanently hide the feedback prompt.
+   * Whether a prior feedback/submit interaction should still hide the prompt.
+   * Suppresses for submitSuppressMonths (default 3), then allows showing again.
    * @param {Object} lastFeedbackPromptInteraction
    * @returns {boolean}
    */
   shouldSuppressForSubmit(lastFeedbackPromptInteraction) {
-    if (!lastFeedbackPromptInteraction || lastFeedbackPromptInteraction.action !== 'submit') {
+    if (!lastFeedbackPromptInteraction) {
+      return false;
+    }
+
+    const action = lastFeedbackPromptInteraction.action;
+    if (action !== 'submit' && action !== 'feedback') {
       return false;
     }
 
     if (!lastFeedbackPromptInteraction.date) {
-      dbgLog('Submit has no date; treating as pre-cutoff and showing prompt');
+      dbgLog('Prior', action, 'has no date; treating as expired and allowing prompt');
       return false;
     }
 
-    const submitDate = new Date(lastFeedbackPromptInteraction.date);
-    const cutoffDate = new Date(`${this.config.submitSuppressCutoffDate}T00:00:00`);
-    const suppress = submitDate >= cutoffDate;
+    const interactionDate = new Date(lastFeedbackPromptInteraction.date);
+    if (Number.isNaN(interactionDate.getTime())) {
+      dbgLog('Prior', action, 'has invalid date; allowing prompt');
+      return false;
+    }
+
+    const suppressUntil = new Date(interactionDate);
+    suppressUntil.setMonth(suppressUntil.getMonth() + this.config.submitSuppressMonths);
+    const suppress = new Date() < suppressUntil;
 
     if (suppress) {
-      dbgLog('Not showing prompt: User submitted feedback on or after', this.config.submitSuppressCutoffDate);
+      dbgLog(
+        'Not showing prompt: prior',
+        action,
+        'within last',
+        this.config.submitSuppressMonths,
+        'months (until',
+        suppressUntil.toISOString(),
+        ')'
+      );
     } else {
-      dbgLog('Ignoring submit before', this.config.submitSuppressCutoffDate, '- will check other conditions');
+      dbgLog(
+        'Prior',
+        action,
+        'is older than',
+        this.config.submitSuppressMonths,
+        'months - will check other conditions'
+      );
     }
 
     return suppress;
@@ -448,7 +474,17 @@ class ReviewPrompt {
       const rewardEnabled = this.isRewardEnabled();
       const rewardMessage = this.escapeHtml(this.getRewardMessage());
       const rewardBlock = rewardEnabled && rewardMessage
-        ? `<div class="thinkreview-store-feedback-reward">${rewardMessage}</div>`
+        ? `<div class="thinkreview-store-feedback-reward" role="status">
+            <div class="thinkreview-store-feedback-reward-icon" aria-hidden="true">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M12 3l2.4 4.86L20 8.7l-4 3.9.94 5.5L12 15.9 7.06 18.1 8 12.6 4 8.7l5.6-.84L12 3z" fill="currentColor"/>
+              </svg>
+            </div>
+            <div class="thinkreview-store-feedback-reward-copy">
+              <span class="thinkreview-store-feedback-reward-label">Reward unlocked</span>
+              <p class="thinkreview-store-feedback-reward-message">${rewardMessage}</p>
+            </div>
+          </div>`
         : '';
 
       return `
@@ -634,10 +670,10 @@ class ReviewPrompt {
       this.pendingFeedbackText = text;
 
       // Keep local dismiss cache in sync with backend action: 'feedback'
+      // (feedback body is stored only in the backend feedback subcollection)
       chrome.storage.local.set({
         lastFeedbackPromptInteraction: {
           action: 'feedback',
-          feedbackText: text,
           date: new Date().toISOString()
         }
       });
@@ -687,7 +723,6 @@ class ReviewPrompt {
     chrome.storage.local.set({
       lastFeedbackPromptInteraction: {
         action: 'submit',
-        feedbackText: this.pendingFeedbackText || null,
         date: new Date().toISOString()
       }
     });

--- a/content.js
+++ b/content.js
@@ -1838,10 +1838,28 @@ async function toggleReviewPanel() {
         dbgWarn('Review fetch failed:', e?.message || e);
       }
     }
+
+    // Feedback prompt only appears after/while the panel is open
+    try {
+      if (typeof window.maybeShowReviewPrompt === 'function') {
+        await window.maybeShowReviewPrompt();
+      }
+    } catch (error) {
+      dbgWarn('Failed to check review prompt after expanding panel:', error);
+    }
   } else {
     // If panel is already visible, minimize it (even if review is in progress)
     panel.classList.remove('thinkreview-panel-minimized', 'thinkreview-panel-hidden', 'thinkreview-panel-minimized-to-button');
     panel.classList.add('thinkreview-panel-minimized-to-button');
+
+    // Feedback prompt must not linger while the panel is closed
+    try {
+      if (window.reviewPrompt && typeof window.reviewPrompt.hideWhilePanelClosed === 'function') {
+        window.reviewPrompt.hideWhilePanelClosed();
+      }
+    } catch (error) {
+      dbgWarn('Failed to hide review prompt after minimizing panel:', error);
+    }
 
     // Get settings to apply left positioning if needed
     const minimizeSettings = await getLayoutSettings();

--- a/services/cloud-service.js
+++ b/services/cloud-service.js
@@ -32,6 +32,7 @@ const GET_AGENT_REVIEWS_FOR_PATCH_URL = `${CLOUD_FUNCTIONS_BASE_URL}/ThinkReview
 const GET_USER_SUBSCRIPTION_DATA_URL = `${CLOUD_FUNCTIONS_BASE_URL}/getUserSubscriptionDataThinkReview`;
 const TRACK_REVIEW_PROMPT_INTERACTION_URL = `${CLOUD_FUNCTIONS_BASE_URL}/trackReviewPromptInteractionHTTP`;
 const GET_REVIEW_PROMPT_MESSAGES_URL = `${CLOUD_FUNCTIONS_BASE_URL}/getReviewPromptMessagesThinkReview`;
+const SUBMIT_EXTENSION_FEEDBACK_URL = `${CLOUD_FUNCTIONS_BASE_URL}/submitExtensionFeedbackThinkReview`;
 const GET_UPGRADE_PROMPT_CONFIG_URL = `${CLOUD_FUNCTIONS_BASE_URL}/getUpgradePromptConfigThinkReview`;
 const FETCH_NEWS_MESSAGE_THINKREVIEW_URL = `${CLOUD_FUNCTIONS_BASE_URL}/fetchNewsMessageThinkReview`;
 const CANCEL_SUBSCRIPTION_URL = `${CLOUD_FUNCTIONS_BASE_URL}/cancelSubscriptionThinkReview`;
@@ -1041,7 +1042,7 @@ export class CloudService {
   /**
    * Get review prompt messages from Remote Config
    * @param {string} email - User's email for authentication
-   * @returns {Promise<Object>} - Promise that resolves with messages object { subtitle, question }
+   * @returns {Promise<Object>} - { subtitle, question, rewardEnabled?, rewardMessage? }
    */
   static async getReviewPromptMessages(email) {
     dbgLog('Fetching review prompt messages:', { email });
@@ -1070,7 +1071,9 @@ export class CloudService {
       if (data.status === 'success' && data.subtitle && data.question) {
         return {
           subtitle: data.subtitle,
-          question: data.question
+          question: data.question,
+          rewardEnabled: data.rewardEnabled === true,
+          rewardMessage: typeof data.rewardMessage === 'string' ? data.rewardMessage : ''
         };
       } else {
         throw new Error('Invalid response format from getReviewPromptMessages');
@@ -1079,6 +1082,48 @@ export class CloudService {
       dbgWarn('Error fetching review prompt messages:', error);
       throw error;
     }
+  }
+
+  /**
+   * Submit extension review-prompt feedback (step 1 of store review flow)
+   * @param {string} email
+   * @param {string} feedback
+   * @param {Object} [options]
+   * @param {string} [options.source]
+   * @param {'chrome'|'firefox'|null} [options.browser]
+   * @returns {Promise<{ status: string, feedbackId: string }>}
+   */
+  static async submitExtensionFeedback(email, feedback, options = {}) {
+    dbgLog('Submitting extension feedback:', { email, feedbackLength: feedback?.length });
+
+    if (!email) {
+      throw new Error('Email is required');
+    }
+    if (!feedback || typeof feedback !== 'string' || !feedback.trim()) {
+      throw new Error('Feedback is required');
+    }
+
+    const payload = {
+      email,
+      feedback: feedback.trim(),
+      source: options.source || 'extension_review_prompt',
+      ...(options.browser ? { browser: options.browser } : {})
+    };
+
+    const response = await CloudService.thinkReviewFetch(SUBMIT_EXTENSION_FEEDBACK_URL, payload);
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`HTTP error ${response.status}: ${errorText}`);
+    }
+
+    const data = await response.json();
+    dbgLog('SubmitExtensionFeedback response:', data);
+
+    if (data.status === 'success' && data.feedbackId) {
+      return data;
+    }
+    throw new Error(data.message || 'Failed to submit extension feedback');
   }
 
   /**


### PR DESCRIPTION
This PR refactors the review prompt into a new compact inline CTA plus a two-step feedback popup flow, and limits prompt visibility to times when the integrated review panel is actively open.

It introduces a new `maybeShowReviewPrompt()` entry point in `components/integrated-review.js`, wires it into both integrated panel rendering and panel expand behavior in `content.js`, and ensures prompt UI is hidden when the panel is minimized.

It significantly expands `components/review-prompt/review-prompt.js` to support popup state management, remote-config reward messaging, feedback submission via `CloudService.submitExtensionFeedback`, local prompt-interaction caching, and updated thank-you behavior.

It updates `services/cloud-service.js` with a new `submitExtensionFeedbackThinkReview` endpoint wrapper and extends review prompt message payload handling to include optional reward configuration.

It also gates the panel settings tour behind authenticated user state in `components/popup-modules/panel-settings-tour.js`, including a second login-state check after async delay to avoid showing onboarding after sign-out.

The CSS in `components/review-prompt/review-prompt.css` is rewritten to match the new compact CTA and modal popup UX, including responsive and reduced-motion handling.