### PR TITLE
Feat/upgrade prompt rewards cta

### DIFF
--- a/components/helpful-tip-banner.js
+++ b/components/helpful-tip-banner.js
@@ -23,12 +23,12 @@ export function injectStyles() {
     .helpful-tip-banner {
       display: flex;
       align-items: flex-start;
-      gap: 8px;
-      background: rgba(99, 179, 237, 0.08);
-      border: 1px solid rgba(99, 179, 237, 0.25);
-      border-radius: 6px;
-      padding: 10px 12px;
-      margin: 0 0 10px;
+      gap: 10px;
+      background: #fff;
+      border: 1px solid #e2e8f0;
+      border-radius: 12px;
+      padding: 12px 14px;
+      margin: 0;
     }
     .helpful-tip-icon {
       font-size: 14px;
@@ -36,8 +36,8 @@ export function injectStyles() {
       margin-top: 1px;
     }
     .helpful-tip-text {
-      font-size: 14px;
-      color: #a0aec0;
+      font-size: 12px;
+      color: #475569;
       line-height: 1.45;
       flex: 1;
     }
@@ -50,22 +50,22 @@ export function injectStyles() {
     .helpful-tip-settings-btn,
     .helpful-tip-usage-btn {
       flex-shrink: 0;
-      padding: 5px 10px;
-      border-radius: 4px;
-      border: 1px solid #4a5568;
-      background: #2d3748;
-      color: #cbd5e0;
+      padding: 6px 10px;
+      border-radius: 8px;
+      border: 1px solid #e2e8f0;
+      background: #f8fafc;
+      color: #334155;
       font-size: 11px;
-      font-weight: 600;
+      font-weight: 700;
       cursor: pointer;
       white-space: nowrap;
-      transition: background 0.15s, border-color 0.15s;
+      transition: background 0.15s, border-color 0.15s, color 0.15s;
     }
     .helpful-tip-settings-btn:hover,
     .helpful-tip-usage-btn:hover {
-      background: #3d4a5e;
-      border-color: #6b4fbb;
-      color: #e2e8f0;
+      background: #eef2ff;
+      border-color: #c4b5fd;
+      color: #4c1d95;
     }
   `;
   document.head.appendChild(styleEl);
@@ -78,7 +78,7 @@ export function injectStyles() {
 export function getHTML() {
   return `
     <div class="helpful-tip-banner">
-      <span class="helpful-tip-icon">💡</span>
+      <span class="helpful-tip-icon" aria-hidden="true">💡</span>
       <span class="helpful-tip-text">You can switch the auto-review setting to manual mode to better manage your daily review credits.</span>
       <div class="helpful-tip-actions">
         <button id="${SETTINGS_BUTTON_ID}" type="button" class="helpful-tip-settings-btn">Go to Settings</button>

--- a/components/subscription-section.css
+++ b/components/subscription-section.css
@@ -1,185 +1,196 @@
-.subscription-section {
-  background-color: #2d3748;
-  border: 1px solid #4a5568;
-  border-radius: 6px;
-  padding: 12px;
-  margin: 12px 0;
-}
+/**
+ * Styles for the daily-limit upgrade prompt (limit header, rewards, credit packs, plans).
+ * Loaded into the integrated review panel.
+ */
 
-.settings-title {
-  font-size: 16px;
-  font-weight: 500;
-  margin-bottom: 6px;
-  color: #e2e8f0;
-}
-
-.settings-description {
-  font-size: 12px;
-  color: #a0aec0;
-  margin-bottom: 12px;
-  line-height: 1.4;
-}
-
-.subscription-promotion {
-  font-size: 12px;
-  font-weight: 600;
-  color: #fbd38d;
-  background: rgba(237, 137, 54, 0.12);
-  border: 1px solid rgba(237, 137, 54, 0.35);
-  border-radius: 6px;
-  padding: 8px 10px;
-  margin-bottom: 12px;
-  line-height: 1.4;
-}
-
-.subscription-buttons {
-  display: flex;
-  gap: 10px;
-  margin-top: 12px;
-  flex-shrink: 0;
-}
-
-.subscription-plans {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
-}
-
-.subscription-plan-card {
+/* ---- Panel shell ---- */
+#upgrade-message-wrapper.upgrade-prompt-panel,
+.upgrade-prompt-panel {
   display: flex;
   flex-direction: column;
-  min-height: 0;
-  border: 1px solid #4a5568;
-  border-radius: 6px;
-  background: #1f2937;
-  padding: 12px;
-  /* Grid row stretch gives equal card heights; flex pushes CTA to the same baseline row */
-  align-self: stretch;
+  gap: 12px;
+  padding: 14px;
+  border-radius: 14px;
+  background: linear-gradient(180deg, #f8fafc 0%, #eef2ff 100%);
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 10px 28px -16px rgba(15, 23, 42, 0.35);
 }
 
-.plan-header {
-  display: flex;
-  justify-content: space-between;
-  gap: 8px;
-  align-items: baseline;
+.upgrade-prompt-header {
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: #fff;
+  border: 1px solid #e2e8f0;
 }
 
-.plan-name {
-  color: #e2e8f0;
-  font-size: 14px;
-  font-weight: 700;
-}
-
-.plan-price {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: baseline;
-  justify-content: flex-end;
-  gap: 6px;
-  color: #cbd5e0;
-  font-size: 13px;
-  font-weight: 600;
-  text-align: right;
-}
-
-.plan-price-current {
-  color: #e2e8f0;
-  font-weight: 700;
-  font-size: 13px;
-}
-
-.plan-price-original {
-  text-decoration: line-through;
-  color: #a0aec0;
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.plan-billed {
-  font-size: 11px;
-  color: #a0aec0;
-  text-align: right;
-  margin-top: 2px;
-  line-height: 1.3;
-}
-
-.plan-tagline {
-  color: #a0aec0;
-  margin-top: 6px;
-  font-size: 12px;
-}
-
-.plan-offer {
-  margin-top: 8px;
-  display: inline-block;
-  font-size: 11px;
-  font-weight: 700;
-  color: #2f855a;
-  background: rgba(72, 187, 120, 0.16);
-  border: 1px solid rgba(72, 187, 120, 0.35);
+.upgrade-prompt-kicker {
+  display: inline-flex;
+  align-items: center;
+  margin-bottom: 6px;
+  padding: 3px 9px;
   border-radius: 999px;
-  padding: 2px 8px;
+  background: #fef3c7;
+  color: #92400e;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
 }
 
-.plan-features {
-  flex: 1 1 auto;
-  min-height: 0;
-  margin: 10px 0 0;
-  padding-left: 16px;
-  list-style-type: disc;
-  list-style-position: outside;
-  color: #cbd5e0;
-  font-size: 12px;
-  line-height: 1.4;
+.upgrade-prompt-kicker--plan {
+  background: #ede9fe;
+  color: #5b21b6;
+  margin-bottom: 8px;
 }
 
-.plan-features li {
-  margin: 3px 0;
-  display: list-item;
+.upgrade-prompt-title {
+  margin: 0 0 6px;
+  font-size: 18px;
+  font-weight: 800;
+  line-height: 1.25;
+  letter-spacing: -0.02em;
+  color: #0f172a;
 }
 
-.upgrade-btn {
-  width: 100%;
-  padding: 12px 24px;
-  border-radius: 6px;
-  border: 1px solid #6b4fbb;
-  background-color: #6b4fbb;
-  color: #e2e8f0;
+.upgrade-prompt-body {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: #475569;
+}
+
+.upgrade-prompt-meter {
+  margin-top: 10px;
+  height: 6px;
+  border-radius: 999px;
+  background: #e2e8f0;
+  overflow: hidden;
+}
+
+.upgrade-prompt-meter-fill {
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #f59e0b 0%, #ef4444 100%);
+  max-width: 100%;
+}
+
+.upgrade-prompt-meter-label {
+  margin-top: 6px;
+  font-size: 11px;
   font-weight: 600;
-  font-size: 14px;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  text-align: center;
+  color: #64748b;
 }
 
-@media (max-width: 860px) {
-  .subscription-plans {
-    grid-template-columns: 1fr;
-  }
+/* ---- Rewards prize (Revolut-style) ---- */
+.upgrade-rewards-prize {
+  margin: 0;
+  padding: 16px 16px 14px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, #4c1d95 0%, #6b4fbb 45%, #2563eb 100%);
+  color: #fff;
+  box-shadow: 0 12px 28px -10px rgba(76, 29, 149, 0.55);
+  position: relative;
+  overflow: hidden;
 }
 
-.upgrade-btn:hover {
-  background-color: #5a3fa8;
-  border-color: #5a3fa8;
-  transform: translateY(-2px);
-  box-shadow: 0 2px 5px rgba(107, 79, 187, 0.3);
+.upgrade-rewards-prize::after {
+  content: '';
+  position: absolute;
+  right: -24px;
+  top: -24px;
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.1);
+  pointer-events: none;
+}
+
+.upgrade-rewards-prize-badge {
+  display: inline-block;
+  margin-bottom: 8px;
+  padding: 3px 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.18);
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  line-height: 1.3;
+  position: relative;
+  z-index: 1;
+}
+
+.upgrade-rewards-prize-title {
+  margin: 0 0 6px;
+  font-size: 17px;
+  font-weight: 800;
+  line-height: 1.3;
+  letter-spacing: -0.015em;
+  color: #fff;
+  position: relative;
+  z-index: 1;
+}
+
+.upgrade-rewards-prize-description {
+  margin: 0 0 14px;
+  font-size: 12px;
+  line-height: 1.45;
+  color: rgba(255, 255, 255, 0.9);
+  position: relative;
+  z-index: 1;
+}
+
+.upgrade-rewards-prize-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 11px 18px;
+  border-radius: 10px;
+  background: #fff;
+  color: #4c1d95;
+  font-size: 13px;
+  font-weight: 800;
+  text-decoration: none;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.14);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  position: relative;
+  z-index: 1;
+}
+
+.upgrade-rewards-prize-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.18);
+  text-decoration: none;
+  color: #3b0764;
+  background: #fff;
+}
+
+/* ---- Buy credits section ---- */
+.upgrade-buy-section {
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: #fff;
+  border: 1px solid #e2e8f0;
 }
 
 .upgrade-credits-balance-note {
   margin: 0 0 8px;
-  font-size: 13px;
+  font-size: 12px;
+  color: #475569;
 }
 
 .upgrade-credits-packs-label {
-  margin: 0 0 4px;
+  margin: 0 0 2px;
   font-size: 13px;
-  font-weight: 600;
+  font-weight: 700;
+  color: #0f172a;
 }
 
 .upgrade-credits-validity-note {
-  margin: 0 0 8px;
-  font-size: 12px;
-  color: #5f6368;
+  margin: 0 0 10px;
+  font-size: 11px;
+  color: #64748b;
 }
 
 .upgrade-credit-packs {
@@ -194,10 +205,12 @@
   flex-direction: column;
   align-items: stretch;
   justify-content: flex-end;
+  flex: 1 1 110px;
+  min-width: 100px;
 }
 
 .upgrade-credit-pack-badge-slot {
-  min-height: 20px;
+  min-height: 18px;
   display: flex;
   align-items: flex-end;
   margin-bottom: 4px;
@@ -206,9 +219,9 @@
 .upgrade-credit-pack-badge {
   padding: 2px 8px;
   border-radius: 10px;
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.02em;
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
   line-height: 1.4;
 }
@@ -224,13 +237,14 @@
 }
 
 .upgrade-credit-pack-btn {
-  padding: 8px 12px;
-  border-radius: 6px;
+  width: 100%;
+  padding: 10px 10px;
+  border-radius: 10px;
   border: 1px solid #047857;
   background: linear-gradient(135deg, #047857 0%, #059669 100%);
   color: #fff;
   font-size: 12px;
-  font-weight: 600;
+  font-weight: 700;
   cursor: pointer;
   transition: all 0.2s ease;
   white-space: nowrap;
@@ -238,7 +252,7 @@
 
 .upgrade-credit-pack-btn:hover {
   transform: translateY(-1px);
-  box-shadow: 0 2px 6px rgba(4, 120, 87, 0.35);
+  box-shadow: 0 4px 12px rgba(4, 120, 87, 0.3);
 }
 
 .upgrade-credit-pack-btn.is-best-value {
@@ -256,65 +270,176 @@
   text-decoration: none;
 }
 
-/* Revolut-style rewards prize card — shown above buy-credits */
-.upgrade-rewards-prize {
-  margin: 0 0 14px;
-  padding: 14px 14px 12px;
+/* ---- Plans / subscription section ---- */
+.subscription-section {
+  background: #fff;
+  border: 1px solid #e2e8f0;
   border-radius: 12px;
-  background: linear-gradient(135deg, #4c1d95 0%, #6b4fbb 48%, #2563eb 100%);
-  color: #fff;
-  box-shadow: 0 8px 20px -8px rgba(76, 29, 149, 0.55);
+  padding: 14px;
+  margin: 0;
 }
 
-.upgrade-rewards-prize-badge {
-  display: inline-block;
-  margin-bottom: 8px;
-  padding: 3px 10px;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.18);
-  border: 1px solid rgba(255, 255, 255, 0.28);
-  font-size: 10px;
+.settings-title {
+  font-size: 15px;
   font-weight: 800;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  line-height: 1.3;
-}
-
-.upgrade-rewards-prize-title {
-  margin: 0 0 6px;
-  font-size: 16px;
-  font-weight: 800;
-  line-height: 1.3;
+  margin: 0 0 4px;
+  color: #0f172a;
   letter-spacing: -0.01em;
-  color: #fff;
 }
 
-.upgrade-rewards-prize-description {
+.settings-description {
+  font-size: 12px;
+  color: #64748b;
   margin: 0 0 12px;
+  line-height: 1.45;
+}
+
+.subscription-promotion {
+  font-size: 12px;
+  font-weight: 700;
+  color: #92400e;
+  background: #fffbeb;
+  border: 1px solid #fde68a;
+  border-radius: 8px;
+  padding: 8px 10px;
+  margin-bottom: 12px;
+  line-height: 1.4;
+}
+
+.subscription-buttons {
+  display: flex;
+  gap: 10px;
+  margin-top: 12px;
+  flex-shrink: 0;
+}
+
+.subscription-plans {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.subscription-plan-card {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  background: #f8fafc;
+  padding: 12px;
+  align-self: stretch;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.subscription-plan-card:hover {
+  border-color: #c4b5fd;
+  box-shadow: 0 6px 16px -10px rgba(107, 79, 187, 0.45);
+}
+
+.plan-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: baseline;
+}
+
+.plan-name {
+  color: #0f172a;
+  font-size: 14px;
+  font-weight: 800;
+}
+
+.plan-price {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: flex-end;
+  gap: 6px;
+  color: #334155;
+  font-size: 13px;
+  font-weight: 700;
+  text-align: right;
+}
+
+.plan-price-current {
+  color: #0f172a;
+  font-weight: 800;
+  font-size: 14px;
+}
+
+.plan-price-original {
+  text-decoration: line-through;
+  color: #94a3b8;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.plan-billed {
+  font-size: 11px;
+  color: #64748b;
+  text-align: right;
+  margin-top: 2px;
+  line-height: 1.3;
+}
+
+.plan-tagline {
+  color: #64748b;
+  margin-top: 6px;
+  font-size: 12px;
+}
+
+.plan-offer {
+  margin-top: 8px;
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 800;
+  color: #166534;
+  background: #dcfce7;
+  border: 1px solid #86efac;
+  border-radius: 999px;
+  padding: 2px 8px;
+}
+
+.plan-features {
+  flex: 1 1 auto;
+  min-height: 0;
+  margin: 10px 0 0;
+  padding-left: 16px;
+  list-style-type: disc;
+  list-style-position: outside;
+  color: #475569;
   font-size: 12px;
   line-height: 1.45;
-  color: rgba(255, 255, 255, 0.9);
 }
 
-.upgrade-rewards-prize-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px 16px;
-  border-radius: 8px;
-  background: #fff;
-  color: #4c1d95;
-  font-size: 13px;
+.plan-features li {
+  margin: 3px 0;
+  display: list-item;
+}
+
+.upgrade-btn {
+  width: 100%;
+  padding: 11px 16px;
+  border-radius: 10px;
+  border: 1px solid #6b4fbb;
+  background: linear-gradient(135deg, #6b4fbb 0%, #5a3fa8 100%);
+  color: #fff;
   font-weight: 800;
-  text-decoration: none;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  font-size: 13px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  text-align: center;
 }
 
-.upgrade-rewards-prize-btn:hover {
+.upgrade-btn:hover {
+  background: linear-gradient(135deg, #5a3fa8 0%, #4c1d95 100%);
+  border-color: #5a3fa8;
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.16);
-  text-decoration: none;
-  color: #3b0764;
-  background: #fff;
+  box-shadow: 0 6px 14px -6px rgba(107, 79, 187, 0.55);
+}
+
+@media (max-width: 860px) {
+  .subscription-plans {
+    grid-template-columns: 1fr;
+  }
 }

--- a/components/subscription-section.css
+++ b/components/subscription-section.css
@@ -255,3 +255,66 @@
   display: inline-block;
   text-decoration: none;
 }
+
+/* Revolut-style rewards prize card — shown above buy-credits */
+.upgrade-rewards-prize {
+  margin: 0 0 14px;
+  padding: 14px 14px 12px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #4c1d95 0%, #6b4fbb 48%, #2563eb 100%);
+  color: #fff;
+  box-shadow: 0 8px 20px -8px rgba(76, 29, 149, 0.55);
+}
+
+.upgrade-rewards-prize-badge {
+  display: inline-block;
+  margin-bottom: 8px;
+  padding: 3px 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.18);
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  line-height: 1.3;
+}
+
+.upgrade-rewards-prize-title {
+  margin: 0 0 6px;
+  font-size: 16px;
+  font-weight: 800;
+  line-height: 1.3;
+  letter-spacing: -0.01em;
+  color: #fff;
+}
+
+.upgrade-rewards-prize-description {
+  margin: 0 0 12px;
+  font-size: 12px;
+  line-height: 1.45;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.upgrade-rewards-prize-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 16px;
+  border-radius: 8px;
+  background: #fff;
+  color: #4c1d95;
+  font-size: 13px;
+  font-weight: 800;
+  text-decoration: none;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.upgrade-rewards-prize-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.16);
+  text-decoration: none;
+  color: #3b0764;
+  background: #fff;
+}

--- a/components/subscription-section.html
+++ b/components/subscription-section.html
@@ -1,5 +1,6 @@
 <!-- Subscription Upgrade Section -->
 <div id="subscription-section" class="subscription-section">
+  <div class="upgrade-prompt-kicker upgrade-prompt-kicker--plan">Upgrade plan</div>
   <h3 id="subscription-title" class="settings-title">Upgrade to one of our premium plans</h3>
   <p id="subscription-description" class="settings-description">Get unlimited reviews, review larger PRs, choose your AI model, customize review rules, and more</p>
   <div id="subscription-promotion" class="subscription-promotion gl-hidden" role="status"></div>

--- a/components/upgrade-credit-packs.js
+++ b/components/upgrade-credit-packs.js
@@ -219,19 +219,24 @@ export async function renderUpgradeCreditPacksActions(container, options = {}) {
   // Prize / rewards first — most prominent path before paid packs.
   appendRewardsCta(container, rewardsCta, analyticsContext);
 
+  const buySection = document.createElement('div');
+  buySection.className = 'upgrade-buy-section';
+  let buySectionHasContent = false;
+
   const balanceNote = getBalanceNoteText(prepaidBalance);
   if (balanceNote) {
-    container.appendChild(createParagraph('upgrade-credits-balance-note', balanceNote));
+    buySection.appendChild(createParagraph('upgrade-credits-balance-note', balanceNote));
+    buySectionHasContent = true;
   }
 
   const validationModule = await import(chrome.runtime.getURL('utils/credit-pack-validation.js'));
   const creditPacks = validationModule.filterValidCreditPacks(rawPacks);
 
   if (creditPacks.length > 0) {
-    container.appendChild(
+    buySection.appendChild(
       createParagraph('upgrade-credits-packs-label', getPacksSectionLabel(prepaidBalance))
     );
-    container.appendChild(createParagraph('upgrade-credits-validity-note', VALIDITY_NOTE_TEXT));
+    buySection.appendChild(createParagraph('upgrade-credits-validity-note', VALIDITY_NOTE_TEXT));
 
     const packsRow = document.createElement('div');
     packsRow.className = 'upgrade-credit-packs';
@@ -240,8 +245,15 @@ export async function renderUpgradeCreditPacksActions(container, options = {}) {
         createCreditPackItem(pack, packIndex, creditPacks.length, analyticsContext)
       );
     });
-    container.appendChild(packsRow);
+    buySection.appendChild(packsRow);
+    buySectionHasContent = true;
   } else if (balanceNote == null) {
-    appendFallbackActions(container);
+    const before = buySection.childNodes.length;
+    appendFallbackActions(buySection);
+    buySectionHasContent = buySection.childNodes.length > before;
+  }
+
+  if (buySectionHasContent) {
+    container.appendChild(buySection);
   }
 }

--- a/components/upgrade-credit-packs.js
+++ b/components/upgrade-credit-packs.js
@@ -142,11 +142,66 @@ function appendFallbackActions(container) {
 }
 
 /**
+ * Prominent Revolut-style rewards prize card (rendered above buy-credits).
+ * Copy/URL come from cloud Remote Config — never hardcoded prize amounts.
+ */
+function appendRewardsCta(container, rewardsCta, analyticsContext) {
+  if (!rewardsCta || rewardsCta.enabled !== true) return;
+  const label = typeof rewardsCta.label === 'string' ? rewardsCta.label.trim() : '';
+  const url = typeof rewardsCta.url === 'string' ? rewardsCta.url.trim() : '';
+  if (!label || !url) return;
+  try {
+    if (new URL(url).protocol !== 'https:') return;
+  } catch {
+    return;
+  }
+
+  const card = document.createElement('div');
+  card.className = 'upgrade-rewards-prize';
+
+  const badge = document.createElement('span');
+  badge.className = 'upgrade-rewards-prize-badge';
+  badge.textContent = 'Free credits';
+  card.appendChild(badge);
+
+  const title = document.createElement('p');
+  title.className = 'upgrade-rewards-prize-title';
+  title.textContent = label;
+  card.appendChild(title);
+
+  const description =
+    typeof rewardsCta.description === 'string' ? rewardsCta.description.trim() : '';
+  if (description) {
+    card.appendChild(createParagraph('upgrade-rewards-prize-description', description));
+  }
+
+  const link = document.createElement('a');
+  link.href = url;
+  link.target = '_blank';
+  link.rel = 'noopener noreferrer';
+  link.className = 'upgrade-rewards-prize-btn';
+  link.textContent = 'Claim free credits';
+  link.addEventListener('click', async () => {
+    try {
+      const { trackUserAction } = await import(chrome.runtime.getURL('utils/analytics-service.js'));
+      trackUserAction('rewards_cta_clicked', {
+        context: analyticsContext
+      }).catch(() => {});
+    } catch {
+      // Silently fail - analytics should never break CTA
+    }
+  });
+  card.appendChild(link);
+  container.appendChild(card);
+}
+
+/**
  * @param {HTMLElement} container
  * @param {{
  *   creditPacks?: unknown[],
  *   prepaidBalance?: number|null,
- *   analyticsContext?: string
+ *   analyticsContext?: string,
+ *   rewardsCta?: { enabled?: boolean, label?: string, description?: string, url?: string }|null
  * }} [options]
  */
 export async function renderUpgradeCreditPacksActions(container, options = {}) {
@@ -155,10 +210,14 @@ export async function renderUpgradeCreditPacksActions(container, options = {}) {
   const {
     creditPacks: rawPacks = [],
     prepaidBalance = null,
-    analyticsContext = 'daily_limit_upgrade_prompt'
+    analyticsContext = 'daily_limit_upgrade_prompt',
+    rewardsCta = null
   } = options;
 
   container.replaceChildren();
+
+  // Prize / rewards first — most prominent path before paid packs.
+  appendRewardsCta(container, rewardsCta, analyticsContext);
 
   const balanceNote = getBalanceNoteText(prepaidBalance);
   if (balanceNote) {
@@ -182,10 +241,7 @@ export async function renderUpgradeCreditPacksActions(container, options = {}) {
       );
     });
     container.appendChild(packsRow);
-    return;
-  }
-
-  if (balanceNote == null) {
+  } else if (balanceNote == null) {
     appendFallbackActions(container);
   }
 }

--- a/content.js
+++ b/content.js
@@ -996,7 +996,7 @@ async function showUpgradeMessage(
           const hasRemotePlans = Array.isArray(remoteConfig?.plans) && remoteConfig.plans.length > 0;
           const hasRemoteCreditPacks =
             Array.isArray(remoteConfig?.creditPacks) && remoteConfig.creditPacks.length > 0;
-          if (remoteConfig && (hasRemotePlans || hasRemoteCreditPacks)) {
+          if (remoteConfig && (hasRemotePlans || hasRemoteCreditPacks || remoteConfig.rewardsCta)) {
             upgradeConfig = {
               ...fallbackConfig,
               ...remoteConfig,
@@ -1006,7 +1006,8 @@ async function showUpgradeMessage(
               },
               plans: hasRemotePlans ? remoteConfig.plans : fallbackConfig.plans,
               creditPacks:
-                hideCreditPacks || !hasRemoteCreditPacks ? [] : remoteConfig.creditPacks
+                hideCreditPacks || !hasRemoteCreditPacks ? [] : remoteConfig.creditPacks,
+              rewardsCta: remoteConfig.rewardsCta || null
             };
           }
         }
@@ -1052,7 +1053,8 @@ async function showUpgradeMessage(
 
       const creditsActionsEl = upgradeWrapper.querySelector('#upgrade-credits-actions');
       if (creditsActionsEl) {
-        if (hideCreditPacks) {
+        const hasRewardsCta = Boolean(upgradeConfig.rewardsCta?.enabled);
+        if (hideCreditPacks && !hasRewardsCta) {
           creditsActionsEl.replaceChildren();
           creditsActionsEl.classList.add('gl-hidden');
         } else {
@@ -1061,8 +1063,9 @@ async function showUpgradeMessage(
             chrome.runtime.getURL('components/upgrade-credit-packs.js')
           );
           await upgradeCreditPacks.renderUpgradeCreditPacksActions(creditsActionsEl, {
-            creditPacks: upgradeConfig.creditPacks,
-            prepaidBalance
+            creditPacks: hideCreditPacks ? [] : upgradeConfig.creditPacks,
+            prepaidBalance: hideCreditPacks ? null : prepaidBalance,
+            rewardsCta: upgradeConfig.rewardsCta || null
           });
         }
       }

--- a/content.js
+++ b/content.js
@@ -905,6 +905,7 @@ async function showUpgradeMessage(
   // Create a dedicated full-panel upgrade container
   const upgradeWrapper = document.createElement('div');
   upgradeWrapper.id = 'upgrade-message-wrapper';
+  upgradeWrapper.className = 'upgrade-prompt-panel';
 
   // Load subscription section styles
   if (!document.getElementById('subscription-styles')) {
@@ -926,15 +927,14 @@ async function showUpgradeMessage(
       if (chrome.runtime.lastError || !response?.success) {
         dbgWarn('Error loading subscription section:', response?.error || chrome.runtime.lastError?.message);
         upgradeWrapper.innerHTML = `
-          <div class="gl-alert gl-alert-warning">
-            <div class="gl-alert-content">
-              <div class="gl-alert-title">Daily Review Limit Reached</div>
-              <div class="gl-mb-3">Unable to load upgrade options. Please try again or visit the portal.</div>
-              <a href="https://portal.thinkreview.dev/subscription" target="_blank" rel="noopener noreferrer"
-                 class="btn btn-md btn-confirm" style="display:inline-block;text-decoration:none;">
-                Open subscription portal
-              </a>
-            </div>
+          <div class="upgrade-prompt-header">
+            <div class="upgrade-prompt-kicker">Daily limit</div>
+            <h2 class="upgrade-prompt-title">Daily Review Limit Reached</h2>
+            <p class="upgrade-prompt-body">Unable to load upgrade options. Please try again or visit the portal.</p>
+            <a href="https://portal.thinkreview.dev/subscription" target="_blank" rel="noopener noreferrer"
+               class="upgrade-rewards-prize-btn" style="margin-top:12px;">
+              Open subscription portal
+            </a>
           </div>
         `;
         revealUpgradePrompt(upgradeWrapper, reviewContent, options);
@@ -1034,16 +1034,29 @@ async function showUpgradeMessage(
           ? purchasedReviewCredits
           : null;
 
+      const showUsageMeter =
+        !limitOverride &&
+        Number.isFinite(Number(reviewCount)) &&
+        Number.isFinite(Number(dailyLimit)) &&
+        Number(dailyLimit) > 0;
+      const usagePct = showUsageMeter
+        ? Math.min(100, Math.round((Number(reviewCount) / Number(dailyLimit)) * 100))
+        : 0;
+      const meterHtml = showUsageMeter
+        ? `<div class="upgrade-prompt-meter" aria-hidden="true"><div class="upgrade-prompt-meter-fill" style="width:${usagePct}%"></div></div>
+           <div class="upgrade-prompt-meter-label">${reviewCount} / ${dailyLimit} reviews used today</div>`
+        : '';
+
       upgradeWrapper.innerHTML = `
-        ${tipBannerModule.getHTML()}
-        <div class="gl-alert gl-alert-warning">
-          <div class="gl-alert-content">
-            <div class="gl-alert-title" id="upgrade-limit-title"></div>
-            <div class="gl-mb-3" id="upgrade-limit-body"></div>
-            <div id="upgrade-credits-actions" class="gl-mt-3"></div>
-          </div>
+        <div class="upgrade-prompt-header">
+          <div class="upgrade-prompt-kicker">Daily limit</div>
+          <h2 class="upgrade-prompt-title" id="upgrade-limit-title"></h2>
+          <p class="upgrade-prompt-body" id="upgrade-limit-body"></p>
+          ${meterHtml}
         </div>
+        <div id="upgrade-credits-actions"></div>
         ${html}
+        ${tipBannerModule.getHTML()}
       `;
 
       const limitTitleEl = upgradeWrapper.querySelector('#upgrade-limit-title');

--- a/content.js
+++ b/content.js
@@ -1044,7 +1044,7 @@ async function showUpgradeMessage(
         : 0;
       const meterHtml = showUsageMeter
         ? `<div class="upgrade-prompt-meter" aria-hidden="true"><div class="upgrade-prompt-meter-fill" style="width:${usagePct}%"></div></div>
-           <div class="upgrade-prompt-meter-label">${reviewCount} / ${dailyLimit} reviews used today</div>`
+           <div class="upgrade-prompt-meter-label">${reviewCount} / ${dailyLimit} review credits used today</div>`
         : '';
 
       upgradeWrapper.innerHTML = `

--- a/services/cloud-service.js
+++ b/services/cloud-service.js
@@ -1129,7 +1129,7 @@ export class CloudService {
   /**
    * Get daily-limit upgrade prompt configuration from Remote Config (via cloud function).
    * @param {string} email - User's email for authentication
-   * @returns {Promise<Object>} - { prompt, allowDiscounts, plans[], creditPacks[], promotionalMessage? }
+   * @returns {Promise<Object>} - { prompt, allowDiscounts, plans[], creditPacks[], promotionalMessage?, rewardsCta? }
    */
   static async getUpgradePromptConfig(email) {
     dbgLog('Fetching upgrade prompt config');
@@ -1149,7 +1149,8 @@ export class CloudService {
     dbgLog('GetUpgradePromptConfig response:', {
       status: data.status,
       planCount: Array.isArray(data.plans) ? data.plans.length : 0,
-      creditPackCount: Array.isArray(data.creditPacks) ? data.creditPacks.length : 0
+      creditPackCount: Array.isArray(data.creditPacks) ? data.creditPacks.length : 0,
+      hasRewardsCta: Boolean(data.rewardsCta?.enabled)
     });
 
     if (data.status !== 'success') {
@@ -1159,12 +1160,32 @@ export class CloudService {
       throw new Error('Invalid response format from getUpgradePromptConfig');
     }
 
+    const rewardsCta =
+      data.rewardsCta &&
+      data.rewardsCta.enabled === true &&
+      typeof data.rewardsCta.label === 'string' &&
+      data.rewardsCta.label.trim() &&
+      typeof data.rewardsCta.url === 'string' &&
+      data.rewardsCta.url.trim()
+        ? {
+            enabled: true,
+            label: data.rewardsCta.label.trim(),
+            description:
+              typeof data.rewardsCta.description === 'string'
+                ? data.rewardsCta.description.trim()
+                : '',
+            url: data.rewardsCta.url.trim()
+          }
+        : null;
+
     return {
       prompt: data.prompt || {},
       allowDiscounts: data.allowDiscounts !== false,
       plans: Array.isArray(data.plans) ? data.plans : [],
       creditPacks: filterValidCreditPacks(data.creditPacks),
-      promotionalMessage: typeof data.promotionalMessage === 'string' ? data.promotionalMessage : ''
+      promotionalMessage: typeof data.promotionalMessage === 'string' ? data.promotionalMessage : '',
+      rewardsCta,
+      remoteConfigApplied: data.remoteConfigApplied === true
     };
   }
 


### PR DESCRIPTION
Redesigns the daily-limit upgrade prompt from a dark GitLab-style alert into a light, card-based panel. Key changes: (1) New 'upgrade-prompt-panel' shell with a header card containing a 'Daily limit' kicker, title, body, and an optional usage meter showing review credits used vs. daily limit. (2) Adds a Remote Config-driven 'rewards CTA' card (Revolut-style gradient prize card) rendered above the credit packs, with label/description/URL coming from cloud config; the URL is validated to be HTTPS and clicks are tracked via analytics. (3) Restyles the subscription section, credit pack buttons, plan cards, and helpful-tip banner to a light theme (white backgrounds, slate text, rounded corners). (4) The helpful tip banner is moved below the subscription plans, gains aria-hidden on its emoji icon, and the subscription section gains an 'Upgrade plan' kicker. (5) cloud-service getUpgradePromptConfig now parses and validates a rewardsCta object and returns remoteConfigApplied. (6) When credit packs are hidden but a rewards CTA is enabled, the rewards card is still rendered.